### PR TITLE
[#38] Add chat input, mode cycling and confirm dialog

### DIFF
--- a/desktop/src/renderer/components/FriendlyOverlay.tsx
+++ b/desktop/src/renderer/components/FriendlyOverlay.tsx
@@ -1,4 +1,14 @@
+import { useState, useCallback, useMemo, useEffect } from 'react'
 import { useStreamJsonParser } from '../hooks/useStreamJsonParser'
+import type { StreamEvent } from '../types/streamEvents'
+import { ChatInput } from './friendly/ChatInput'
+import { ConfirmDialog } from './friendly/ConfirmDialog'
+
+const FAKE_CONFIRM_EVENT: StreamEvent = {
+  type: 'system',
+  subtype: 'tool_use_permission',
+  message: 'Claude wants to execute Bash(rm -rf node_modules). Allow?',
+}
 
 interface FriendlyOverlayProps {
   terminalId: string | null
@@ -6,6 +16,25 @@ interface FriendlyOverlayProps {
 
 export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
   const { events } = useStreamJsonParser(terminalId)
+  const [isConfirmationActive, setIsConfirmationActive] = useState(false)
+  const [debugConfirm, setDebugConfirm] = useState(false)
+
+  // Listen for debug trigger from UpdateOverlay debug menu
+  useEffect(() => {
+    const handler = () => setDebugConfirm(true)
+    window.addEventListener('debug:confirm-dialog', handler)
+    return () => window.removeEventListener('debug:confirm-dialog', handler)
+  }, [])
+
+  const confirmEvents = useMemo<StreamEvent[]>(
+    () => (debugConfirm ? [...events, FAKE_CONFIRM_EVENT] : events),
+    [events, debugConfirm],
+  )
+
+  const handleConfirmActiveChange = useCallback((active: boolean) => {
+    setIsConfirmationActive(active)
+    if (!active) setDebugConfirm(false)
+  }, [])
 
   return (
     <div className="h-full flex flex-col bg-black/30 backdrop-blur-md overflow-hidden">
@@ -26,10 +55,19 @@ export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
         )}
       </div>
 
-      {/* Fixed input zone at bottom */}
-      <div className="shrink-0 bg-white/5 mx-2 mb-4 px-4 py-3 rounded-lg">
-        <span className="text-text-secondary text-sm">Input will be connected in a future sub-issue</span>
-      </div>
+      {/* Confirmation dialog (above input) */}
+      <ConfirmDialog
+        terminalId={terminalId}
+        events={confirmEvents}
+        onActiveChange={handleConfirmActiveChange}
+      />
+
+      {/* Chat input bar */}
+      <ChatInput
+        terminalId={terminalId}
+        disabled={isConfirmationActive}
+      />
+
     </div>
   )
 }

--- a/desktop/src/renderer/components/UpdateOverlay.tsx
+++ b/desktop/src/renderer/components/UpdateOverlay.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Bug, Download, CheckCircle, Loader2, Play, ScrollText, Sparkles } from 'lucide-react'
+import { Bug, Download, CheckCircle, Loader2, Play, ScrollText, ShieldQuestion, Sparkles } from 'lucide-react'
 import { useStore } from '../store'
 
 type UpdateStatus =
@@ -115,6 +115,11 @@ export function UpdateOverlay() {
     setDebugMenuOpen(false)
     const prompt = 'Print exactly 200 lines of lorem ipsum text, each line numbered. Do not ask questions, just print.\n'
     window.electronAPI.terminal.write(activeTerminalId, prompt)
+  }
+
+  function showConfirmDialog() {
+    setDebugMenuOpen(false)
+    window.dispatchEvent(new Event('debug:confirm-dialog'))
   }
 
   function showWhatsNew() {
@@ -244,6 +249,13 @@ export function UpdateOverlay() {
                 >
                   <ScrollText className="w-3.5 h-3.5" />
                   Flood terminal
+                </button>
+                <button
+                  onClick={showConfirmDialog}
+                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-text-secondary hover:text-white hover:bg-bg-tertiary transition-colors"
+                >
+                  <ShieldQuestion className="w-3.5 h-3.5" />
+                  Confirm dialog
                 </button>
               </div>
             )}

--- a/desktop/src/renderer/components/friendly/ChatInput.tsx
+++ b/desktop/src/renderer/components/friendly/ChatInput.tsx
@@ -1,0 +1,276 @@
+import { useRef, useCallback, useEffect, useState } from 'react'
+import { ArrowUp } from 'lucide-react'
+import { MODE_CYCLE, type ClaudeMode } from './ModeLabel'
+
+// PTY escape sequences for mode switching in Claude Code
+// Shift+Tab sends the escape sequence that Claude Code interprets as mode cycle
+const SHIFT_TAB_SEQUENCE = '\x1b[Z'
+
+// Persist mode per terminal across remounts and refreshes
+const STORAGE_KEY = 'magic-slash-terminal-modes'
+
+function loadModes(): Map<string, ClaudeMode> {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    return raw ? new Map(JSON.parse(raw)) : new Map()
+  } catch {
+    return new Map()
+  }
+}
+
+function saveModes(modes: Map<string, ClaudeMode>) {
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...modes]))
+}
+
+const terminalModes = loadModes()
+
+const MODE_PILL: Record<ClaudeMode, { label: string; bg: string; text: string }> = {
+  normal: { label: 'Normal', bg: 'bg-white/10', text: 'text-text-secondary' },
+  'auto-accept': { label: 'Auto-accept', bg: 'bg-orange/20', text: 'text-orange' },
+  plan: { label: 'Plan', bg: 'bg-purple/20', text: 'text-purple' },
+}
+
+interface ChatInputProps {
+  terminalId: string | null
+  disabled?: boolean
+}
+
+export function ChatInput({ terminalId, disabled = false }: ChatInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [value, setValue] = useState('')
+  const [isMultiline, setIsMultiline] = useState(false)
+  const [mode, setModeState] = useState<ClaudeMode>(
+    () => (terminalId && terminalModes.get(terminalId)) || 'normal'
+  )
+  const [displayedMode, setDisplayedMode] = useState<ClaudeMode>(mode)
+  const [slidePhase, setSlidePhase] = useState<'idle' | 'out' | 'in'>('idle')
+  const [pillWidth, setPillWidth] = useState<number | undefined>(undefined)
+  const measureRef = useRef<HTMLSpanElement>(null)
+  const pillLabelRef = useRef<HTMLSpanElement>(null)
+
+  // Measure initial width on mount
+  useEffect(() => {
+    if (pillLabelRef.current) {
+      setPillWidth(pillLabelRef.current.offsetWidth)
+    }
+  }, [])
+
+  // Animate mode label transition: slide-out-left → swap text → slide-in-right
+  useEffect(() => {
+    if (mode === displayedMode) return
+    // Pre-measure target width via hidden span
+    if (measureRef.current) {
+      measureRef.current.textContent = MODE_PILL[mode].label
+      setPillWidth(measureRef.current.offsetWidth)
+    }
+    setSlidePhase('out')
+    const timer = setTimeout(() => {
+      setDisplayedMode(mode)
+      setSlidePhase('in')
+      const timer2 = setTimeout(() => setSlidePhase('idle'), 200)
+      return () => clearTimeout(timer2)
+    }, 150)
+    return () => clearTimeout(timer)
+  }, [mode])
+
+  // Wrap setMode to also persist to the Map
+  const setMode = useCallback((updater: ClaudeMode | ((prev: ClaudeMode) => ClaudeMode)) => {
+    setModeState(prev => {
+      const next = typeof updater === 'function' ? updater(prev) : updater
+      if (terminalId) {
+        terminalModes.set(terminalId, next)
+        saveModes(terminalModes)
+      }
+      return next
+    })
+  }, [terminalId])
+
+  // Restore mode when switching terminals
+  useEffect(() => {
+    if (terminalId) {
+      setModeState(terminalModes.get(terminalId) || 'normal')
+    }
+  }, [terminalId])
+
+  // Auto-resize textarea
+  const adjustHeight = useCallback(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    textarea.style.height = 'auto'
+    const height = Math.min(textarea.scrollHeight, 200)
+    textarea.style.height = `${height}px`
+    setIsMultiline(textarea.scrollHeight > textarea.clientHeight || value.includes('\n'))
+  }, [value])
+
+  useEffect(() => {
+    adjustHeight()
+  }, [value, adjustHeight])
+
+  // Focus input when enabled changes from disabled to enabled
+  useEffect(() => {
+    if (!disabled && textareaRef.current) {
+      textareaRef.current.focus()
+    }
+  }, [disabled])
+
+  const sendMessage = useCallback(() => {
+    if (!terminalId || !value.trim()) return
+    window.electronAPI.terminal.write(terminalId, value + '\r')
+    setValue('')
+  }, [terminalId, value])
+
+  const cycleMode = useCallback(() => {
+    if (!terminalId) return
+    setMode(prev => MODE_CYCLE[(MODE_CYCLE.indexOf(prev) + 1) % MODE_CYCLE.length])
+    window.electronAPI.terminal.write(terminalId, SHIFT_TAB_SEQUENCE)
+  }, [terminalId])
+
+
+  // Global Shift+Tab handler (works even when input is not focused)
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Tab' && e.shiftKey) {
+        e.preventDefault()
+        cycleMode()
+      }
+    }
+
+    document.addEventListener('keydown', handleGlobalKeyDown)
+    return () => document.removeEventListener('keydown', handleGlobalKeyDown)
+  }, [cycleMode])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Shift+Tab: handled globally, prevent default here too
+    if (e.key === 'Tab' && e.shiftKey) {
+      e.preventDefault()
+      return
+    }
+
+    // Enter: send message (without shift)
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage()
+      return
+    }
+
+    // Escape: send to PTY (cancel current action)
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      if (terminalId) {
+        window.electronAPI.terminal.write(terminalId, '\x1b')
+      }
+      setValue('')
+      return
+    }
+
+    // Ctrl+C: interrupt
+    if (e.key === 'c' && e.ctrlKey) {
+      e.preventDefault()
+      if (terminalId) {
+        window.electronAPI.terminal.write(terminalId, '\x03')
+      }
+      setValue('')
+      return
+    }
+
+    // Ctrl+D: EOF
+    if (e.key === 'd' && e.ctrlKey) {
+      e.preventDefault()
+      if (terminalId) {
+        window.electronAPI.terminal.write(terminalId, '\x04')
+      }
+      return
+    }
+  }, [terminalId, sendMessage, cycleMode])
+
+  return (
+    <div
+      className={`shrink-0 bg-white/5 mx-3 mb-3 border ${
+        mode === 'auto-accept'
+          ? 'border-orange/30'
+          : mode === 'plan'
+            ? 'border-purple/30'
+            : 'border-transparent'
+      }`}
+      style={{
+        borderRadius: isMultiline ? '12px' : '9999px',
+        transition: 'border-radius 300ms ease-in-out, box-shadow 200ms ease, border-color 200ms ease',
+        boxShadow: mode === 'auto-accept'
+          ? '0 0 12px 0 rgba(249, 115, 22, 0.3)'
+          : mode === 'plan'
+            ? '0 0 12px 0 rgba(168, 85, 247, 0.3)'
+            : 'none',
+      }}
+    >
+      <div className={`flex gap-2 pl-4 pr-3 py-2 ${isMultiline ? 'items-end' : 'items-center'}`}>
+        {/* Textarea */}
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          placeholder={disabled ? 'Waiting for response...' : 'Send a message...'}
+          rows={1}
+          spellCheck={false}
+          className={`
+            flex-1 bg-transparent text-white text-sm font-sans resize-none outline-none focus:ring-0 focus:outline-none
+            placeholder:text-text-secondary py-1.5
+            ${disabled ? 'opacity-40 cursor-not-allowed' : ''}
+          `}
+        />
+
+        {/* Hidden span to measure target label width */}
+        <span
+          ref={measureRef}
+          aria-hidden
+          className="absolute invisible whitespace-nowrap text-[11px] font-medium"
+        />
+
+        {/* Active mode pill */}
+        <button
+          onClick={cycleMode}
+          className={`shrink-0 h-[26px] rounded-full text-xs font-medium cursor-pointer overflow-hidden flex items-center justify-center ${MODE_PILL[mode].bg} ${MODE_PILL[mode].text}`}
+          style={{
+            width: pillWidth ? pillWidth + 20 : undefined,
+            transition: 'width 250ms ease-in-out, background-color 200ms ease, color 200ms ease',
+          }}
+        >
+          <span
+            ref={pillLabelRef}
+            className="inline-block"
+            style={{
+              transition: slidePhase === 'out'
+                ? 'transform 150ms ease-in, opacity 150ms ease-in'
+                : slidePhase === 'in'
+                  ? 'none'
+                  : 'none',
+              transform: slidePhase === 'out' ? 'translateX(-100%)' : 'translateX(0)',
+              opacity: slidePhase === 'out' ? 0 : 1,
+              ...(slidePhase === 'in' && {
+                animation: 'slideInFromRight 200ms ease-out forwards',
+              }),
+            }}
+          >
+            {MODE_PILL[displayedMode].label}
+          </span>
+        </button>
+
+        {/* Send button */}
+        <button
+          onClick={sendMessage}
+          disabled={disabled || !value.trim()}
+          className={`
+            shrink-0 w-[26px] h-[26px] flex items-center justify-center rounded-full transition-all
+            ${value.trim() && !disabled
+              ? 'bg-accent text-white hover:bg-accent-hover'
+              : 'bg-bg-tertiary text-text-secondary cursor-not-allowed'
+            }
+          `}
+        >
+          <ArrowUp className="w-3.5 h-3.5" strokeWidth={2.5} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/desktop/src/renderer/components/friendly/ConfirmDialog.tsx
+++ b/desktop/src/renderer/components/friendly/ConfirmDialog.tsx
@@ -1,0 +1,160 @@
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { ShieldQuestion } from 'lucide-react'
+import type { StreamEvent } from '../../hooks/useStreamJsonParser'
+
+interface ConfirmDialogProps {
+  terminalId: string | null
+  events: StreamEvent[]
+  onActiveChange: (active: boolean) => void
+}
+
+interface ConfirmationRequest {
+  question: string
+  options: string[]
+}
+
+// Only scan the last N events to detect confirmations — avoids O(n) growth
+const SCAN_WINDOW = 20
+
+// Detect when Claude Code is waiting for user confirmation from stream-json events.
+function detectConfirmation(events: StreamEvent[]): ConfirmationRequest | null {
+  const start = Math.max(0, events.length - SCAN_WINDOW)
+
+  for (let i = events.length - 1; i >= start; i--) {
+    const event = events[i]
+
+    if (event.type === 'system' && event.subtype === 'tool_use_permission') {
+      return {
+        question: (event.message as string) || 'Claude wants to execute a tool. Allow?',
+        options: ['Yes', 'No'],
+      }
+    }
+
+    if (event.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
+      const toolName = event.content_block.name || 'a tool'
+
+      // Check if a completion event follows within the remaining window
+      let hasCompleted = false
+      for (let j = i + 1; j < events.length; j++) {
+        const e = events[j]
+        if (e.type === 'message_stop' || (e.type === 'message_delta' && e.delta?.stop_reason)) {
+          hasCompleted = true
+          break
+        }
+      }
+      if (!hasCompleted) {
+        return {
+          question: `Allow Claude to use ${toolName}?`,
+          options: ['Yes', 'No'],
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+export function ConfirmDialog({ terminalId, events, onActiveChange }: ConfirmDialogProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [dismissed, setDismissed] = useState(false)
+  const prevConfirmRef = useRef<ConfirmationRequest | null>(null)
+
+  const confirmation = useMemo(() => detectConfirmation(events), [events])
+
+  // Reset dismissed state when a new confirmation appears
+  useEffect(() => {
+    if (confirmation && confirmation !== prevConfirmRef.current) {
+      prevConfirmRef.current = confirmation
+      setDismissed(false)
+      setSelectedIndex(0)
+    }
+  }, [confirmation])
+
+  const isActive = confirmation !== null && !dismissed
+
+  // Notify parent of active state changes
+  useEffect(() => {
+    onActiveChange(isActive)
+  }, [isActive, onActiveChange])
+
+  const respond = useCallback((option: string) => {
+    if (!terminalId) return
+    // Send the response as lowercase 'y' or 'n' for Yes/No
+    const response = option.toLowerCase().startsWith('y') ? 'y' : 'n'
+    window.electronAPI.terminal.write(terminalId, response + '\r')
+    setDismissed(true)
+  }, [terminalId])
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!isActive || !confirmation) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        e.preventDefault()
+        setSelectedIndex(prev => {
+          if (e.key === 'ArrowLeft') return Math.max(0, prev - 1)
+          return Math.min(confirmation.options.length - 1, prev + 1)
+        })
+      }
+
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        respond(confirmation.options[selectedIndex])
+      }
+
+      // Quick shortcuts: y for Yes, n for No
+      if (e.key === 'y' || e.key === 'Y') {
+        e.preventDefault()
+        respond('yes')
+      }
+      if (e.key === 'n' || e.key === 'N') {
+        e.preventDefault()
+        respond('no')
+      }
+
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        respond('no')
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isActive, confirmation, selectedIndex, respond])
+
+  if (!isActive || !confirmation) return null
+
+  return (
+    <div className="shrink-0 mx-2 mb-2 p-3 bg-white/5 border border-white/10 rounded-lg animate-fade-in">
+      <div className="flex items-start gap-2.5">
+        <ShieldQuestion className="w-4 h-4 text-yellow shrink-0 mt-0.5" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-white mb-2.5">{confirmation.question}</p>
+          <div className="flex items-center gap-2">
+            {confirmation.options.map((option, i) => (
+              <button
+                key={option}
+                onClick={() => respond(option)}
+                className={`
+                  px-3 py-1 text-xs font-medium rounded-md transition-all
+                  ${i === selectedIndex
+                    ? option.toLowerCase().startsWith('y')
+                      ? 'bg-green/20 text-green border border-green/30'
+                      : 'bg-red/20 text-red border border-red/30'
+                    : 'bg-white/5 text-text-secondary border border-white/10 hover:bg-white/10'
+                  }
+                `}
+              >
+                {option}
+                <kbd className="ml-1.5 text-[10px] opacity-50">
+                  {option.toLowerCase().startsWith('y') ? 'Y' : 'N'}
+                </kbd>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/desktop/src/renderer/components/friendly/ModeLabel.tsx
+++ b/desktop/src/renderer/components/friendly/ModeLabel.tsx
@@ -1,0 +1,3 @@
+export type ClaudeMode = 'normal' | 'auto-accept' | 'plan'
+
+export const MODE_CYCLE: ClaudeMode[] = ['normal', 'auto-accept', 'plan']

--- a/desktop/src/renderer/index.css
+++ b/desktop/src/renderer/index.css
@@ -249,3 +249,14 @@ input[type="checkbox"] {
     transition-duration: 0.01ms !important;
   }
 }
+
+@keyframes slideInFromRight {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Description

Add the chat input bar, mode label, and confirmation dialog for the friendly overlay (issue #38 part 3/5). This replaces the placeholder input zone with a full ChatInput component supporting multi-line input, Shift+Tab mode cycling (normal/auto-accept/plan), keyboard shortcuts, and a ConfirmDialog that appears when Claude requests tool approval. A debug trigger is wired into the existing DEV debug menu.

## Related Issue

Closes #38

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `ChatInput.tsx` — persistent input bar with auto-resize, mode cycling, keyboard shortcuts (Enter, Shift+Tab, Escape, Ctrl+C/D)
- `ModeLabel.tsx` — mode type definition (normal, auto-accept, plan)
- `ConfirmDialog.tsx` — confirmation UI detecting `tool_use_permission` stream events, keyboard-first navigation (Y/N, arrows, Enter)
- `FriendlyOverlay.tsx` — integrates ChatInput + ConfirmDialog, listens for `debug:confirm-dialog` event
- `UpdateOverlay.tsx` — adds "Confirm dialog" button to DEV debug menu
- `index.css` — `slideInFromRight` keyframe for mode pill animation

## Testing

- [x] Tested locally with Claude Code

### Test Steps

1. `npm run desktop` — open the app in dev mode
2. Switch a terminal to Friendly overlay mode
3. Verify the chat input bar appears at the bottom with a text area
4. Type a message and press Enter — confirm it's sent to the PTY
5. Press Shift+Tab — verify the mode label cycles: normal → auto-accept (orange) → plan (purple) → normal
6. Press Escape — verify input clears and escape is sent to PTY
7. Click the red bug button (bottom-right) → click "Confirm dialog" — verify the ConfirmDialog appears above the input with Yes/No buttons
8. Verify the input is disabled while the dialog is active
9. Press Y or click Yes — verify the dialog dismisses and input re-enables

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Linked Issues

- Closes #38