### PR TITLE
[#34] Add /simplify pass after implementation (step 5.4.5)

### DIFF
--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -362,6 +362,23 @@ After all subagents complete:
 2. Check for conflicts/inconsistencies
 3. Fix integration issues if needed
 
+### 5.4.5: Simplify pass
+
+After implementation completes (step 5.4), run a simplification pass **only on the files changed during this task** to catch redundant code, missed reuse opportunities, or efficiency issues.
+
+1. Collect the list of changed files:
+
+```bash
+cd {WORKTREE_PATH}
+git diff --name-only HEAD
+git ls-files --others --exclude-standard
+```
+
+2. If no files changed, skip this step silently.
+3. Display `MSG_SIMPLIFY`.
+4. Invoke the `/simplify` skill. It may explore the full codebase to detect duplicates, missed reuse opportunities, and existing patterns — but it must only **modify files from the changed list above**. Do NOT let it modify files that were not changed during this task.
+5. If `/simplify` finds no issues, continue silently to the next step.
+
 ### 5.5: Final summary
 
 Display `MSG_FINAL_SUMMARY` (or `MSG_FINAL_SUMMARY_FULLSTACK`).

--- a/skills/magic-start/references/messages.md
+++ b/skills/magic-start/references/messages.md
@@ -674,6 +674,20 @@ Sauvegarder dans la config pour les prochains worktrees ? (o/n)
    • Lance /pr pour créer une Pull Request
 ```
 
+## MSG_SIMPLIFY
+
+### en
+
+```text
+🔍 Running simplification pass on modified files...
+```
+
+### fr
+
+```text
+🔍 Passe de simplification en cours sur les fichiers modifiés...
+```
+
 ## MSG_MULTI_REPO_CONTEXT
 
 ### en


### PR DESCRIPTION
## Description

Add a new step 5.4.5 in the `/start` skill that automatically runs `/simplify` on changed files after implementation completes, before the final summary. This catches redundant code, missed reuse opportunities, and efficiency issues.

The simplify pass can explore the full codebase to detect duplicates and existing patterns, but only modifies files changed during the current task.

## Related Issue

Closes #34

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- Added step 5.4.5 (Simplify pass) in `skills/magic-start/SKILL.md` between implementation (5.4) and final summary (5.5)
- Added bilingual `MSG_SIMPLIFY` message (EN/FR) in `skills/magic-start/references/messages.md`

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [x] Tested affected slash commands

### Test Steps

1. Run `/start` on any ticket to trigger the full workflow
2. After implementation (step 5.4), verify that step 5.4.5 runs `/simplify` on the changed files
3. Verify that `/simplify` only modifies files from the changed list, not unrelated files
4. Verify that if `/simplify` finds no issues, the workflow continues silently to step 5.5

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)