### PR TITLE
[#48] Add Claude modes, always allow, and stop/interrupt support

### DIFF
--- a/desktop/src/main/ipc/terminal-handlers.ts
+++ b/desktop/src/main/ipc/terminal-handlers.ts
@@ -11,6 +11,7 @@ import {
   respondToOverlay,
   resetOverlaySession,
   cleanupOverlay,
+  abortOverlayQuery,
   getClaudeCodeInfo,
   type TerminalMetadata,
   type TerminalState,
@@ -241,7 +242,7 @@ export function setupTerminalHandlers(
     return getClaudeCodeInfo()
   })
 
-  ipcMain.handle('overlay:sendMessage', async (_event, { id, message, cwd }) => {
+  ipcMain.handle('overlay:sendMessage', async (_event, { id, message, cwd, mode }) => {
     const mainWindow = getMainWindow()
     if (!mainWindow) return
 
@@ -254,7 +255,17 @@ export function setupTerminalHandlers(
       },
       (exitCode) => {
         mainWindow.webContents.send('overlay:done', { id, exitCode })
-      }
+      },
+      mode
+    )
+  })
+
+  // Abort (interrupt) an active overlay query
+  ipcMain.handle('overlay:abort', async (_event, { id }) => {
+    const mainWindow = getMainWindow()
+    abortOverlayQuery(
+      id,
+      mainWindow ? (jsonLine) => mainWindow.webContents.send('overlay:data', { id, data: jsonLine }) : undefined
     )
   })
 

--- a/desktop/src/main/pty/overlay-sdk.ts
+++ b/desktop/src/main/pty/overlay-sdk.ts
@@ -36,6 +36,19 @@ interface PendingPermission {
 }
 const pendingPermissions = new Map<string, PendingPermission>()
 
+// Track terminals where ExitPlanMode was already approved (auto-approve on resume)
+const planApprovedTerminals = new Set<string>()
+
+/** Reject all pending permissions for a terminal */
+function rejectPendingPermissions(terminalId: string, reason: string): void {
+  for (const [key, pending] of pendingPermissions) {
+    if (key.startsWith(`${terminalId}:`)) {
+      pending.resolve({ behavior: 'deny', message: reason })
+      pendingPermissions.delete(key)
+    }
+  }
+}
+
 // Expand ~ to home directory
 function expandPath(inputPath: string): string {
   if (!inputPath) return inputPath
@@ -59,12 +72,15 @@ export function setOverlaySessionId(id: string, sessionId: string): void {
  * Each SDK message is forwarded to the renderer via onEvent().
  * Permission requests emit synthetic control_request events.
  */
+export type ClaudeMode = 'normal' | 'auto-accept' | 'plan'
+
 export function sendOverlayMessage(
   terminalId: string,
   message: string,
   cwd: string,
   onEvent: (jsonLine: string) => void,
-  onDone: (exitCode: number) => void
+  onDone: (exitCode: number) => void,
+  mode: ClaudeMode = 'normal'
 ): void {
   const expandedCwd = expandPath(cwd)
   const defaultDir = path.join(os.homedir(), 'Documents')
@@ -77,13 +93,7 @@ export function sendOverlayMessage(
     activeQueries.delete(terminalId)
   }
 
-  // Reject any stale pending permissions for this terminal
-  for (const [key, pending] of pendingPermissions) {
-    if (key.startsWith(`${terminalId}:`)) {
-      pending.resolve({ behavior: 'deny', message: 'Session replaced' })
-      pendingPermissions.delete(key)
-    }
-  }
+  rejectPendingPermissions(terminalId, 'Session replaced')
 
   const sessionId = overlaySessionIds.get(terminalId)
 
@@ -98,41 +108,72 @@ export function sendOverlayMessage(
       return
     }
 
+    // Track whether ExitPlanMode was approved during this query
+    // (plan mode queries end after ExitPlanMode; we need to auto-resume for implementation)
+    let exitPlanModeApproved = false
+
+    const canUseToolCallback = async (toolName: string, input: Record<string, unknown>, options: { signal: AbortSignal; toolUseID?: string }) => {
+      // Auto-accept mode: auto-allow tool permissions (but not AskUserQuestion)
+      if (mode === 'auto-accept' && toolName !== 'AskUserQuestion') {
+        return { behavior: 'allow' as const }
+      }
+
+      // Auto-approve ExitPlanMode if the plan was already approved for this terminal
+      // (happens when the resumed session restores plan mode state)
+      if (toolName === 'ExitPlanMode' && planApprovedTerminals.has(terminalId)) {
+        return { behavior: 'allow' as const }
+      }
+
+      const requestId = `perm_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+
+      // Emit synthetic control_request event (same shape ConfirmDialog expects)
+      const controlRequest = {
+        type: 'control_request',
+        request_id: requestId,
+        request: {
+          subtype: 'can_use_tool',
+          tool_name: toolName,
+          input,
+          tool_use_id: options.toolUseID,
+        },
+      }
+      onEvent(JSON.stringify(controlRequest))
+
+      // Return a Promise that resolves when respondToOverlay() is called
+      return new Promise<PermissionResult>((resolve) => {
+        const key = `${terminalId}:${requestId}`
+        pendingPermissions.set(key, {
+          resolve: (result: PermissionResult) => {
+            // Track ExitPlanMode approval for auto-resume and auto-approve on resume
+            if (toolName === 'ExitPlanMode' && result.behavior === 'allow') {
+              exitPlanModeApproved = true
+              planApprovedTerminals.add(terminalId)
+            }
+            resolve(result)
+          },
+        })
+
+        // Cleanup on abort
+        options.signal.addEventListener('abort', () => {
+          if (pendingPermissions.has(key)) {
+            pendingPermissions.delete(key)
+            resolve({ behavior: 'deny', message: 'Aborted' })
+          }
+        })
+      })
+    }
+
     const q = queryFn({
       prompt: message,
       options: {
         cwd: workingDir,
         resume: sessionId,
-        canUseTool: async (toolName, input, options) => {
-          const requestId = `perm_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
-
-          // Emit synthetic control_request event (same shape ConfirmDialog expects)
-          const controlRequest = {
-            type: 'control_request',
-            request_id: requestId,
-            request: {
-              subtype: 'can_use_tool',
-              tool_name: toolName,
-              input,
-              tool_use_id: options.toolUseID,
-            },
-          }
-          onEvent(JSON.stringify(controlRequest))
-
-          // Return a Promise that resolves when respondToOverlay() is called
-          return new Promise<PermissionResult>((resolve) => {
-            const key = `${terminalId}:${requestId}`
-            pendingPermissions.set(key, { resolve })
-
-            // Cleanup on abort
-            options.signal.addEventListener('abort', () => {
-              if (pendingPermissions.has(key)) {
-                pendingPermissions.delete(key)
-                resolve({ behavior: 'deny', message: 'Aborted' })
-              }
-            })
-          })
-        },
+        ...(mode === 'plan'
+          ? { permissionMode: 'plan' as const }
+          : mode === 'auto-accept'
+            ? { permissionMode: 'acceptEdits' as const }
+            : {}),
+        canUseTool: canUseToolCallback,
         env: {
           ...process.env,
           HOME: os.homedir(),
@@ -154,6 +195,26 @@ export function sendOverlayMessage(
 
         onEvent(jsonLine)
       }
+
+      // After a plan mode query completes with ExitPlanMode approved,
+      // auto-resume to start the implementation phase.
+      // The CLI exits after plan approval; we resume the session in normal mode.
+      if (mode === 'plan' && exitPlanModeApproved && overlaySessionIds.has(terminalId)) {
+        exitPlanModeApproved = false
+        // Notify renderer to switch UI mode to auto-accept
+        onEvent(JSON.stringify({ type: 'mode_change', mode: 'auto-accept' }))
+        // Resume in auto-accept mode so implementation tools are auto-approved
+        sendOverlayMessage(
+          terminalId,
+          'Plan mode has been deactivated. You now have full permission to edit files, write files, and run commands. Proceed with implementing the plan.',
+          cwd,
+          onEvent,
+          onDone,
+          'auto-accept'
+        )
+        return
+      }
+
       onDone(0)
     } catch (err) {
       console.error(`[overlay-sdk:${terminalId}] query error:`, err)
@@ -164,6 +225,25 @@ export function sendOverlayMessage(
       }
     }
   })()
+}
+
+/** Abort an active overlay query (idempotent — safe to call multiple times) */
+export function abortOverlayQuery(
+  terminalId: string,
+  onEvent?: (jsonLine: string) => void
+): void {
+  const q = activeQueries.get(terminalId)
+  if (!q) return
+
+  // Emit synthetic interrupted event so the renderer knows it was user-initiated
+  if (onEvent) {
+    onEvent(JSON.stringify({ type: 'interrupted' }))
+  }
+
+  rejectPendingPermissions(terminalId, 'Interrupted by user')
+
+  q.interrupt().catch(() => {})
+  activeQueries.delete(terminalId)
 }
 
 /** Resolve a pending permission request from the renderer */
@@ -195,18 +275,13 @@ export function respondToOverlay(
 /** Reset the overlay session (clears session ID so next message starts fresh) */
 export function resetOverlaySession(id: string): void {
   overlaySessionIds.delete(id)
+  planApprovedTerminals.delete(id)
   const q = activeQueries.get(id)
   if (q) {
     q.return().catch(() => {})
     activeQueries.delete(id)
   }
-  // Reject all pending permissions for this terminal
-  for (const [key, pending] of pendingPermissions) {
-    if (key.startsWith(`${id}:`)) {
-      pending.resolve({ behavior: 'deny', message: 'Session reset' })
-      pendingPermissions.delete(key)
-    }
-  }
+  rejectPendingPermissions(id, 'Session reset')
 }
 
 /** Clean up overlay resources when a terminal is killed */

--- a/desktop/src/main/pty/terminal-manager.ts
+++ b/desktop/src/main/pty/terminal-manager.ts
@@ -253,6 +253,7 @@ export {
   respondToOverlay,
   resetOverlaySession,
   cleanupOverlay,
+  abortOverlayQuery,
   getOverlaySessionId,
   setOverlaySessionId,
 } from './overlay-sdk'

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -155,8 +155,11 @@ const overlayApi = {
   getClaudeInfo: (): Promise<{ version: string; model: string; accountType: string }> =>
     ipcRenderer.invoke('overlay:getClaudeInfo'),
 
-  sendMessage: (id: string, message: string, cwd: string) =>
-    ipcRenderer.invoke('overlay:sendMessage', { id, message, cwd }),
+  sendMessage: (id: string, message: string, cwd: string, mode?: 'normal' | 'auto-accept' | 'plan') =>
+    ipcRenderer.invoke('overlay:sendMessage', { id, message, cwd, mode }),
+
+  abort: (id: string) =>
+    ipcRenderer.invoke('overlay:abort', { id }),
 
   respond: (id: string, requestId: string, behavior: 'allow' | 'deny', message?: string, updatedInput?: Record<string, unknown>) =>
     ipcRenderer.invoke('overlay:respond', { id, requestId, behavior, message, updatedInput }),

--- a/desktop/src/renderer/components/FriendlyOverlay.tsx
+++ b/desktop/src/renderer/components/FriendlyOverlay.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef, memo } from 'react'
 import { useStreamJsonParser } from '../hooks/useStreamJsonParser'
-import type { StreamEvent, AssistantEvent } from '../types/streamEvents'
+import type { StreamEvent, AssistantEvent, ControlRequest } from '../types/streamEvents'
+import type { ClaudeMode } from './friendly/ModeLabel'
 import { ChatInput } from './friendly/ChatInput'
 import { ConfirmDialog } from './friendly/ConfirmDialog'
 import { SessionHeader } from './friendly/SessionHeader'
@@ -128,6 +129,11 @@ function buildConversation(
     if (event.type === 'result') {
       isThinking = false
     }
+
+    if (event.type === 'interrupted') {
+      entries.push({ role: 'assistant', text: '*Interrupted*' })
+      isThinking = false
+    }
   }
 
   // Flush remaining user messages
@@ -180,6 +186,30 @@ function saveUserMessages(terminalId: string, messages: UserMsg[]) {
     const all = raw ? JSON.parse(raw) : {}
     all[terminalId] = messages
     sessionStorage.setItem(USER_MESSAGES_KEY, JSON.stringify(all))
+  } catch { /* ignore storage errors */ }
+}
+
+// --- Always-allowed tools persistence (per session) ---
+
+const ALWAYS_ALLOWED_KEY = 'magic-slash-always-allowed'
+
+function loadAlwaysAllowed(terminalId: string): Set<string> {
+  try {
+    const raw = sessionStorage.getItem(ALWAYS_ALLOWED_KEY)
+    if (!raw) return new Set()
+    const all = JSON.parse(raw) as Record<string, string[]>
+    return all[terminalId] ? new Set(all[terminalId]) : new Set()
+  } catch {
+    return new Set()
+  }
+}
+
+function saveAlwaysAllowed(terminalId: string, tools: Set<string>) {
+  try {
+    const raw = sessionStorage.getItem(ALWAYS_ALLOWED_KEY)
+    const all = raw ? JSON.parse(raw) : {}
+    all[terminalId] = [...tools]
+    sessionStorage.setItem(ALWAYS_ALLOWED_KEY, JSON.stringify(all))
   } catch { /* ignore storage errors */ }
 }
 
@@ -238,7 +268,7 @@ function saveQuestionAnswers(terminalId: string, answers: Map<string, Record<str
 
 import type { PermissionStatus } from './friendly/StepCard'
 
-const ToolStepCard = memo(function ToolStepCard({ entry, permissionStatus, questionAnswers }: { entry: ToolEntry; permissionStatus?: PermissionStatus; questionAnswers?: Record<string, string> }) {
+const ToolStepCard = memo(function ToolStepCard({ entry, permissionStatus, questionAnswers, autoApproved }: { entry: ToolEntry; permissionStatus?: PermissionStatus; questionAnswers?: Record<string, string>; autoApproved?: boolean }) {
   const { toolName, input, summary } = entry
 
   // Edit tool — show diff
@@ -247,7 +277,7 @@ const ToolStepCard = memo(function ToolStepCard({ entry, permissionStatus, quest
     const newStr = (input.new_string || '') as string
     const filePath = (input.file_path || '') as string
     return (
-      <StepCard toolName={toolName} summary={summary} permissionStatus={permissionStatus}>
+      <StepCard toolName={toolName} summary={summary} permissionStatus={permissionStatus} autoApproved={autoApproved}>
         {oldStr || newStr ? (
           <DiffViewer filePath={filePath} oldString={oldStr} newString={newStr} />
         ) : null}
@@ -259,7 +289,7 @@ const ToolStepCard = memo(function ToolStepCard({ entry, permissionStatus, quest
   if (toolName === 'Bash') {
     const command = (input.command || '') as string
     return (
-      <StepCard toolName={toolName} summary={summary} permissionStatus={permissionStatus}>
+      <StepCard toolName={toolName} summary={summary} permissionStatus={permissionStatus} autoApproved={autoApproved}>
         <BashOutput command={command} />
       </StepCard>
     )
@@ -271,7 +301,7 @@ const ToolStepCard = memo(function ToolStepCard({ entry, permissionStatus, quest
     const hasAnswers = questionAnswers && Object.keys(questionAnswers).length > 0
 
     return (
-      <StepCard toolName={toolName} summary={summary} permissionStatus={permissionStatus}>
+      <StepCard toolName={toolName} summary={summary} permissionStatus={permissionStatus} autoApproved={autoApproved}>
         <div className="mt-2 space-y-2.5">
           {questions.map((q, i) => {
             const answer = questionAnswers?.[q.question]
@@ -292,7 +322,7 @@ const ToolStepCard = memo(function ToolStepCard({ entry, permissionStatus, quest
   }
 
   // Read/Write/Grep/Glob/Agent — simple step card
-  return <StepCard toolName={toolName} summary={summary} permissionStatus={permissionStatus} />
+  return <StepCard toolName={toolName} summary={summary} permissionStatus={permissionStatus} autoApproved={autoApproved} />
 })
 
 // --- Main component ---
@@ -308,6 +338,9 @@ export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
   const [debugConfirm, setDebugConfirm] = useState(false)
   const [permissionResults, setPermissionResults] = useState<Map<string, 'allow' | 'deny'>>(
     () => terminalId ? loadPermissionResults(terminalId) : new Map()
+  )
+  const [alwaysAllowed, setAlwaysAllowed] = useState<Set<string>>(
+    () => terminalId ? loadAlwaysAllowed(terminalId) : new Set()
   )
   const [questionAnswers, setQuestionAnswers] = useState<Map<string, Record<string, string>>>(
     () => terminalId ? loadQuestionAnswers(terminalId) : new Map()
@@ -331,10 +364,12 @@ export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
       setUserMessages(loadUserMessages(terminalId))
       setPermissionResults(loadPermissionResults(terminalId))
       setQuestionAnswers(loadQuestionAnswers(terminalId))
+      setAlwaysAllowed(loadAlwaysAllowed(terminalId))
     } else {
       setUserMessages([])
       setPermissionResults(new Map())
       setQuestionAnswers(new Map())
+      setAlwaysAllowed(new Set())
     }
   }, [terminalId])
 
@@ -358,6 +393,13 @@ export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
       saveQuestionAnswers(terminalId, questionAnswers)
     }
   }, [terminalId, questionAnswers])
+
+  // Persist always-allowed tools on every update
+  useEffect(() => {
+    if (terminalId) {
+      saveAlwaysAllowed(terminalId, alwaysAllowed)
+    }
+  }, [terminalId, alwaysAllowed])
 
   // Listen for debug trigger from UpdateOverlay debug menu
   useEffect(() => {
@@ -392,8 +434,62 @@ export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
     })
   }, [])
 
+  const handleAlwaysAllow = useCallback((toolName: string) => {
+    setAlwaysAllowed(prev => {
+      const next = new Set(prev)
+      next.add(toolName)
+      return next
+    })
+  }, [])
+
+  const handleAbort = useCallback(() => {
+    if (!terminalId) return
+    window.electronAPI.overlay.abort(terminalId)
+  }, [terminalId])
+
+  // Auto-respond to permission requests for always-allowed tools
+  const alwaysAllowedRef = useRef(alwaysAllowed)
+  alwaysAllowedRef.current = alwaysAllowed
+  const respondedRequests = useRef(new Set<string>())
+  useEffect(() => {
+    if (!terminalId || events.length === 0) return
+    const start = Math.max(0, events.length - 20)
+    for (let i = events.length - 1; i >= start; i--) {
+      const event = events[i]
+      if (event.type !== 'control_request') continue
+      const cr = event as ControlRequest
+      if (cr.request.subtype !== 'can_use_tool') continue
+      if (cr.request.tool_name === 'AskUserQuestion') continue
+      if (!alwaysAllowedRef.current.has(cr.request.tool_name)) continue
+      if (respondedRequests.current.has(cr.request_id)) continue
+      // Check not already answered by a subsequent event
+      let wasAnswered = false
+      for (let j = i + 1; j < events.length; j++) {
+        if (events[j].type === 'result' || events[j].type === 'assistant') { wasAnswered = true; break }
+      }
+      if (wasAnswered) continue
+      respondedRequests.current.add(cr.request_id)
+      window.electronAPI.overlay.respond(terminalId, cr.request_id, 'allow')
+      if (cr.request.tool_use_id) handlePermissionResult(cr.request.tool_use_id, 'allow')
+      break // Handle one at a time
+    }
+  }, [terminalId, events, handlePermissionResult])
+
+  // Detect mode_change events from the backend (e.g. plan→auto-accept after ExitPlanMode)
+  const [forcedMode, setForcedMode] = useState<ClaudeMode | undefined>(undefined)
+  useEffect(() => {
+    if (events.length === 0) return
+    for (let i = events.length - 1; i >= Math.max(0, events.length - 5); i--) {
+      const event = events[i]
+      if (event.type === 'mode_change' && 'mode' in event) {
+        setForcedMode((event as { type: string; mode: ClaudeMode }).mode)
+        return
+      }
+    }
+  }, [events])
+
   // Send message via overlay API (not PTY)
-  const handleUserSend = useCallback((text: string) => {
+  const handleUserSend = useCallback((text: string, mode?: 'normal' | 'auto-accept' | 'plan') => {
     if (!terminalId) return
 
     // Handle /clear — reset conversation and session in overlay
@@ -402,10 +498,12 @@ export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
       setUserMessages([])
       setPermissionResults(new Map())
       setQuestionAnswers(new Map())
+      setAlwaysAllowed(new Set())
       if (terminalId) {
         saveUserMessages(terminalId, [])
         savePermissionResults(terminalId, new Map())
         saveQuestionAnswers(terminalId, new Map())
+        saveAlwaysAllowed(terminalId, new Set())
         window.electronAPI.overlay.resetSession(terminalId)
       }
       return
@@ -413,7 +511,7 @@ export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
 
     setUserMessages(prev => [...prev, { text, afterEventIndex: eventsLengthRef.current }])
     // Send via overlay channel (spawns claude -p --output-format stream-json --verbose)
-    window.electronAPI.overlay.sendMessage(terminalId, text, activeCwd)
+    window.electronAPI.overlay.sendMessage(terminalId, text, activeCwd, mode)
   }, [terminalId, activeCwd, clearEvents])
 
   // Build conversation model
@@ -448,7 +546,7 @@ export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
                 return <ClaudeMessage key={i} content={entry.text} />
               }
               // Tool entry
-              return <ToolStepCard key={i} entry={entry} permissionStatus={permissionResults.get(entry.toolId)} questionAnswers={questionAnswers.get(entry.toolId)} />
+              return <ToolStepCard key={i} entry={entry} permissionStatus={permissionResults.get(entry.toolId)} questionAnswers={questionAnswers.get(entry.toolId)} autoApproved={alwaysAllowed.has(entry.toolName)} />
             })}
             {(isThinking || isLoading) && <ThinkingLoader />}
           </div>
@@ -459,16 +557,21 @@ export function FriendlyOverlay({ terminalId }: FriendlyOverlayProps) {
       <ConfirmDialog
         terminalId={terminalId}
         events={confirmEvents}
+        alwaysAllowed={alwaysAllowed}
         onActiveChange={handleConfirmActiveChange}
         onPermissionResult={handlePermissionResult}
         onQuestionAnswered={handleQuestionAnswered}
+        onAlwaysAllow={handleAlwaysAllow}
       />
 
       {/* Chat input bar — overlay mode: don't write to PTY, use overlay API */}
       <ChatInput
         terminalId={terminalId}
-        disabled={isConfirmationActive || isLoading}
+        disabled={isConfirmationActive}
+        isWorking={isLoading && !isConfirmationActive}
+        forceMode={forcedMode}
         onSend={handleUserSend}
+        onAbort={handleAbort}
       />
     </div>
   )

--- a/desktop/src/renderer/components/friendly/ChatInput.tsx
+++ b/desktop/src/renderer/components/friendly/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { useRef, useCallback, useEffect, useState } from 'react'
-import { ArrowUp } from 'lucide-react'
+import { ArrowUp, Square } from 'lucide-react'
 import { MODE_CYCLE, type ClaudeMode } from './ModeLabel'
 
 // Persist mode per terminal across remounts and refreshes
@@ -29,10 +29,13 @@ const MODE_PILL: Record<ClaudeMode, { label: string; bg: string; text: string }>
 interface ChatInputProps {
   terminalId: string | null
   disabled?: boolean
-  onSend?: (text: string) => void
+  isWorking?: boolean
+  forceMode?: ClaudeMode
+  onSend?: (text: string, mode: ClaudeMode) => void
+  onAbort?: () => void
 }
 
-export function ChatInput({ terminalId, disabled = false, onSend }: ChatInputProps) {
+export function ChatInput({ terminalId, disabled = false, isWorking = false, forceMode, onSend, onAbort }: ChatInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [value, setValue] = useState('')
   const [isMultiline, setIsMultiline] = useState(false)
@@ -89,6 +92,13 @@ export function ChatInput({ terminalId, disabled = false, onSend }: ChatInputPro
     }
   }, [terminalId])
 
+  // Apply externally-forced mode changes (e.g. plan→auto-accept after ExitPlanMode)
+  useEffect(() => {
+    if (forceMode !== undefined && forceMode !== mode) {
+      setMode(forceMode)
+    }
+  }, [forceMode])
+
   // Auto-resize textarea
   const adjustHeight = useCallback(() => {
     const textarea = textareaRef.current
@@ -112,9 +122,9 @@ export function ChatInput({ terminalId, disabled = false, onSend }: ChatInputPro
 
   const sendMessage = useCallback(() => {
     if (!terminalId || !value.trim()) return
-    onSend?.(value)
+    onSend?.(value, mode)
     setValue('')
-  }, [terminalId, value, onSend])
+  }, [terminalId, value, mode, onSend])
 
   const cycleMode = useCallback(() => {
     if (!terminalId) return
@@ -123,17 +133,34 @@ export function ChatInput({ terminalId, disabled = false, onSend }: ChatInputPro
 
 
   // Global Shift+Tab handler (works even when input is not focused)
+  // Global Ctrl+C handler (abort when working, preserve copy when text selected)
+  // Global Escape handler (abort when working and no dialog active)
   useEffect(() => {
     const handleGlobalKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Tab' && e.shiftKey) {
         e.preventDefault()
         cycleMode()
       }
+
+      // Ctrl+C: abort only when working and no text selected (preserve copy)
+      if (e.key === 'c' && (e.ctrlKey || e.metaKey) && isWorking) {
+        const selection = window.getSelection()?.toString()
+        if (!selection) {
+          e.preventDefault()
+          onAbort?.()
+        }
+      }
+
+      // Escape: abort when working (but not if ConfirmDialog is active — it handles Escape itself via disabled prop)
+      if (e.key === 'Escape' && isWorking && !disabled) {
+        e.preventDefault()
+        onAbort?.()
+      }
     }
 
     document.addEventListener('keydown', handleGlobalKeyDown)
     return () => document.removeEventListener('keydown', handleGlobalKeyDown)
-  }, [cycleMode])
+  }, [cycleMode, isWorking, disabled, onAbort])
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Shift+Tab: handled globally, prevent default here too
@@ -149,13 +176,15 @@ export function ChatInput({ terminalId, disabled = false, onSend }: ChatInputPro
       return
     }
 
-    // Escape: clear input
+    // Escape: clear input (abort is handled by the global handler)
     if (e.key === 'Escape') {
       e.preventDefault()
-      setValue('')
+      if (!isWorking) {
+        setValue('')
+      }
       return
     }
-  }, [terminalId, sendMessage, cycleMode])
+  }, [terminalId, sendMessage, cycleMode, isWorking])
 
   return (
     <div
@@ -183,8 +212,8 @@ export function ChatInput({ terminalId, disabled = false, onSend }: ChatInputPro
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
-          disabled={disabled}
-          placeholder={disabled ? 'Waiting for response...' : 'Send a message...'}
+          disabled={disabled || isWorking}
+          placeholder={isWorking ? 'Claude is working...' : disabled ? 'Waiting for response...' : 'Send a message...'}
           rows={1}
           spellCheck={false}
           className={`
@@ -230,20 +259,29 @@ export function ChatInput({ terminalId, disabled = false, onSend }: ChatInputPro
           </span>
         </button>
 
-        {/* Send button */}
-        <button
-          onClick={sendMessage}
-          disabled={disabled || !value.trim()}
-          className={`
-            shrink-0 w-[26px] h-[26px] flex items-center justify-center rounded-full transition-all
-            ${value.trim() && !disabled
-              ? 'bg-accent text-white hover:bg-accent-hover'
-              : 'bg-bg-tertiary text-text-secondary cursor-not-allowed'
-            }
-          `}
-        >
-          <ArrowUp className="w-3.5 h-3.5" strokeWidth={2.5} />
-        </button>
+        {/* Send / Stop button */}
+        {isWorking ? (
+          <button
+            onClick={onAbort}
+            className="shrink-0 w-[26px] h-[26px] flex items-center justify-center rounded-full transition-all bg-red/20 text-red hover:bg-red/30 cursor-pointer"
+          >
+            <Square className="w-3 h-3" fill="currentColor" />
+          </button>
+        ) : (
+          <button
+            onClick={sendMessage}
+            disabled={disabled || !value.trim()}
+            className={`
+              shrink-0 w-[26px] h-[26px] flex items-center justify-center rounded-full transition-all
+              ${value.trim() && !disabled
+                ? 'bg-accent text-white hover:bg-accent-hover'
+                : 'bg-bg-tertiary text-text-secondary cursor-not-allowed'
+              }
+            `}
+          >
+            <ArrowUp className="w-3.5 h-3.5" strokeWidth={2.5} />
+          </button>
+        )}
       </div>
     </div>
   )

--- a/desktop/src/renderer/components/friendly/ConfirmDialog.tsx
+++ b/desktop/src/renderer/components/friendly/ConfirmDialog.tsx
@@ -1,13 +1,16 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
-import { ShieldQuestion, MessageCircleQuestion } from 'lucide-react'
-import type { StreamEvent, ControlRequest } from '../../types/streamEvents'
+import { ShieldQuestion, MessageCircleQuestion, FileText } from 'lucide-react'
+import { MarkdownRenderer } from './MarkdownRenderer'
+import type { StreamEvent, ControlRequest, AssistantEvent } from '../../types/streamEvents'
 
 interface ConfirmDialogProps {
   terminalId: string | null
   events: StreamEvent[]
+  alwaysAllowed?: Set<string>
   onActiveChange: (active: boolean) => void
   onPermissionResult?: (toolUseId: string, behavior: 'allow' | 'deny') => void
   onQuestionAnswered?: (toolUseId: string, answers: Record<string, string>) => void
+  onAlwaysAllow?: (toolName: string) => void
 }
 
 interface QuestionOption {
@@ -35,7 +38,7 @@ interface PermissionRequest {
 const SCAN_WINDOW = 20
 
 // Detect when Claude Code is waiting for a permission decision from control_request events.
-function detectPermissionRequest(events: StreamEvent[]): PermissionRequest | null {
+function detectPermissionRequest(events: StreamEvent[], alwaysAllowed?: Set<string>): PermissionRequest | null {
   const start = Math.max(0, events.length - SCAN_WINDOW)
 
   for (let i = events.length - 1; i >= start; i--) {
@@ -44,6 +47,8 @@ function detectPermissionRequest(events: StreamEvent[]): PermissionRequest | nul
     if (event.type === 'control_request') {
       const cr = event as ControlRequest
       if (cr.request.subtype === 'can_use_tool') {
+        // Skip tools that are always-allowed (auto-respond handles them)
+        if (alwaysAllowed?.has(cr.request.tool_name)) continue
         // Check if a control_response or result event follows (meaning it was already answered)
         let wasAnswered = false
         for (let j = i + 1; j < events.length; j++) {
@@ -73,6 +78,31 @@ function detectPermissionRequest(events: StreamEvent[]): PermissionRequest | nul
   return null
 }
 
+/**
+ * Search backwards through events to find the plan content
+ * written by a Write tool call to a plans/ directory.
+ */
+function findPlanContent(events: StreamEvent[]): string | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i]
+    if (event.type !== 'assistant') continue
+    const assistantEvent = event as AssistantEvent
+    const blocks = assistantEvent.message.content
+    for (let j = blocks.length - 1; j >= 0; j--) {
+      const block = blocks[j]
+      if (block.type === 'tool_use' && block.name === 'Write') {
+        const input = block.input as Record<string, unknown> | undefined
+        const filePath = (input?.file_path || '') as string
+        const content = (input?.content || '') as string
+        if (filePath.includes('/plans/') && content) {
+          return content
+        }
+      }
+    }
+  }
+  return null
+}
+
 function buildToolDescription(toolName: string, input: Record<string, unknown>): string {
   const filePath = (input.file_path || input.path || '') as string
   const fileName = filePath ? filePath.split('/').pop() || filePath : ''
@@ -90,7 +120,10 @@ function buildToolDescription(toolName: string, input: Record<string, unknown>):
   }
 }
 
-export function ConfirmDialog({ terminalId, events, onActiveChange, onPermissionResult, onQuestionAnswered }: ConfirmDialogProps) {
+// Number of buttons in the standard permission dialog (Allow, Always Allow, Deny)
+const PERMISSION_BUTTON_COUNT = 3
+
+export function ConfirmDialog({ terminalId, events, alwaysAllowed, onActiveChange, onPermissionResult, onQuestionAnswered, onAlwaysAllow }: ConfirmDialogProps) {
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [dismissed, setDismissed] = useState(false)
   const [currentQuestionIdx, setCurrentQuestionIdx] = useState(0)
@@ -98,11 +131,19 @@ export function ConfirmDialog({ terminalId, events, onActiveChange, onPermission
   const [textAnswer, setTextAnswer] = useState('')
   const prevRequestRef = useRef<string | null>(null)
   const textInputRef = useRef<HTMLInputElement>(null)
+  const planScrollRef = useRef<HTMLDivElement>(null)
 
-  const permissionRequest = useMemo(() => detectPermissionRequest(events), [events])
+  const permissionRequest = useMemo(() => detectPermissionRequest(events, alwaysAllowed), [events, alwaysAllowed])
 
   const isQuestion = !!(permissionRequest?.questions && permissionRequest.questions.length > 0)
   const currentQuestion = isQuestion ? permissionRequest!.questions![currentQuestionIdx] : null
+  const isPlanApproval = permissionRequest?.toolName === 'ExitPlanMode'
+
+  // Find plan content when ExitPlanMode is detected
+  const planContent = useMemo(
+    () => isPlanApproval ? findPlanContent(events) : null,
+    [isPlanApproval, events]
+  )
 
   // Reset state when a new request appears
   useEffect(() => {
@@ -174,6 +215,12 @@ export function ConfirmDialog({ terminalId, events, onActiveChange, onPermission
     setDismissed(true)
   }, [terminalId, permissionRequest, onPermissionResult])
 
+  const respondAlwaysAllow = useCallback(() => {
+    if (!permissionRequest) return
+    onAlwaysAllow?.(permissionRequest.toolName)
+    respondPermission('allow')
+  }, [permissionRequest, onAlwaysAllow, respondPermission])
+
   const dismiss = useCallback(() => {
     if (!terminalId || !permissionRequest) return
     window.electronAPI.overlay.respond(terminalId, permissionRequest.requestId, 'deny', 'User skipped the question')
@@ -222,20 +269,38 @@ export function ConfirmDialog({ terminalId, events, onActiveChange, onPermission
         return
       }
 
-      // --- Standard permission dialog ---
-      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      // --- Standard permission dialog (3 buttons: Allow=0, Always Allow=1, Deny=2) ---
+      // --- Plan approval dialog (2 buttons: Accept=0, Reject=1) ---
+      const buttonCount = isPlanApproval ? 2 : PERMISSION_BUTTON_COUNT
+
+      if (e.key === 'ArrowLeft') {
         e.preventDefault()
-        setSelectedIndex(prev => prev === 0 ? 1 : 0)
+        setSelectedIndex(prev => (prev - 1 + buttonCount) % buttonCount)
+      }
+      if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        setSelectedIndex(prev => (prev + 1) % buttonCount)
       }
 
       if (e.key === 'Enter') {
         e.preventDefault()
-        respondPermission(selectedIndex === 0 ? 'allow' : 'deny')
+        if (isPlanApproval) {
+          respondPermission(selectedIndex === 0 ? 'allow' : 'deny')
+        } else {
+          // 0=Allow, 1=Always Allow, 2=Deny
+          if (selectedIndex === 0) respondPermission('allow')
+          else if (selectedIndex === 1) respondAlwaysAllow()
+          else respondPermission('deny')
+        }
       }
 
       if (e.key === 'y' || e.key === 'Y') {
         e.preventDefault()
         respondPermission('allow')
+      }
+      if (!isPlanApproval && (e.key === 'a' || e.key === 'A')) {
+        e.preventDefault()
+        respondAlwaysAllow()
       }
       if (e.key === 'n' || e.key === 'N') {
         e.preventDefault()
@@ -250,7 +315,7 @@ export function ConfirmDialog({ terminalId, events, onActiveChange, onPermission
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [isActive, permissionRequest, isQuestion, currentQuestion, selectedIndex, textAnswer, respondPermission, selectOption, submitTextAnswer, dismiss])
+  }, [isActive, permissionRequest, isQuestion, isPlanApproval, currentQuestion, selectedIndex, textAnswer, respondPermission, respondAlwaysAllow, selectOption, submitTextAnswer, dismiss])
 
   if (!isActive || !permissionRequest) return null
 
@@ -350,6 +415,54 @@ export function ConfirmDialog({ terminalId, events, onActiveChange, onPermission
     )
   }
 
+  // --- Plan approval UI (ExitPlanMode) ---
+  if (isPlanApproval) {
+    return (
+      <div className="shrink-0 mx-2 mb-2 bg-white/5 border border-purple/30 rounded-lg animate-fade-in overflow-hidden">
+        <div className="px-3 pt-3 pb-2 flex items-center gap-2">
+          <FileText className="w-4 h-4 text-purple shrink-0" />
+          <p className="text-sm font-medium text-white">Accept this plan?</p>
+        </div>
+        {planContent && (
+          <div
+            ref={planScrollRef}
+            className="mx-3 mb-2 max-h-[300px] overflow-y-auto bg-black/30 border border-white/5 rounded-md px-3 py-2"
+          >
+            <MarkdownRenderer content={planContent} />
+          </div>
+        )}
+        <div className="px-3 pb-3 flex items-center gap-2">
+          <button
+            onClick={() => respondPermission('allow')}
+            className={`
+              px-3 py-1 text-xs font-medium rounded-md transition-all
+              ${selectedIndex === 0
+                ? 'bg-green/20 text-green border border-green/30'
+                : 'bg-white/5 text-text-secondary border border-white/10 hover:bg-white/10'
+              }
+            `}
+          >
+            Accept Plan
+            <kbd className="ml-1.5 text-[10px] opacity-50">Y</kbd>
+          </button>
+          <button
+            onClick={() => respondPermission('deny')}
+            className={`
+              px-3 py-1 text-xs font-medium rounded-md transition-all
+              ${selectedIndex === 1
+                ? 'bg-red/20 text-red border border-red/30'
+                : 'bg-white/5 text-text-secondary border border-white/10 hover:bg-white/10'
+              }
+            `}
+          >
+            Reject
+            <kbd className="ml-1.5 text-[10px] opacity-50">N</kbd>
+          </button>
+        </div>
+      </div>
+    )
+  }
+
   // --- Standard permission UI ---
   const description = buildToolDescription(permissionRequest.toolName, permissionRequest.input)
 
@@ -379,10 +492,23 @@ export function ConfirmDialog({ terminalId, events, onActiveChange, onPermission
               <kbd className="ml-1.5 text-[10px] opacity-50">Y</kbd>
             </button>
             <button
-              onClick={() => respondPermission('deny')}
+              onClick={respondAlwaysAllow}
               className={`
                 px-3 py-1 text-xs font-medium rounded-md transition-all
                 ${selectedIndex === 1
+                  ? 'bg-orange/20 text-orange border border-orange/30'
+                  : 'bg-white/5 text-text-secondary border border-white/10 hover:bg-white/10'
+                }
+              `}
+            >
+              Always Allow
+              <kbd className="ml-1.5 text-[10px] opacity-50">A</kbd>
+            </button>
+            <button
+              onClick={() => respondPermission('deny')}
+              className={`
+                px-3 py-1 text-xs font-medium rounded-md transition-all
+                ${selectedIndex === 2
                   ? 'bg-red/20 text-red border border-red/30'
                   : 'bg-white/5 text-text-secondary border border-white/10 hover:bg-white/10'
                 }

--- a/desktop/src/renderer/components/friendly/StepCard.tsx
+++ b/desktop/src/renderer/components/friendly/StepCard.tsx
@@ -24,6 +24,7 @@ interface StepCardProps {
   isError?: boolean
   defaultOpen?: boolean
   permissionStatus?: PermissionStatus
+  autoApproved?: boolean
   children?: ReactNode
 }
 
@@ -33,6 +34,7 @@ export const StepCard = memo(function StepCard({
   isError = false,
   defaultOpen = false,
   permissionStatus,
+  autoApproved = false,
   children,
 }: StepCardProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen)
@@ -60,6 +62,9 @@ export const StepCard = memo(function StepCard({
         )}
         <Icon className={`w-4 h-4 ${iconColor} shrink-0`} />
         <span className={`text-xs font-mono truncate ${denied ? 'text-red/60 line-through' : 'text-text-secondary'}`}>{summary}</span>
+        {autoApproved && permissionStatus === 'allow' && (
+          <span className="text-[9px] font-medium text-orange/70 bg-orange/10 px-1.5 py-0.5 rounded-full shrink-0">auto</span>
+        )}
         {permissionStatus === 'allow' && (
           <Check className="w-3.5 h-3.5 text-green shrink-0 ml-auto" />
         )}

--- a/desktop/src/renderer/hooks/useStreamJsonParser.ts
+++ b/desktop/src/renderer/hooks/useStreamJsonParser.ts
@@ -77,7 +77,7 @@ function setupGlobalListener() {
       const stream = getOrCreateStream(id)
       stream.events = [...stream.events, parsed]
       stream.lastEvent = parsed
-      stream.isLoading = parsed.type !== 'result'
+      stream.isLoading = parsed.type !== 'result' && parsed.type !== 'interrupted'
       // Persist to sessionStorage
       saveEvents(id, stream.events)
       notifySubscribers(id)


### PR DESCRIPTION
## Description

Enrich the SDK overlay with three key features: Claude permission modes (Normal / Auto-accept / Plan), an Always Allow button for tool permissions, and a Stop/Interrupt mechanism.

**Key fix**: Plan mode → Auto-accept transition now works correctly. After plan approval, the resumed session explicitly sets `permissionMode: 'acceptEdits'` to override the SDK's persisted plan mode state, and the resume prompt tells Claude that plan mode is deactivated.

Closes #48

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **Modes support** (`overlay-sdk.ts`, `ChatInput.tsx`): Added `ClaudeMode` type (`normal` | `auto-accept` | `plan`), mode parameter flows from renderer → IPC → SDK. Plan mode passes `permissionMode: 'plan'`, auto-accept passes `permissionMode: 'acceptEdits'`. Mode cycling via Shift+Tab in ChatInput.
- **Plan mode lifecycle** (`overlay-sdk.ts`, `ConfirmDialog.tsx`): ExitPlanMode approval tracking, auto-resume in auto-accept mode after plan approval, plan content extraction and display in ConfirmDialog.
- **Always Allow** (`FriendlyOverlay.tsx`, `ConfirmDialog.tsx`): Session-persisted set of always-allowed tools, auto-respond to permission requests for tools the user has approved with "Always Allow".
- **Stop/Interrupt** (`overlay-sdk.ts`, `terminal-handlers.ts`, `preload/index.ts`): `abortOverlayQuery()` function, `overlay:abort` IPC handler, synthetic `interrupted` event emission, pending permission cleanup on abort.
- **Minor fixes**: `rejectPendingPermissions` helper extracted for reuse, `planApprovedTerminals` cleanup on session reset, `getShellPathForOverlay` export.

## Testing

- [x] Tested locally with Claude Code
- [x] Tested affected slash commands

### Test Steps

1. **Normal mode**: Open a terminal, send a message — tools should prompt for permission as usual (Allow / Always Allow / Deny buttons visible).
2. **Auto-accept mode**: Press Shift+Tab to cycle to "Auto-accept" (orange pill). Send a message that requires file edits — tools should execute without permission prompts (except AskUserQuestion).
3. **Plan mode**: Cycle to "Plan" (purple pill). Ask Claude to modify a file. Verify:
   - Claude creates a plan and writes it to `.claude/plans/`
   - ExitPlanMode triggers "Accept this plan?" dialog with plan content
   - Clicking "Accept Plan" switches mode to Auto-accept and Claude successfully implements the plan (edits files without errors)
4. **Always Allow**: In Normal mode, click "Always Allow" for a tool (e.g., Read). Verify subsequent Read calls are auto-approved without prompting.
5. **Stop/Interrupt**: While Claude is processing, click the stop button. Verify the query is interrupted and pending permissions are cleaned up.

## Linked Issues

- Closes #48