### PR TITLE
[magic-slash-37] Add FriendlyOverlay shell and view mode toggle

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-slash-desktop",
-  "version": "0.20.2",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-slash-desktop",
-      "version": "0.20.2",
+      "version": "0.24.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/desktop/src/renderer/components/FriendlyOverlay.tsx
+++ b/desktop/src/renderer/components/FriendlyOverlay.tsx
@@ -1,0 +1,35 @@
+import { useStreamJsonParser } from '../hooks/useStreamJsonParser'
+
+interface FriendlyOverlayProps {
+  terminalId: string | null
+}
+
+export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
+  const { events } = useStreamJsonParser(terminalId)
+
+  return (
+    <div className="h-full flex flex-col bg-black/30 backdrop-blur-md overflow-hidden">
+      {/* Scrollable conversation area */}
+      <div className="flex-1 overflow-y-auto p-4">
+        {events.length === 0 ? (
+          <div className="h-full flex items-center justify-center text-text-secondary text-sm">
+            Overlay mode — events will appear here
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {events.map((event, i) => (
+              <div key={i} className="text-sm text-text-secondary font-mono">
+                <span className="text-white/40">[{event.type}]</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Fixed input zone at bottom */}
+      <div className="shrink-0 bg-white/5 mx-2 mb-4 px-4 py-3 rounded-lg">
+        <span className="text-text-secondary text-sm">Input will be connected in a future sub-issue</span>
+      </div>
+    </div>
+  )
+}

--- a/desktop/src/renderer/components/TitleBar.tsx
+++ b/desktop/src/renderer/components/TitleBar.tsx
@@ -1,3 +1,4 @@
+import { Monitor, MessageSquare } from 'lucide-react'
 import { useStore } from '../store'
 
 // Inline SVG components for left sidebar toggle icons
@@ -35,7 +36,7 @@ const RightSidebarCloseIcon = () => (
 )
 
 export function TitleBar() {
-  const { currentPage, terminals, activeTerminalId, rightSidebar, leftSidebarVisible, toggleRightSidebar, toggleLeftSidebar } = useStore()
+  const { currentPage, terminals, activeTerminalId, rightSidebar, leftSidebarVisible, viewMode, toggleRightSidebar, toggleLeftSidebar, toggleViewMode } = useStore()
   const activeTerminal = terminals.find((t) => t.id === activeTerminalId)
 
   return (
@@ -67,6 +68,35 @@ export function TitleBar() {
             </button>
           </div>
         )}
+
+        {/* View mode toggle */}
+        {currentPage === 'terminals' && terminals.length > 0 && (
+          <div
+            className="flex items-center"
+            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+          >
+            <button
+              onClick={toggleViewMode}
+              className="relative flex items-center gap-0.5 p-1 rounded-lg"
+              title={`Switch to ${viewMode === 'overlay' ? 'terminal' : 'overlay'} mode (${navigator.platform.toUpperCase().indexOf('MAC') >= 0 ? '⌘T' : 'Ctrl+T'})`}
+            >
+              {/* Sliding active indicator */}
+              <span className={`absolute top-1 w-6 h-6 rounded-md bg-white/20 transition-transform duration-200 ease-in-out ${
+                viewMode === 'terminal' ? 'translate-x-[26px]' : 'translate-x-0'
+              }`} />
+              <span className={`relative flex items-center justify-center w-6 h-6 rounded-md transition-colors duration-200 ${
+                viewMode === 'overlay' ? 'text-white' : 'text-text-secondary'
+              }`}>
+                <MessageSquare className="w-3.5 h-3.5" />
+              </span>
+              <span className={`relative flex items-center justify-center w-6 h-6 rounded-md transition-colors duration-200 ${
+                viewMode === 'terminal' ? 'text-white' : 'text-text-secondary'
+              }`}>
+                <Monitor className="w-3.5 h-3.5" />
+              </span>
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Center - Active agent name */}
@@ -74,7 +104,7 @@ export function TitleBar() {
         {currentPage === 'terminals' && (activeTerminal?.metadata?.title || activeTerminal?.name)}
       </div>
 
-      {/* Right side - Sidebar toggle (only on agents page with at least one agent) */}
+      {/* Right side - View mode toggle + Sidebar toggle */}
       {currentPage === 'terminals' && terminals.length > 0 && (
         <div
           className="flex items-center gap-1"

--- a/desktop/src/renderer/pages/Terminals/index.tsx
+++ b/desktop/src/renderer/pages/Terminals/index.tsx
@@ -5,6 +5,7 @@ import { useScriptRunner } from '../../hooks/useScriptRunner'
 import { useGroupedTerminals } from '../../hooks/useGroupedTerminals'
 import { useStore } from '../../store'
 import { TerminalView } from '../../components/TerminalView'
+import { FriendlyOverlay } from '../../components/FriendlyOverlay'
 import { showToast } from '../../components/Toast'
 
 const DEFAULT_PATH = '~/Documents'
@@ -14,7 +15,7 @@ export function TerminalsPage() {
   const { terminals, activeTerminalId, launchClaudeTerminal, setActiveTerminal, duplicateAgent } = useTerminals()
   const { scriptTerminals } = useScriptRunner()
   const { flatVisualOrder } = useGroupedTerminals()
-  const { toggleRightSidebar, setCurrentPage } = useStore()
+  const { toggleRightSidebar, setCurrentPage, viewMode, toggleViewMode } = useStore()
   const [isCreating, setIsCreating] = useState(false)
 
   // Generate terminal name based on count
@@ -141,6 +142,19 @@ export function TerminalsPage() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [activeTerminalId, terminals, duplicateAgent, setActiveTerminal])
 
+  // Listen for Command+T to toggle view mode
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 't') {
+        e.preventDefault()
+        toggleViewMode()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [toggleViewMode])
+
   // Detect platform for keyboard shortcut display
   const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
   const shortcutKey = isMac ? '⌘N' : 'Ctrl+N'
@@ -168,27 +182,34 @@ export function TerminalsPage() {
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      {/* Terminal Content */}
-      <div className="flex-1 overflow-hidden">
-        {terminals.map((terminal) => (
-          <TerminalView
-            key={terminal.id}
-            terminal={terminal}
-            isActive={terminal.id === activeTerminalId}
-          />
-        ))}
-        {scriptTerminals.map((script) => (
-          <TerminalView
-            key={script.id}
-            terminal={{
-              id: script.id,
-              name: `${script.scriptName} (${script.agentName})`,
-              state: script.state === 'running' ? 'working' : 'error',
-              repositories: [script.projectPath],
-            }}
-            isActive={script.id === activeTerminalId}
-          />
-        ))}
+      <div className="flex-1 overflow-hidden relative">
+        {/* Terminal views — kept mounted to preserve PTY state */}
+        <div className={viewMode === 'terminal' ? 'h-full' : 'hidden'}>
+          {terminals.map((terminal) => (
+            <TerminalView
+              key={terminal.id}
+              terminal={terminal}
+              isActive={terminal.id === activeTerminalId && viewMode === 'terminal'}
+            />
+          ))}
+          {scriptTerminals.map((script) => (
+            <TerminalView
+              key={script.id}
+              terminal={{
+                id: script.id,
+                name: `${script.scriptName} (${script.agentName})`,
+                state: script.state === 'running' ? 'working' : 'error',
+                repositories: [script.projectPath],
+              }}
+              isActive={script.id === activeTerminalId && viewMode === 'terminal'}
+            />
+          ))}
+        </div>
+
+        {/* Friendly overlay */}
+        {viewMode === 'overlay' && (
+          <FriendlyOverlay terminalId={activeTerminalId} />
+        )}
       </div>
     </div>
   )

--- a/desktop/src/renderer/store/index.ts
+++ b/desktop/src/renderer/store/index.ts
@@ -22,6 +22,7 @@ interface AppState {
   rightSidebar: 'info' | null
   leftSidebarVisible: boolean
   iconSidebarVisible: boolean
+  viewMode: 'terminal' | 'overlay'
 
   // Workspace terminals
   workspaceTerminals: WorkspaceTerminal[]
@@ -55,6 +56,8 @@ interface AppState {
   toggleRightSidebar: (sidebar: 'info') => void
   toggleLeftSidebar: () => void
   toggleIconSidebar: () => void
+  setViewMode: (mode: 'terminal' | 'overlay') => void
+  toggleViewMode: () => void
 
   // Workspace terminal actions
   addWorkspaceTerminal: (paneIndex: number, id: string, name: string, repositories: string[]) => void
@@ -91,6 +94,7 @@ export const useStore = create<AppState>()(
         rightSidebar: null,
         leftSidebarVisible: true,
         iconSidebarVisible: true,
+        viewMode: 'overlay',
 
         workspaceTerminals: [],
         workspaceLayout: 1,
@@ -168,6 +172,8 @@ export const useStore = create<AppState>()(
         })),
         toggleLeftSidebar: () => set((state) => ({ leftSidebarVisible: !state.leftSidebarVisible })),
         toggleIconSidebar: () => set((state) => ({ iconSidebarVisible: !state.iconSidebarVisible })),
+        setViewMode: (viewMode) => set({ viewMode }),
+        toggleViewMode: () => set((state) => ({ viewMode: state.viewMode === 'terminal' ? 'overlay' : 'terminal' })),
 
         // Workspace terminal actions
         addWorkspaceTerminal: (paneIndex, id, name, repositories) =>
@@ -231,6 +237,7 @@ export const useStore = create<AppState>()(
       partialize: (state) => ({
         leftSidebarVisible: state.leftSidebarVisible,
         iconSidebarVisible: state.iconSidebarVisible,
+        viewMode: state.viewMode,
         workspaceLayout: state.workspaceLayout,
       }),
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-slash",
-  "version": "0.20.2",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-slash",
-      "version": "0.20.2",
+      "version": "0.24.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",


### PR DESCRIPTION
## Summary

Add the `FriendlyOverlay` container component (empty shell with scrollable conversation area + fixed input zone) and the terminal/overlay toggle mechanism with `Cmd+T` shortcut. View mode preference is persisted across sessions via Zustand store. This is part 2/5 of the Friendly UI overlay feature (#32).

## Changes

- 10445c8 feat(desktop): add FriendlyOverlay shell and view mode toggle

## How to test

1. Launch the desktop app and create an agent
2. Verify the toggle switch appears in the title bar (left side, after sidebar toggle) with two icons: chat bubble (overlay) and monitor (terminal)
3. Click the toggle — it should switch between overlay and terminal view with a sliding animation on the active indicator
4. In overlay mode: verify the FriendlyOverlay displays with "Overlay mode — events will appear here" placeholder and an input zone at the bottom
5. Switch back to terminal mode — verify the terminal is still functional (PTY connection preserved)
6. Press `Cmd+T` — verify it toggles the view mode
7. Restart the app — verify the last selected mode is remembered (default: overlay)

## Linked Issues

- Closes #37