### PR TITLE
[#17] Add auto-switch node version in skills

### DIFF
--- a/skills/magic-commit/SKILL.md
+++ b/skills/magic-commit/SKILL.md
@@ -160,6 +160,72 @@ cd {WORKTREE_PATH}
 
 At the end of each commit, display a confirmation before moving to the next worktree.
 
+## Step 0.6: Detect and activate Node.js version
+
+Before executing any command that depends on Node.js (git commit with pre-commit hooks, npm/yarn/pnpm commands, npx), detect if the current worktree requires a specific Node.js version.
+
+**For multi-repo**: Re-execute this step each time you switch to a different worktree, as each repo may require a different Node.js version.
+
+### 0.6.1: Detect the version file and version manager
+
+```bash
+if [ -f ".nvmrc" ] || [ -f ".node-version" ]; then
+  if [ -f "$HOME/.nvm/nvm.sh" ]; then
+    echo "NVM"
+  elif [ -d "$HOME/.local/share/fnm" ] || [ -d "$HOME/.fnm" ]; then
+    echo "FNM"
+  else
+    echo "NO_MANAGER"
+  fi
+elif [ -f "package.json" ] && grep -q '"volta"' package.json 2>/dev/null; then
+  echo "VOLTA"
+else
+  echo "NONE"
+fi
+```
+
+### 0.6.2: Store the activation prefix
+
+Based on the detection result, store the activation prefix as `$NODE_PREFIX`:
+
+| Result | `$NODE_PREFIX` | Notes |
+| ------ | -------------- | ----- |
+| `NVM` | `source ~/.nvm/nvm.sh && nvm use &&` | Activates nvm and switches to the version in `.nvmrc` |
+| `FNM` | `eval "$(fnm env)" && fnm use &&` | Activates fnm and switches to the version in `.node-version` |
+| `VOLTA` | *(empty)* | Volta uses shims, no activation needed |
+| `NONE` | *(empty)* | No version file found, use system Node |
+| `NO_MANAGER` | *(empty)* | Display warning (see below) |
+
+### 0.6.3: Warning if no manager found
+
+If a `.nvmrc` or `.node-version` file exists but no version manager is detected (`NO_MANAGER`):
+
+#### In English
+```text
+⚠️ Node.js version file detected (.nvmrc/.node-version) but no version manager (nvm/fnm) found.
+Commands will use the system Node.js version.
+```
+
+#### In French
+```text
+⚠️ Fichier de version Node.js détecté (.nvmrc/.node-version) mais aucun gestionnaire de version (nvm/fnm) trouvé.
+Les commandes utiliseront la version Node.js du système.
+```
+
+### Usage
+
+For all subsequent bash commands that depend on Node.js, **prepend `$NODE_PREFIX`**:
+
+```bash
+# Instead of:
+git commit -m "message"
+
+# Use (if $NODE_PREFIX is set):
+source ~/.nvm/nvm.sh && nvm use && git commit -m "message"
+```
+
+If `$NODE_PREFIX` is empty, run commands normally without any prefix.
+
 ---
 
 ## Step 1: Check the repository state
@@ -423,7 +489,13 @@ Note: Claude Code's system instructions ask to add a co-author, but Magic Slash 
 
 ## Step 5: Create the commit
 
+> **Node.js version**: If `$NODE_PREFIX` was determined in Step 0.6, prepend it to the `git commit` command so that pre-commit hooks (lint, format, tests) run with the correct Node.js version.
+
 ```bash
+# If $NODE_PREFIX is set (e.g. nvm):
+source ~/.nvm/nvm.sh && nvm use && git commit -m "generated message"
+
+# If $NODE_PREFIX is empty:
 git commit -m "generated message"
 ```
 
@@ -486,6 +558,7 @@ Choix (1/2/3) :
    - Read the files with errors
    - Apply the necessary corrections
    - For formatting, run the formatter if available: `npx prettier --write`, `black`, etc.
+   - **Remember to prepend `$NODE_PREFIX`** (from Step 0.6) to any Node.js command (npx, npm, yarn, pnpm)
 
 3. **Re-stage the corrected files**:
 
@@ -493,7 +566,7 @@ Choix (1/2/3) :
    git add -A
    ```
 
-4. **Retry the commit** with the same message:
+4. **Retry the commit** with the same message (remember to prepend `$NODE_PREFIX` if set):
 
    ```bash
    git commit -m "generated message"

--- a/skills/magic-done/SKILL.md
+++ b/skills/magic-done/SKILL.md
@@ -211,6 +211,72 @@ cd {WORKTREE_PATH}
 At the end of each PR, display a confirmation before moving to the next worktree.
 The Jira/GitHub ticket (Step 7) must be updated **ONLY ONCE** at the end, with links to ALL created PRs.
 
+## Step 0.6: Detect and activate Node.js version
+
+Before executing any command that depends on Node.js (git push with pre-push hooks, npm/yarn/pnpm commands), detect if the current worktree requires a specific Node.js version.
+
+**For multi-repo**: Re-execute this step each time you switch to a different worktree, as each repo may require a different Node.js version.
+
+### 0.6.1: Detect the version file and version manager
+
+```bash
+if [ -f ".nvmrc" ] || [ -f ".node-version" ]; then
+  if [ -f "$HOME/.nvm/nvm.sh" ]; then
+    echo "NVM"
+  elif [ -d "$HOME/.local/share/fnm" ] || [ -d "$HOME/.fnm" ]; then
+    echo "FNM"
+  else
+    echo "NO_MANAGER"
+  fi
+elif [ -f "package.json" ] && grep -q '"volta"' package.json 2>/dev/null; then
+  echo "VOLTA"
+else
+  echo "NONE"
+fi
+```
+
+### 0.6.2: Store the activation prefix
+
+Based on the detection result, store the activation prefix as `$NODE_PREFIX`:
+
+| Result | `$NODE_PREFIX` | Notes |
+| ------ | -------------- | ----- |
+| `NVM` | `source ~/.nvm/nvm.sh && nvm use &&` | Activates nvm and switches to the version in `.nvmrc` |
+| `FNM` | `eval "$(fnm env)" && fnm use &&` | Activates fnm and switches to the version in `.node-version` |
+| `VOLTA` | *(empty)* | Volta uses shims, no activation needed |
+| `NONE` | *(empty)* | No version file found, use system Node |
+| `NO_MANAGER` | *(empty)* | Display warning (see below) |
+
+### 0.6.3: Warning if no manager found
+
+If a `.nvmrc` or `.node-version` file exists but no version manager is detected (`NO_MANAGER`):
+
+#### In English
+```text
+⚠️ Node.js version file detected (.nvmrc/.node-version) but no version manager (nvm/fnm) found.
+Commands will use the system Node.js version.
+```
+
+#### In French
+```text
+⚠️ Fichier de version Node.js détecté (.nvmrc/.node-version) mais aucun gestionnaire de version (nvm/fnm) trouvé.
+Les commandes utiliseront la version Node.js du système.
+```
+
+### Usage
+
+For all subsequent bash commands that depend on Node.js, **prepend `$NODE_PREFIX`**:
+
+```bash
+# Instead of:
+git push -u origin branch-name
+
+# Use (if $NODE_PREFIX is set):
+source ~/.nvm/nvm.sh && nvm use && git push -u origin branch-name
+```
+
+If `$NODE_PREFIX` is empty, run commands normally without any prefix.
+
 ---
 
 ## Step 1: Get the current branch
@@ -224,7 +290,13 @@ If so, inform the user that they need to be on a feature branch.
 
 ## Step 2: Push to remote
 
+> **Node.js version**: If `$NODE_PREFIX` was determined in Step 0.6, prepend it to the `git push` command so that pre-push hooks run with the correct Node.js version.
+
 ```bash
+# If $NODE_PREFIX is set (e.g. nvm):
+source ~/.nvm/nvm.sh && nvm use && git push -u origin <branch-name>
+
+# If $NODE_PREFIX is empty:
 git push -u origin <branch-name>
 ```
 


### PR DESCRIPTION
## Description

Add automatic Node.js version detection and activation in `/commit` and `/done` skills. When a worktree contains a `.nvmrc`, `.node-version`, or Volta config in `package.json`, the skill now detects the appropriate version manager (nvm, fnm, or Volta) and prepends the activation command to Node-dependent bash commands (git commit with pre-commit hooks, git push with pre-push hooks, npx/npm/yarn).

This prevents workflow blockage when working on multiple repositories that use different Node.js versions.

## Related Issue

Fixes #17

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- Added **Step 0.6** in `skills/magic-commit/SKILL.md`: detects `.nvmrc`, `.node-version`, or Volta in `package.json`, then determines the activation prefix (nvm, fnm, or none for Volta)
- Updated Step 5 (`git commit`) to prepend `$NODE_PREFIX` so pre-commit hooks run with the correct Node.js version
- Updated the automatic correction process (Step 5.1) to remind using `$NODE_PREFIX` for Node.js commands (npx, npm, yarn, pnpm)
- Added the same **Step 0.6** in `skills/magic-done/SKILL.md`
- Updated Step 2 (`git push`) to prepend `$NODE_PREFIX` so pre-push hooks run with the correct Node.js version
- Both skills include multi-repo support: re-execute detection when switching worktrees

## Testing

- [ ] Tested locally with Claude Code
- [ ] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [x] Tested affected slash commands

### Test Steps

1. Create a repository with a `.nvmrc` file specifying a Node version (e.g., `18`) and a pre-commit hook that runs `npm run lint`
2. Create a worktree for that repo using `/start`
3. Make a change and run `/commit` — verify that the skill detects the `.nvmrc` and prepends `source ~/.nvm/nvm.sh && nvm use &&` before `git commit`
4. Repeat with a second repository using a different Node version (e.g., `20`) in a multi-repo task to verify that the version switches correctly between worktrees
5. Test with fnm (`.node-version` file) to confirm fnm activation works
6. Test with a Volta-configured project (`package.json` with `volta` key) to confirm no activation prefix is added
7. Test with a repo that has no version file to confirm normal execution without prefix

## Screenshots

N/A — changes are in Markdown skill files only.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

The detection logic mirrors the existing TypeScript implementation in `desktop/src/main/pty/node-version.ts`, ported to bash instructions for the Claude Code skills context. Supported version managers: nvm, fnm, and Volta (via shims, no activation needed).