### PR TITLE
[#36] feat(desktop): stream-json PTY mode and parser infrastructure

### DIFF
--- a/desktop/src/main/ipc/terminal-handlers.ts
+++ b/desktop/src/main/ipc/terminal-handlers.ts
@@ -243,7 +243,7 @@ export function setupTerminalHandlers(
   })
 
   // Launch Claude in a new terminal
-  ipcMain.handle('terminal:launchClaude', async (_event, { id, name, cwd }) => {
+  ipcMain.handle('terminal:launchClaude', async (_event, { id, name, cwd, outputFormat }) => {
     const terminal = launchClaude(
       id,
       name,
@@ -315,7 +315,9 @@ export function setupTerminalHandlers(
         if (mainWindow) {
           mainWindow.webContents.send('terminal:repositories', { id, repositories })
         }
-      }
+      },
+      // outputFormat
+      outputFormat
     )
 
     // Save agent to disk immediately

--- a/desktop/src/main/pty/terminal-manager.ts
+++ b/desktop/src/main/pty/terminal-manager.ts
@@ -403,7 +403,8 @@ export function launchClaude(
   onMetadataChange?: (metadata: TerminalMetadata) => void,
   initialMetadata?: TerminalMetadata,
   onRepositoriesChange?: (repositories: string[]) => void,
-  initialRepositories?: string[]
+  initialRepositories?: string[],
+  outputFormat?: 'raw' | 'stream-json'
 ): Terminal {
   const shell = getDefaultShell()
   const expandedCwd = expandPath(cwd)
@@ -413,9 +414,14 @@ export function launchClaude(
   // Track when PTY process started for stable-run detection
   let ptyStartTime = Date.now()
 
+  // Build the claude command with optional output format
+  const claudeCmd = outputFormat === 'stream-json'
+    ? 'claude --output-format stream-json'
+    : 'claude'
+
   // Function to create and attach a new PTY process
   const createPtyProcess = (currentCwd: string, cols: number = 120, rows: number = 30) => {
-    const ptyProcess = pty.spawn(shell, ['-li', '-c', 'claude'], {
+    const ptyProcess = pty.spawn(shell, ['-li', '-c', claudeCmd], {
       name: 'xterm-256color',
       cols,
       rows,

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -97,8 +97,8 @@ const terminalApi = {
   create: (id: string, name: string, cwd: string) =>
     ipcRenderer.invoke('terminal:create', { id, name, cwd }),
 
-  launchClaude: (id: string, name: string, cwd: string) =>
-    ipcRenderer.invoke('terminal:launchClaude', { id, name, cwd }),
+  launchClaude: (id: string, name: string, cwd: string, outputFormat?: 'raw' | 'stream-json') =>
+    ipcRenderer.invoke('terminal:launchClaude', { id, name, cwd, outputFormat }),
 
   write: (id: string, data: string) =>
     ipcRenderer.invoke('terminal:write', { id, data }),

--- a/desktop/src/renderer/hooks/streamJsonParser.ts
+++ b/desktop/src/renderer/hooks/streamJsonParser.ts
@@ -1,0 +1,29 @@
+import type { StreamEvent } from '../types/streamEvents'
+
+// Pure parser function — no React dependency, testable standalone
+export function parseStreamLines(
+  buffer: string,
+  incoming: string
+): { events: StreamEvent[]; remaining: string } {
+  const combined = buffer + incoming
+  const lines = combined.split('\n')
+  // Last element is either empty (if incoming ended with \n) or a partial line
+  const remaining = lines.pop() ?? ''
+  const events: StreamEvent[] = []
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+
+    try {
+      const parsed = JSON.parse(trimmed)
+      if (parsed && typeof parsed === 'object' && typeof parsed.type === 'string') {
+        events.push(parsed as StreamEvent)
+      }
+    } catch {
+      // Non-JSON line (ANSI sequences, shell output) — skip silently
+    }
+  }
+
+  return { events, remaining }
+}

--- a/desktop/src/renderer/hooks/useStreamJsonParser.test.ts
+++ b/desktop/src/renderer/hooks/useStreamJsonParser.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { parseStreamLines } from './streamJsonParser'
+
+describe('parseStreamLines', () => {
+  it('parses a single complete JSON line', () => {
+    const { events, remaining } = parseStreamLines('', '{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-4"}}\n')
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe('message_start')
+    expect(remaining).toBe('')
+  })
+
+  it('parses multiple JSON lines in one chunk', () => {
+    const input = [
+      '{"type":"content_block_start","index":0,"content_block":{"type":"text"}}',
+      '{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}',
+      '{"type":"content_block_stop","index":0}',
+      '',
+    ].join('\n')
+
+    const { events, remaining } = parseStreamLines('', input)
+    expect(events).toHaveLength(3)
+    expect(events[0].type).toBe('content_block_start')
+    expect(events[1].type).toBe('content_block_delta')
+    expect(events[2].type).toBe('content_block_stop')
+    expect(remaining).toBe('')
+  })
+
+  it('buffers incomplete lines across chunks', () => {
+    const fullLine = '{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello world"}}'
+    const part1 = fullLine.slice(0, 40)
+    const part2 = fullLine.slice(40) + '\n'
+
+    // First chunk: partial line, no events
+    const result1 = parseStreamLines('', part1)
+    expect(result1.events).toHaveLength(0)
+    expect(result1.remaining).toBe(part1)
+
+    // Second chunk: completes the line
+    const result2 = parseStreamLines(result1.remaining, part2)
+    expect(result2.events).toHaveLength(1)
+    expect(result2.events[0].type).toBe('content_block_delta')
+    expect(result2.remaining).toBe('')
+  })
+
+  it('ignores non-JSON lines (ANSI escape sequences)', () => {
+    const input = '\x1b[2J\x1b[H\n{"type":"system","subtype":"init"}\nsome random text\n'
+    const { events } = parseStreamLines('', input)
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe('system')
+  })
+
+  it('ignores empty lines', () => {
+    const input = '\n\n{"type":"message_stop"}\n\n'
+    const { events } = parseStreamLines('', input)
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe('message_stop')
+  })
+
+  it('ignores JSON without a type field', () => {
+    const input = '{"foo":"bar"}\n{"type":"error","error":{"type":"api_error","message":"fail"}}\n'
+    const { events } = parseStreamLines('', input)
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe('error')
+  })
+
+  it('handles all major event types', () => {
+    const eventLines = [
+      '{"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","model":"claude-4"}}',
+      '{"type":"content_block_start","index":0,"content_block":{"type":"text"}}',
+      '{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}',
+      '{"type":"content_block_stop","index":0}',
+      '{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tu_1","name":"Read"}}',
+      '{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\""}}',
+      '{"type":"content_block_stop","index":1}',
+      '{"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+      '{"type":"message_stop"}',
+      '{"type":"result","subtype":"success","cost_usd":0.01,"duration_ms":1500}',
+      '',
+    ].join('\n')
+
+    const { events } = parseStreamLines('', eventLines)
+    expect(events).toHaveLength(10)
+    expect(events.map(e => e.type)).toEqual([
+      'message_start',
+      'content_block_start',
+      'content_block_delta',
+      'content_block_stop',
+      'content_block_start',
+      'content_block_delta',
+      'content_block_stop',
+      'message_delta',
+      'message_stop',
+      'result',
+    ])
+  })
+
+  it('handles malformed JSON gracefully', () => {
+    const input = '{broken json\n{"type":"message_stop"}\n{also broken}\n'
+    const { events } = parseStreamLines('', input)
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe('message_stop')
+  })
+
+  it('preserves remaining buffer when input does not end with newline', () => {
+    const input = '{"type":"message_stop"}\n{"type":"partial'
+    const { events, remaining } = parseStreamLines('', input)
+    expect(events).toHaveLength(1)
+    expect(remaining).toBe('{"type":"partial')
+  })
+
+  it('works with empty input', () => {
+    const { events, remaining } = parseStreamLines('', '')
+    expect(events).toHaveLength(0)
+    expect(remaining).toBe('')
+  })
+
+  it('works with only a newline', () => {
+    const { events, remaining } = parseStreamLines('', '\n')
+    expect(events).toHaveLength(0)
+    expect(remaining).toBe('')
+  })
+})

--- a/desktop/src/renderer/hooks/useStreamJsonParser.ts
+++ b/desktop/src/renderer/hooks/useStreamJsonParser.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useCallback, useState } from 'react'
+import type { StreamEvent } from '../types/streamEvents'
+import { parseStreamLines } from './streamJsonParser'
+
+export type { StreamEvent }
+export { parseStreamLines }
+
+export interface StreamJsonParserState {
+  events: StreamEvent[]
+  lastEvent: StreamEvent | null
+  error: string | null
+}
+
+export function useStreamJsonParser(
+  terminalId: string | null,
+  enabled: boolean = true
+): StreamJsonParserState {
+  const bufferRef = useRef('')
+  const [state, setState] = useState<StreamJsonParserState>({
+    events: [],
+    lastEvent: null,
+    error: null,
+  })
+
+  const handleData = useCallback((data: string) => {
+    const { events, remaining } = parseStreamLines(bufferRef.current, data)
+    bufferRef.current = remaining
+
+    if (events.length > 0) {
+      setState(prev => ({
+        events: [...prev.events, ...events],
+        lastEvent: events[events.length - 1],
+        error: null,
+      }))
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!terminalId || !enabled) return
+
+    // Reset state when terminal changes
+    bufferRef.current = ''
+    setState({ events: [], lastEvent: null, error: null })
+
+    const unsubscribe = window.electronAPI.terminal.onData(({ id, data }) => {
+      if (id === terminalId) {
+        handleData(data)
+      }
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [terminalId, enabled, handleData])
+
+  return state
+}

--- a/desktop/src/renderer/types/streamEvents.ts
+++ b/desktop/src/renderer/types/streamEvents.ts
@@ -1,0 +1,97 @@
+// Stream-JSON event types for Claude Code --output-format stream-json
+// See: https://docs.anthropic.com/en/docs/build-with-claude/claude-code/streaming
+
+export interface MessageStart {
+  type: 'message_start'
+  message: {
+    id: string
+    type: 'message'
+    role: 'assistant'
+    model: string
+    usage?: {
+      input_tokens: number
+      output_tokens: number
+      cache_creation_input_tokens?: number
+      cache_read_input_tokens?: number
+    }
+  }
+}
+
+export interface MessageDelta {
+  type: 'message_delta'
+  delta: {
+    stop_reason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence' | null
+  }
+  usage?: {
+    output_tokens: number
+  }
+}
+
+export interface MessageStop {
+  type: 'message_stop'
+}
+
+export interface ContentBlockStart {
+  type: 'content_block_start'
+  index: number
+  content_block: {
+    type: 'text' | 'tool_use'
+    text?: string
+    id?: string
+    name?: string
+    input?: Record<string, unknown>
+  }
+}
+
+export interface ContentBlockDelta {
+  type: 'content_block_delta'
+  index: number
+  delta: {
+    type: 'text_delta' | 'input_json_delta'
+    text?: string
+    partial_json?: string
+  }
+}
+
+export interface ContentBlockStop {
+  type: 'content_block_stop'
+  index: number
+}
+
+export interface SystemEvent {
+  type: 'system'
+  subtype: string
+  message?: string
+  [key: string]: unknown
+}
+
+export interface ResultEvent {
+  type: 'result'
+  subtype: 'success' | 'error'
+  result?: string
+  cost_usd?: number
+  duration_ms?: number
+  duration_api_ms?: number
+  num_turns?: number
+  is_error?: boolean
+  session_id?: string
+}
+
+export interface ErrorEvent {
+  type: 'error'
+  error: {
+    type: string
+    message: string
+  }
+}
+
+export type StreamEvent =
+  | MessageStart
+  | MessageDelta
+  | MessageStop
+  | ContentBlockStart
+  | ContentBlockDelta
+  | ContentBlockStop
+  | SystemEvent
+  | ResultEvent
+  | ErrorEvent


### PR DESCRIPTION
## Description

Add foundational infrastructure for the stream-json overlay mode (sub-issue 1/5 of #32):

- **PTY spawn**: `launchClaude()` now accepts an optional `outputFormat` parameter. When set to `'stream-json'`, the PTY spawns Claude Code with `--output-format stream-json`. Default behavior (raw mode) is unchanged.
- **TypeScript types**: New `StreamEvent` union type covering all Claude Code stream-json event types (`message_start`, `content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`, `message_stop`, `system`, `result`, `error`).
- **Parser hook**: `useStreamJsonParser` React hook that subscribes to PTY data, buffers incomplete lines, parses each line as JSON, and emits typed `StreamEvent` objects. Non-JSON lines (ANSI escape sequences, shell output) are gracefully ignored.
- **Unit tests**: 11 tests covering valid JSON, partial lines across chunks, malformed input, all event types, and edge cases.

## Related Issue

Closes #36

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- Added `outputFormat?: 'raw' | 'stream-json'` parameter to `launchClaude()` in `terminal-manager.ts`
- Propagated `outputFormat` through IPC in `terminal-handlers.ts` and `preload/index.ts`
- Created `desktop/src/renderer/types/streamEvents.ts` with 9-variant `StreamEvent` union type
- Created `desktop/src/renderer/hooks/useStreamJsonParser.ts` with pure `parseStreamLines` function and `useStreamJsonParser` hook
- Created `desktop/src/renderer/hooks/useStreamJsonParser.test.ts` with 11 unit tests

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

### Test Steps

1. Run `npm test` from the repo root — all 55 tests should pass (including 11 new parser tests)
2. Verify existing terminal view still works in raw mode: launch a Claude agent from the desktop app — it should behave identically to before (no `outputFormat` is passed by default)
3. To test stream-json mode manually: in `terminal-handlers.ts`, temporarily pass `outputFormat: 'stream-json'` to `launchClaude()` and observe the PTY output is JSON lines instead of raw terminal output

## Screenshots

N/A — no UI changes in this PR (infrastructure only).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

This is sub-issue 1/5 for the friendly overlay feature (#32). It provides the foundational stream-json infrastructure that sub-issues 2-5 will build upon. The `outputFormat` parameter is opt-in — no existing behavior is changed.