### PR TITLE
[#41] refactor(skills): rename skill names from magic-* to magic:*

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Magic Slash
 
-7 skills for Claude Code that automate the entire development cycle with Jira and GitHub: `/magic-start`, `/magic-continue`, `/magic-commit`, `/magic-pr`, `/magic-review`, `/magic-resolve`, `/magic-done`.
+7 skills for Claude Code that automate the entire development cycle with Jira and GitHub: `/magic:start`, `/magic:continue`, `/magic:commit`, `/magic:pr`, `/magic:review`, `/magic:resolve`, `/magic:done`.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -29,24 +29,24 @@
 
 | Skill              | Description                                          |
 | ------------------ | ---------------------------------------------------- |
-| `/magic-start`     | Start a task from a Jira ticket or GitHub issue      |
-| `/magic-continue`  | Resume work on an existing ticket                    |
-| `/magic-commit`    | Create an atomic commit with conventional message    |
-| `/magic-pr`        | Push, create PR and update Jira                      |
-| `/magic-review`    | Review a Pull Request (self or external)             |
-| `/magic-resolve`   | Address review comments and force-push fixes         |
-| `/magic-done`      | Finalize after PR merge (transition Jira to Done)    |
+| `/magic:start`     | Start a task from a Jira ticket or GitHub issue      |
+| `/magic:continue`  | Resume work on an existing ticket                    |
+| `/magic:commit`    | Create an atomic commit with conventional message    |
+| `/magic:pr`        | Push, create PR and update Jira                      |
+| `/magic:review`    | Review a Pull Request (self or external)             |
+| `/magic:resolve`   | Address review comments and force-push fixes         |
+| `/magic:done`      | Finalize after PR merge (transition Jira to Done)    |
 
-> Type `/magic-` to quickly find all commands.
+> Type `/magic:` to quickly find all commands.
 
 You can also invoke skills using natural language:
 
-- "démarre PROJ-123" or "work on PROJ-123" → `/magic-start`
-- "je suis prêt à committer" or "ready to commit" → `/magic-commit`
-- "on peut créer la PR" or "create the PR" → `/magic-pr`
-- "regarde la PR" or "review my PR" → `/magic-review`
-- "corriger les commentaires" or "fix review comments" → `/magic-resolve`
-- "la PR est mergée" or "the PR is merged" → `/magic-done`
+- "démarre PROJ-123" or "work on PROJ-123" → `/magic:start`
+- "je suis prêt à committer" or "ready to commit" → `/magic:commit`
+- "on peut créer la PR" or "create the PR" → `/magic:pr`
+- "regarde la PR" or "review my PR" → `/magic:review`
+- "corriger les commentaires" or "fix review comments" → `/magic:resolve`
+- "la PR est mergée" or "the PR is merged" → `/magic:done`
 
 ## Installation
 
@@ -72,12 +72,12 @@ Two installation modes are available: **Desktop App** (recommended) and **Standa
 
 ## Usage
 
-### /magic-start - Start a task
+### /magic:start - Start a task
 
 ```bash
-/magic-start PROJ-1234    # Jira ticket
-/magic-start 42           # GitHub issue
-/magic-start #42          # GitHub issue (with #)
+/magic:start PROJ-1234    # Jira ticket
+/magic:start 42           # GitHub issue
+/magic:start #42          # GitHub issue (with #)
 ```
 
 1. Detects the ticket type (Jira or GitHub) based on format
@@ -89,7 +89,7 @@ Two installation modes are available: **Desktop App** (recommended) and **Standa
 **Jira example (single repo detected):**
 
 ```text
-> /magic-start PROJ-42
+> /magic:start PROJ-42
 
 Source: Jira
 Ticket: PROJ-42 - Add API endpoint for users
@@ -106,7 +106,7 @@ You need to implement the new API endpoint for users...
 **Jira example (multiple repos detected):**
 
 ```text
-> /magic-start PROJ-42
+> /magic:start PROJ-42
 
 Source: Jira
 Ticket: PROJ-42 - Add pagination on /users
@@ -124,10 +124,10 @@ Worktrees created:
 ✓ /projects/my-web-PROJ-42
 ```
 
-### /magic-commit - Create a commit
+### /magic:commit - Create a commit
 
 ```bash
-/magic-commit
+/magic:commit
 ```
 
 1. Stage all changes
@@ -152,12 +152,12 @@ Worktrees created:
 ```
 
 **Multi-repo support:** If you're in a worktree associated with a ticket that spans multiple repos,
-`/magic-commit` will detect all related worktrees and commit changes in each one.
+`/magic:commit` will detect all related worktrees and commit changes in each one.
 
-### /magic-pr - Push and create a Pull Request
+### /magic:pr - Push and create a Pull Request
 
 ```bash
-/magic-pr
+/magic:pr
 ```
 
 1. Push the branch to origin
@@ -169,7 +169,7 @@ Worktrees created:
 5. Add comment with PR link on Jira (by default)
 
 **Multi-repo support:** If you're in a worktree associated with a ticket that spans multiple repos,
-`/magic-pr` will push and create PRs for each one.
+`/magic:pr` will push and create PRs for each one.
 
 **Example:**
 
@@ -184,11 +184,11 @@ Next steps:
 3. Merge the PR once approved
 ```
 
-### /magic-review - Review a Pull Request
+### /magic:review - Review a Pull Request
 
 ```bash
-/magic-review          # Review the PR for the current branch
-/magic-review PROJ-42  # Review a specific ticket's PR
+/magic:review          # Review the PR for the current branch
+/magic:review PROJ-42  # Review a specific ticket's PR
 ```
 
 1. Detect the PR associated with the current branch (or a given ticket)
@@ -199,11 +199,11 @@ Next steps:
 
 > **Note:** This skill is read-only — it does not modify any files.
 
-### /magic-resolve - Address review feedback
+### /magic:resolve - Address review feedback
 
 ```bash
-/magic-resolve          # Fix comments on the current branch's PR
-/magic-resolve PROJ-42  # Fix comments for a specific ticket's PR
+/magic:resolve          # Fix comments on the current branch's PR
+/magic:resolve PROJ-42  # Fix comments for a specific ticket's PR
 ```
 
 1. Retrieve unresolved review comments from the PR
@@ -212,10 +212,10 @@ Next steps:
 4. Amend or create fixup commits as appropriate
 5. Force-push with `--force-with-lease`
 
-### /magic-done - Finalize after merge
+### /magic:done - Finalize after merge
 
 ```bash
-/magic-done
+/magic:done
 ```
 
 1. Verify the PR has been merged

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -797,7 +797,7 @@
                 <div class="doc-section" id="usage">
                     <h2>Usage</h2>
                     <p>The typical workflow follows four steps. Start by referencing your ticket ID &mdash; magic-slash handles the rest.</p>
-                    <pre><code>&gt; /magic-start PROJ-142
+                    <pre><code>&gt; /magic:start PROJ-142
 &#10003; Fetched ticket: "Add JWT auth middleware"
 &#10003; Created worktree: /projects/api-PROJ-142
 &#10003; Branch feature/PROJ-142 created
@@ -805,35 +805,35 @@
 
   ... you write code ...
 
-&gt; /magic-commit
+&gt; /magic:commit
 &#10003; Staged 4 files (excluded .env.local)
 &#10003; feat(auth): add JWT token refresh mechanism
 
-&gt; /magic-pr
+&gt; /magic:pr
 &#10003; Pushed to origin/feature/PROJ-142
 &#10003; PR #87 created — linked to PROJ-142
 &#10003; Ticket moved to "To be reviewed"
 
   ... PR gets reviewed ...
 
-&gt; /magic-review 87
+&gt; /magic:review 87
 &#10003; Fetched PR #87 (3 files, +10 −1)
 &#10003; Approved with 2 suggestions
 
-&gt; /magic-resolve
+&gt; /magic:resolve
 &#10003; 2 comments addressed — 2 files updated
 &#10003; Force-pushed to origin/feature/PROJ-142
 
   ... PR is merged ...
 
-&gt; /magic-done
+&gt; /magic:done
 &#10003; PR #87 merged
 &#10003; Branch feature/PROJ-142 deleted
 &#10003; Ticket moved to "Done"</code></pre>
 
                     <h3>Resuming work</h3>
-                    <p>Already started a ticket? Use <code>/magic-continue</code> to pick up where you left off.</p>
-                    <pre><code>&gt; /magic-continue PROJ-142
+                    <p>Already started a ticket? Use <code>/magic:continue</code> to pick up where you left off.</p>
+                    <pre><code>&gt; /magic:continue PROJ-142
 &#10003; Worktree found: /projects/api-PROJ-142
 &#10003; Branch: feature/PROJ-142 (3 commits ahead)
 &#10003; PR #87 (open)
@@ -877,11 +877,11 @@ Ready to continue. What would you like to do?</code></pre>
                 <div class="doc-section" id="skills">
                     <h2>Built-in Skills Reference</h2>
                     <p>magic-slash ships with seven built-in skills that cover the full development lifecycle — from ticket to merge. Each skill is invoked as a slash command inside Claude Code and handles multi-repo worktrees automatically.</p>
-                    <p>All skills share the <code>magic-</code> prefix (<code>/magic-start</code>, <code>/magic-continue</code>, <code>/magic-commit</code>, <code>/magic-pr</code>, <code>/magic-review</code>, <code>/magic-resolve</code>, <code>/magic-done</code>) so you can type <code>/magic-</code> to quickly find them all.</p>
+                    <p>All skills share the <code>magic:</code> prefix (<code>/magic:start</code>, <code>/magic:continue</code>, <code>/magic:commit</code>, <code>/magic:pr</code>, <code>/magic:review</code>, <code>/magic:resolve</code>, <code>/magic:done</code>) so you can type <code>/magic:</code> to quickly find them all.</p>
 
                     <div class="doc-skill">
-                        <h3><img src="skill-start.png" alt="skill /magic-start icon" class="doc-skill-img"><span class="doc-skill-name">/magic-start</span> <span class="doc-skill-tag">Lifecycle</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-start/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
-                        <p class="doc-skill-desc">Bootstraps a development task from a Jira ticket or GitHub issue. Say <code>/magic-start PROJ-123</code> or <code>/magic-start #456</code>.</p>
+                        <h3><img src="skill-start.png" alt="skill /magic:start icon" class="doc-skill-img"><span class="doc-skill-name">/magic:start</span> <span class="doc-skill-tag">Lifecycle</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-start/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
+                        <p class="doc-skill-desc">Bootstraps a development task from a Jira ticket or GitHub issue. Say <code>/magic:start PROJ-123</code> or <code>/magic:start #456</code>.</p>
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
                                 <h4>What it does</h4>
@@ -896,7 +896,7 @@ Ready to continue. What would you like to do?</code></pre>
                             <div class="doc-skill-col">
                                 <h4>Trigger phrases</h4>
                                 <ul>
-                                    <li><code>/magic-start &lt;ID&gt;</code></li>
+                                    <li><code>/magic:start &lt;ID&gt;</code></li>
                                     <li>"start", "begin work on", "work on ticket"</li>
                                     <li>"commencer", "travailler sur", "demarre"</li>
                                 </ul>
@@ -907,8 +907,8 @@ Ready to continue. What would you like to do?</code></pre>
                     </div>
 
                     <div class="doc-skill">
-                        <h3><img src="skill-continue.png" alt="skill /magic-continue icon" class="doc-skill-img"><span class="doc-skill-name">/magic-continue</span> <span class="doc-skill-tag">Lifecycle</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-continue/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
-                        <p class="doc-skill-desc">Resumes work on an existing Jira ticket or GitHub issue. Say <code>/magic-continue PROJ-123</code> or <code>/magic-continue #456</code>.</p>
+                        <h3><img src="skill-continue.png" alt="skill /magic:continue icon" class="doc-skill-img"><span class="doc-skill-name">/magic:continue</span> <span class="doc-skill-tag">Lifecycle</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-continue/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
+                        <p class="doc-skill-desc">Resumes work on an existing Jira ticket or GitHub issue. Say <code>/magic:continue PROJ-123</code> or <code>/magic:continue #456</code>.</p>
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
                                 <h4>What it does</h4>
@@ -924,7 +924,7 @@ Ready to continue. What would you like to do?</code></pre>
                             <div class="doc-skill-col">
                                 <h4>Trigger phrases</h4>
                                 <ul>
-                                    <li><code>/magic-continue &lt;ID&gt;</code></li>
+                                    <li><code>/magic:continue &lt;ID&gt;</code></li>
                                     <li>"continue", "resume work on", "switch to"</li>
                                     <li>"reprendre", "je reprends", "basculer sur"</li>
                                 </ul>
@@ -935,8 +935,8 @@ Ready to continue. What would you like to do?</code></pre>
                     </div>
 
                     <div class="doc-skill">
-                        <h3><img src="skill-commit.png" alt="skill /magic-commit icon" class="doc-skill-img"><span class="doc-skill-name">/magic-commit</span> <span class="doc-skill-tag">Git</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-commit/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
-                        <p class="doc-skill-desc">Creates atomic, conventional commits by analyzing your staged changes. Just say <code>/magic-commit</code>.</p>
+                        <h3><img src="skill-commit.png" alt="skill /magic:commit icon" class="doc-skill-img"><span class="doc-skill-name">/magic:commit</span> <span class="doc-skill-tag">Git</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-commit/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
+                        <p class="doc-skill-desc">Creates atomic, conventional commits by analyzing your staged changes. Just say <code>/magic:commit</code>.</p>
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
                                 <h4>What it does</h4>
@@ -961,8 +961,8 @@ Ready to continue. What would you like to do?</code></pre>
                     </div>
 
                     <div class="doc-skill">
-                        <h3><img src="skill-done.png" alt="skill /magic-pr icon" class="doc-skill-img"><span class="doc-skill-name">/magic-pr</span> <span class="doc-skill-tag">Lifecycle</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-pr/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
-                        <p class="doc-skill-desc">Pushes your commits, creates a pull request, and updates the ticket. Say <code>/magic-pr</code> when you are finished coding.</p>
+                        <h3><img src="skill-done.png" alt="skill /magic:pr icon" class="doc-skill-img"><span class="doc-skill-name">/magic:pr</span> <span class="doc-skill-tag">Lifecycle</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-pr/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
+                        <p class="doc-skill-desc">Pushes your commits, creates a pull request, and updates the ticket. Say <code>/magic:pr</code> when you are finished coding.</p>
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
                                 <h4>What it does</h4>
@@ -989,8 +989,8 @@ Ready to continue. What would you like to do?</code></pre>
                     </div>
 
                     <div class="doc-skill">
-                        <h3><img src="skill-done.png" alt="skill /magic-review icon" class="doc-skill-img"><span class="doc-skill-name">/magic-review</span> <span class="doc-skill-tag">Review</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-review/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
-                        <p class="doc-skill-desc">Performs a thorough code review on a pull request. Say <code>/magic-review</code> for the current PR or <code>/magic-review 87</code> for a specific one.</p>
+                        <h3><img src="skill-done.png" alt="skill /magic:review icon" class="doc-skill-img"><span class="doc-skill-name">/magic:review</span> <span class="doc-skill-tag">Review</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-review/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
+                        <p class="doc-skill-desc">Performs a thorough code review on a pull request. Say <code>/magic:review</code> for the current PR or <code>/magic:review 87</code> for a specific one.</p>
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
                                 <h4>What it does</h4>
@@ -1005,7 +1005,7 @@ Ready to continue. What would you like to do?</code></pre>
                             <div class="doc-skill-col">
                                 <h4>Trigger phrases</h4>
                                 <ul>
-                                    <li><code>/magic-review</code>, <code>/magic-review 87</code></li>
+                                    <li><code>/magic:review</code>, <code>/magic:review 87</code></li>
                                     <li>"review", "code review", "review the PR"</li>
                                     <li>"revue de code", "regarde la PR", "vérifie ma PR"</li>
                                 </ul>
@@ -1014,8 +1014,8 @@ Ready to continue. What would you like to do?</code></pre>
                     </div>
 
                     <div class="doc-skill">
-                        <h3><img src="skill-done.png" alt="skill /magic-resolve icon" class="doc-skill-img"><span class="doc-skill-name">/magic-resolve</span> <span class="doc-skill-tag">Review</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-resolve/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
-                        <p class="doc-skill-desc">Addresses code review feedback by fixing the requested changes and force-pushing. Say <code>/magic-resolve</code> after receiving review comments.</p>
+                        <h3><img src="skill-done.png" alt="skill /magic:resolve icon" class="doc-skill-img"><span class="doc-skill-name">/magic:resolve</span> <span class="doc-skill-tag">Review</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-resolve/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
+                        <p class="doc-skill-desc">Addresses code review feedback by fixing the requested changes and force-pushing. Say <code>/magic:resolve</code> after receiving review comments.</p>
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
                                 <h4>What it does</h4>
@@ -1030,7 +1030,7 @@ Ready to continue. What would you like to do?</code></pre>
                             <div class="doc-skill-col">
                                 <h4>Trigger phrases</h4>
                                 <ul>
-                                    <li><code>/magic-resolve</code></li>
+                                    <li><code>/magic:resolve</code></li>
                                     <li>"resolve", "fix review comments", "address feedback"</li>
                                     <li>"résoudre", "corriger les commentaires", "traiter les retours"</li>
                                 </ul>
@@ -1039,8 +1039,8 @@ Ready to continue. What would you like to do?</code></pre>
                     </div>
 
                     <div class="doc-skill">
-                        <h3><img src="skill-done.png" alt="skill /magic-done icon" class="doc-skill-img"><span class="doc-skill-name">/magic-done</span> <span class="doc-skill-tag">Lifecycle</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-done/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
-                        <p class="doc-skill-desc">Finalizes a task after the PR has been merged: verifies the merge, transitions the Jira ticket to "Done", and cleans up. Say <code>/magic-done</code> once the PR is merged.</p>
+                        <h3><img src="skill-done.png" alt="skill /magic:done icon" class="doc-skill-img"><span class="doc-skill-name">/magic:done</span> <span class="doc-skill-tag">Lifecycle</span> <a href="https://github.com/Xrequillart/magic-slash/blob/main/skills/magic-done/SKILL.md" target="_blank" class="doc-skill-source"><i data-feather="external-link"></i> Source</a></h3>
+                        <p class="doc-skill-desc">Finalizes a task after the PR has been merged: verifies the merge, transitions the Jira ticket to "Done", and cleans up. Say <code>/magic:done</code> once the PR is merged.</p>
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
                                 <h4>What it does</h4>
@@ -1055,12 +1055,12 @@ Ready to continue. What would you like to do?</code></pre>
                             <div class="doc-skill-col">
                                 <h4>Trigger phrases</h4>
                                 <ul>
-                                    <li><code>/magic-done</code></li>
+                                    <li><code>/magic:done</code></li>
                                     <li>"the PR is merged", "close the ticket", "task is done"</li>
                                     <li>"la PR est mergée", "fermer le ticket", "tâche terminée"</li>
                                 </ul>
                                 <h4>Note</h4>
-                                <p>Do <strong>not</strong> use this to create a PR &mdash; use <code>/magic-pr</code> instead. This skill is only for post-merge finalization.</p>
+                                <p>Do <strong>not</strong> use this to create a PR &mdash; use <code>/magic:pr</code> instead. This skill is only for post-merge finalization.</p>
                             </div>
                         </div>
                     </div>
@@ -1214,7 +1214,7 @@ Ready to continue. What would you like to do?</code></pre>
 }</code></pre>
 
                     <h3>Repository settings</h3>
-                    <p>Each repository entry defines its local path and keyword list. Keywords are used by <code>/magic-start</code> to automatically match tickets to the right repo.</p>
+                    <p>Each repository entry defines its local path and keyword list. Keywords are used by <code>/magic:start</code> to automatically match tickets to the right repo.</p>
                     <div class="doc-skill">
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
@@ -1330,13 +1330,13 @@ Ready to continue. What would you like to do?</code></pre>
 
                     <h3>File locations</h3>
                     <pre><code>~/.config/magic-slash/config.json   # Main configuration
-~/.claude/skills/magic-start/SKILL.md      # /magic-start skill definition
-~/.claude/skills/magic-continue/SKILL.md   # /magic-continue skill definition
-~/.claude/skills/magic-commit/SKILL.md     # /magic-commit skill definition
-~/.claude/skills/magic-pr/SKILL.md         # /magic-pr skill definition
-~/.claude/skills/magic-review/SKILL.md     # /magic-review skill definition
-~/.claude/skills/magic-resolve/SKILL.md    # /magic-resolve skill definition
-~/.claude/skills/magic-done/SKILL.md       # /magic-done skill definition
+~/.claude/skills/magic-start/SKILL.md      # /magic:start skill definition
+~/.claude/skills/magic-continue/SKILL.md   # /magic:continue skill definition
+~/.claude/skills/magic-commit/SKILL.md     # /magic:commit skill definition
+~/.claude/skills/magic-pr/SKILL.md         # /magic:pr skill definition
+~/.claude/skills/magic-review/SKILL.md     # /magic:review skill definition
+~/.claude/skills/magic-resolve/SKILL.md    # /magic:resolve skill definition
+~/.claude/skills/magic-done/SKILL.md       # /magic:done skill definition
 ~/.claude.json                      # MCP server settings (Jira &amp; GitHub)</code></pre>
                 </div>
 
@@ -1437,7 +1437,7 @@ Ready to continue. What would you like to do?</code></pre>
                     <div class="doc-skill">
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
-                                <h4>/magic-start</h4>
+                                <h4>/magic:start</h4>
                                 <ul>
                                     <li>Scores all configured repos against the ticket keywords</li>
                                     <li>If multiple repos match, asks you to choose or select "all"</li>
@@ -1446,7 +1446,7 @@ Ready to continue. What would you like to do?</code></pre>
                                 </ul>
                             </div>
                             <div class="doc-skill-col">
-                                <h4>/magic-continue</h4>
+                                <h4>/magic:continue</h4>
                                 <ul>
                                     <li>Searches all configured repos for worktrees matching the ticket ID</li>
                                     <li>If multiple worktrees found, asks to choose or select "all"</li>
@@ -1455,18 +1455,18 @@ Ready to continue. What would you like to do?</code></pre>
                                 </ul>
                             </div>
                             <div class="doc-skill-col">
-                                <h4>/magic-commit &amp; /magic-pr</h4>
+                                <h4>/magic:commit &amp; /magic:pr</h4>
                                 <ul>
                                     <li>Detects all worktrees sharing the same ticket ID</li>
-                                    <li><code>/magic-commit</code> iterates over each worktree that has changes</li>
-                                    <li><code>/magic-pr</code> creates one PR per repo, then updates the ticket once with all PR links</li>
+                                    <li><code>/magic:commit</code> iterates over each worktree that has changes</li>
+                                    <li><code>/magic:pr</code> creates one PR per repo, then updates the ticket once with all PR links</li>
                                 </ul>
                             </div>
                         </div>
                     </div>
 
                     <h3>Example: full-stack task</h3>
-                    <pre><code>&gt; /magic-start PROJ-200
+                    <pre><code>&gt; /magic:start PROJ-200
 &#10003; Ticket: "Add user avatar upload"
 &#10003; Matched repos: api (score: 15), web (score: 12)
 
@@ -1477,11 +1477,11 @@ Ready to continue. What would you like to do?</code></pre>
 
   ... you implement backend + frontend ...
 
-&gt; /magic-commit
+&gt; /magic:commit
 &#10003; api-PROJ-200: feat(upload): add avatar endpoint
 &#10003; web-PROJ-200: feat(profile): add avatar picker component
 
-&gt; /magic-pr
+&gt; /magic:pr
 &#10003; PR #42 created on org/api
 &#10003; PR #43 created on org/web
 &#10003; Jira PROJ-200 updated with both PR links</code></pre>
@@ -1572,7 +1572,7 @@ You are working on ticket **PROJ-200** which spans multiple repos.
                                 <ul>
                                     <li><code>repos</code> &mdash; JSON array of absolute paths</li>
                                 </ul>
-                                <p>Attaches worktrees to the agent for sidebar grouping. Called automatically by <code>/magic-start</code> after creating a worktree.</p>
+                                <p>Attaches worktrees to the agent for sidebar grouping. Called automatically by <code>/magic:start</code> after creating a worktree.</p>
                             </div>
                         </div>
                     </div>
@@ -1616,7 +1616,7 @@ You are working on ticket **PROJ-200** which spans multiple repos.
 
                     <div class="doc-skill">
                         <h3>Worktree already exists</h3>
-                        <p class="doc-skill-desc"><code>/magic-start</code> detects existing worktrees and offers three options: reuse, recreate, or abort.</p>
+                        <p class="doc-skill-desc"><code>/magic:start</code> detects existing worktrees and offers three options: reuse, recreate, or abort.</p>
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
                                 <h4>Options</h4>
@@ -1636,7 +1636,7 @@ git worktree remove ../repo-PROJ-123</code></pre>
 
                     <div class="doc-skill">
                         <h3>Pre-commit hook failures</h3>
-                        <p class="doc-skill-desc"><code>/magic-commit</code> handles hook errors automatically based on severity.</p>
+                        <p class="doc-skill-desc"><code>/magic:commit</code> handles hook errors automatically based on severity.</p>
                         <div class="doc-skill-details">
                             <div class="doc-skill-col">
                                 <h4>Auto-fixed (level 1-2)</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -357,7 +357,7 @@
                                 <!-- Phase 1: /start PROJ-142 -->
                                 <div class="workflow-line phase-1-line cli-prompt">
                                     <span class="cli-prompt-icon">❯</span>
-                                    <span class="command" data-text="/magic-start PROJ-142"></span>
+                                    <span class="command" data-text="/magic:start PROJ-142"></span>
                                 </div>
                                 <div class="workflow-line phase-1-line cli-response">
                                     <div class="cli-status phase-1-status-1">
@@ -409,7 +409,7 @@
                                 <!-- Phase 2: /commit -->
                                 <div class="workflow-line phase-2-line cli-prompt" style="margin-top: 16px">
                                     <span class="cli-prompt-icon purple">❯</span>
-                                    <span class="command purple" data-text="/magic-commit"></span>
+                                    <span class="command purple" data-text="/magic:commit"></span>
                                 </div>
                                 <div class="workflow-line phase-2-line cli-response purple">
                                     <div class="cli-status phase-2-status-1">
@@ -435,7 +435,7 @@
                                 <!-- Phase 3: /pr -->
                                 <div class="workflow-line phase-3-line cli-prompt" style="margin-top: 16px">
                                     <span class="cli-prompt-icon green">❯</span>
-                                    <span class="command green" data-text="/magic-pr"></span>
+                                    <span class="command green" data-text="/magic:pr"></span>
                                 </div>
                                 <div class="workflow-line phase-3-line cli-response green">
                                     <div class="cli-status phase-3-status-1">
@@ -458,7 +458,7 @@
                                 <!-- Phase 4: /review -->
                                 <div class="workflow-line phase-4-line cli-prompt" style="margin-top: 16px">
                                     <span class="cli-prompt-icon cyan">❯</span>
-                                    <span class="command cyan" data-text="/magic-review 87"></span>
+                                    <span class="command cyan" data-text="/magic:review 87"></span>
                                 </div>
                                 <div class="workflow-line phase-4-line cli-response cyan">
                                     <div class="cli-status phase-4-status-1">
@@ -480,7 +480,7 @@
                                 <!-- Phase 5: /resolve -->
                                 <div class="workflow-line phase-5-line cli-prompt" style="margin-top: 16px">
                                     <span class="cli-prompt-icon orange">❯</span>
-                                    <span class="command orange" data-text="/magic-resolve"></span>
+                                    <span class="command orange" data-text="/magic:resolve"></span>
                                 </div>
                                 <div class="workflow-line phase-5-line cli-response orange">
                                     <div class="cli-status phase-5-status-1">
@@ -503,7 +503,7 @@
                                 <!-- Phase 6: /done -->
                                 <div class="workflow-line phase-6-line cli-prompt" style="margin-top: 16px">
                                     <span class="cli-prompt-icon green">❯</span>
-                                    <span class="command green" data-text="/magic-done"></span>
+                                    <span class="command green" data-text="/magic:done"></span>
                                 </div>
                                 <div class="workflow-line phase-6-line cli-response green">
                                     <div class="cli-status phase-6-status-1">
@@ -598,15 +598,15 @@
                     <h2 class="section-header" data-i18n="section1.title" data-i18n-html>7 skills.<br>Entire workflow.</h2>
                     <p data-i18n="section1.subtitle">From ticket to merge in seven slash commands.</p>
                     <ul>
-                        <li data-i18n="section1.startDesc" data-i18n-html><b style="color:#000">/magic-start</b> grabs your ticket and creates the branch.</li>
-                        <li data-i18n="section1.continueDesc" data-i18n-html><b style="color:#000">/magic-continue</b> resumes work on an existing ticket.</li>
-                        <li data-i18n="section1.commitDesc" data-i18n-html><b style="color:#000">/magic-commit</b> stages, splits, and writes your commit message.</li>
-                        <li data-i18n="section1.prDesc" data-i18n-html><b style="color:#000">/magic-pr</b> pushes and creates the pull request.</li>
-                        <li data-i18n="section1.reviewDesc" data-i18n-html><b style="color:#000">/magic-review</b> reviews a PR with your team conventions.</li>
-                        <li data-i18n="section1.resolveDesc" data-i18n-html><b style="color:#000">/magic-resolve</b> addresses review comments and pushes fixes.</li>
-                        <li data-i18n="section1.doneDesc" data-i18n-html><b style="color:#000">/magic-done</b> finalizes after merge — cleans up and updates Jira.</li>
+                        <li data-i18n="section1.startDesc" data-i18n-html><b style="color:#000">/magic:start</b> grabs your ticket and creates the branch.</li>
+                        <li data-i18n="section1.continueDesc" data-i18n-html><b style="color:#000">/magic:continue</b> resumes work on an existing ticket.</li>
+                        <li data-i18n="section1.commitDesc" data-i18n-html><b style="color:#000">/magic:commit</b> stages, splits, and writes your commit message.</li>
+                        <li data-i18n="section1.prDesc" data-i18n-html><b style="color:#000">/magic:pr</b> pushes and creates the pull request.</li>
+                        <li data-i18n="section1.reviewDesc" data-i18n-html><b style="color:#000">/magic:review</b> reviews a PR with your team conventions.</li>
+                        <li data-i18n="section1.resolveDesc" data-i18n-html><b style="color:#000">/magic:resolve</b> addresses review comments and pushes fixes.</li>
+                        <li data-i18n="section1.doneDesc" data-i18n-html><b style="color:#000">/magic:done</b> finalizes after merge — cleans up and updates Jira.</li>
                     </ul>
-                    <p class="cmd-prefix-hint" data-i18n="section1.prefixHint" data-i18n-html>Type <b style="color:#000">/magic-</b> to find all commands at once.</p>
+                    <p class="cmd-prefix-hint" data-i18n="section1.prefixHint" data-i18n-html>Type <b style="color:#000">/magic:</b> to find all commands at once.</p>
                     <p data-i18n="section1.noContext">No context switching. No copy-pasting ticket IDs. Just flow.</p>
                     <a href="documentation.html" class="btn-get-started" style="margin-top: 1.5rem;" data-i18n="section1.seeDocs">See docs</a>
                 </div>
@@ -619,19 +619,19 @@
                             <span class="cmd-terminal-dot"></span>
                         </div>
                         <div class="cmd-terminal-body">
-                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic-start</span> <span class="cmd-arg">PROJ-142</span></div>
+                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic:start</span> <span class="cmd-arg">PROJ-142</span></div>
                             <div class="cmd-line"><span class="cmd-output">&#10003; Branch feature/PROJ-142 created</span></div>
-                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic-continue</span> <span class="cmd-arg">PROJ-142</span></div>
+                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic:continue</span> <span class="cmd-arg">PROJ-142</span></div>
                             <div class="cmd-line"><span class="cmd-output">&#10003; Resuming — worktree found at api-PROJ-142</span></div>
-                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic-commit</span></div>
+                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic:commit</span></div>
                             <div class="cmd-line"><span class="cmd-output">&#10003; feat: add user authentication</span></div>
-                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic-pr</span></div>
+                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic:pr</span></div>
                             <div class="cmd-line"><span class="cmd-output">&#10003; PR #87 created &mdash; linked to PROJ-142</span></div>
-                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic-review</span> <span class="cmd-arg">87</span></div>
+                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic:review</span> <span class="cmd-arg">87</span></div>
                             <div class="cmd-line"><span class="cmd-output">&#10003; 2 comments &mdash; approved</span></div>
-                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic-resolve</span></div>
+                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic:resolve</span></div>
                             <div class="cmd-line"><span class="cmd-output">&#10003; 2 comments resolved &mdash; force-pushed</span></div>
-                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic-done</span></div>
+                            <div class="cmd-line"><span class="cmd-prompt">&#10095;</span> <span class="cmd-slash">/magic:done</span></div>
                             <div class="cmd-line"><span class="cmd-output">&#10003; PROJ-142 &rarr; Done &mdash; branch cleaned up</span></div>
                         </div>
                     </div>
@@ -899,7 +899,7 @@
                 </div>
                 <div class="split-text reveal-right">
                     <h2 class="section-header" data-i18n="section6.title">Your ticket, always in context.</h2>
-                    <p data-i18n="section6.p1" data-i18n-html>When you <b style="color:#000">/magic-start</b> a ticket, magic-slash fetches the title, description, and metadata from Jira or GitHub Issues. Every command you run knows what you're working on.</p>
+                    <p data-i18n="section6.p1" data-i18n-html>When you <b style="color:#000">/magic:start</b> a ticket, magic-slash fetches the title, description, and metadata from Jira or GitHub Issues. Every command you run knows what you're working on.</p>
                     <p data-i18n="section6.p2">Commit messages reference the right ticket. PRs include the full context. No more tab-switching to copy-paste issue details.</p>
                     <a href="documentation.html" class="btn-get-started" style="margin-top: 1.5rem;" data-i18n="section6.seeDocs">See docs</a>
                 </div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -33,14 +33,14 @@ var i18n = {
         // Section 1 — Seven Skills
         'section1.title': '7 skills.<br>Entire workflow.',
         'section1.subtitle': 'From ticket to merge in seven slash commands.',
-        'section1.startDesc': '<b style="color:#000">/magic-start</b> grabs your ticket and creates the branch.',
-        'section1.continueDesc': '<b style="color:#000">/magic-continue</b> resumes work on an existing ticket.',
-        'section1.commitDesc': '<b style="color:#000">/magic-commit</b> stages, splits, and writes your commit message.',
-        'section1.prDesc': '<b style="color:#000">/magic-pr</b> pushes and creates the pull request.',
-        'section1.reviewDesc': '<b style="color:#000">/magic-review</b> reviews a PR with your team conventions.',
-        'section1.resolveDesc': '<b style="color:#000">/magic-resolve</b> addresses review comments and pushes fixes.',
-        'section1.doneDesc': '<b style="color:#000">/magic-done</b> finalizes after merge — cleans up and updates Jira.',
-        'section1.prefixHint': 'Type <b style="color:#000">/magic-</b> to find all commands at once.',
+        'section1.startDesc': '<b style="color:#000">/magic:start</b> grabs your ticket and creates the branch.',
+        'section1.continueDesc': '<b style="color:#000">/magic:continue</b> resumes work on an existing ticket.',
+        'section1.commitDesc': '<b style="color:#000">/magic:commit</b> stages, splits, and writes your commit message.',
+        'section1.prDesc': '<b style="color:#000">/magic:pr</b> pushes and creates the pull request.',
+        'section1.reviewDesc': '<b style="color:#000">/magic:review</b> reviews a PR with your team conventions.',
+        'section1.resolveDesc': '<b style="color:#000">/magic:resolve</b> addresses review comments and pushes fixes.',
+        'section1.doneDesc': '<b style="color:#000">/magic:done</b> finalizes after merge — cleans up and updates Jira.',
+        'section1.prefixHint': 'Type <b style="color:#000">/magic:</b> to find all commands at once.',
         'section1.noContext': 'No context switching. No copy-pasting ticket IDs. Just flow.',
         'section1.seeDocs': 'See docs',
         // Section 2 — Skills Manager
@@ -86,7 +86,7 @@ var i18n = {
         'section6.filesChanged': '3 files changed',
         'section6.noCommits': 'No committed changes',
         'section6.title': 'Your ticket, always in context.',
-        'section6.p1': 'When you <b style="color:#000">/magic-start</b> a ticket, magic-slash fetches the title, description, and metadata from Jira or GitHub Issues. Every command you run knows what you\'re working on.',
+        'section6.p1': 'When you <b style="color:#000">/magic:start</b> a ticket, magic-slash fetches the title, description, and metadata from Jira or GitHub Issues. Every command you run knows what you\'re working on.',
         'section6.p2': 'Commit messages reference the right ticket. PRs include the full context. No more tab-switching to copy-paste issue details.',
         'section6.seeDocs': 'See docs',
         // CTA
@@ -126,14 +126,14 @@ var i18n = {
         // Section 1 — Seven Skills
         'section1.title': '7 skills.<br>Tout le workflow.',
         'section1.subtitle': 'Du ticket au merge en sept commandes slash.',
-        'section1.startDesc': '<b style="color:#000">/magic-start</b> récupère votre ticket et crée la branche.',
-        'section1.continueDesc': '<b style="color:#000">/magic-continue</b> reprend le travail sur un ticket existant.',
-        'section1.commitDesc': '<b style="color:#000">/magic-commit</b> indexe, découpe et rédige votre message de commit.',
-        'section1.prDesc': '<b style="color:#000">/magic-pr</b> pousse et crée la pull request.',
-        'section1.reviewDesc': '<b style="color:#000">/magic-review</b> review une PR selon les conventions d\'équipe.',
-        'section1.resolveDesc': '<b style="color:#000">/magic-resolve</b> traite les commentaires de review et pousse les corrections.',
-        'section1.doneDesc': '<b style="color:#000">/magic-done</b> finalise après le merge — nettoie et met à jour Jira.',
-        'section1.prefixHint': 'Tapez <b style="color:#000">/magic-</b> pour retrouver toutes les commandes.',
+        'section1.startDesc': '<b style="color:#000">/magic:start</b> récupère votre ticket et crée la branche.',
+        'section1.continueDesc': '<b style="color:#000">/magic:continue</b> reprend le travail sur un ticket existant.',
+        'section1.commitDesc': '<b style="color:#000">/magic:commit</b> indexe, découpe et rédige votre message de commit.',
+        'section1.prDesc': '<b style="color:#000">/magic:pr</b> pousse et crée la pull request.',
+        'section1.reviewDesc': '<b style="color:#000">/magic:review</b> review une PR selon les conventions d\'équipe.',
+        'section1.resolveDesc': '<b style="color:#000">/magic:resolve</b> traite les commentaires de review et pousse les corrections.',
+        'section1.doneDesc': '<b style="color:#000">/magic:done</b> finalise après le merge — nettoie et met à jour Jira.',
+        'section1.prefixHint': 'Tapez <b style="color:#000">/magic:</b> pour retrouver toutes les commandes.',
         'section1.noContext': 'Pas de changement de contexte. Pas de copier-coller d\'identifiants. Juste du flow.',
         'section1.seeDocs': 'Voir la doc',
         // Section 2 — Skills Manager
@@ -179,7 +179,7 @@ var i18n = {
         'section6.filesChanged': '3 fichiers modifiés',
         'section6.noCommits': 'Aucun commit',
         'section6.title': 'Votre ticket, toujours en contexte.',
-        'section6.p1': 'Quand vous faites <b style="color:#000">/magic-start</b> sur un ticket, magic-slash récupère le titre, la description et les métadonnées depuis Jira ou GitHub Issues. Chaque commande que vous lancez sait sur quoi vous travaillez.',
+        'section6.p1': 'Quand vous faites <b style="color:#000">/magic:start</b> sur un ticket, magic-slash récupère le titre, la description et les métadonnées depuis Jira ou GitHub Issues. Chaque commande que vous lancez sait sur quoi vous travaillez.',
         'section6.p2': 'Les messages de commit référencent le bon ticket. Les PRs incluent le contexte complet. Fini les allers-retours entre onglets pour copier-coller les détails des issues.',
         'section6.seeDocs': 'Voir la doc',
         // CTA
@@ -439,7 +439,7 @@ function copyCommand(btn) {
 }
 
 // Fetch latest version from GitHub
-fetch('https://api.github.com/repos/Xrequillart/magic-slash/releases/latest')
+fetch('https://api.github.com/repos/Xrequillart/magic:slash/releases/latest')
     .then(function(r) { return r.json(); })
     .then(function(data) {
         if (data.tag_name) {
@@ -633,13 +633,13 @@ fetch('https://api.github.com/repos/Xrequillart/magic-slash/releases/latest')
     function startDesktopTerminalAnimation() {
         lockScroll();
         var typeSpeed = 60;
-        var startCmdText = '/magic-start PROJ-142';
+        var startCmdText = '/magic:start PROJ-142';
         var startCmdDuration = startCmdText.length * typeSpeed;
-        var commitCmdDuration = '/magic-commit'.length * typeSpeed;
-        var prCmdDuration = '/magic-pr'.length * typeSpeed;
-        var reviewCmdDuration = '/magic-review 87'.length * typeSpeed;
-        var resolveCmdDuration = '/magic-resolve'.length * typeSpeed;
-        var doneCmdDuration = '/magic-done'.length * typeSpeed;
+        var commitCmdDuration = '/magic:commit'.length * typeSpeed;
+        var prCmdDuration = '/magic:pr'.length * typeSpeed;
+        var reviewCmdDuration = '/magic:review 87'.length * typeSpeed;
+        var resolveCmdDuration = '/magic:resolve'.length * typeSpeed;
+        var doneCmdDuration = '/magic:done'.length * typeSpeed;
 
         // ===== PHASE 1: /start =====
         var p1 = 400;

--- a/install/install.sh
+++ b/install/install.sh
@@ -95,7 +95,7 @@ print_logo() {
 }
 
 print_logo
-echo "  Installing /magic-start, /magic-continue, /magic-commit, /magic-pr, /magic-review, /magic-resolve and /magic-done"
+echo "  Installing /magic:start, /magic:continue, /magic:commit, /magic:pr, /magic:review, /magic:resolve and /magic:done"
 echo ""
 
 # ============================================
@@ -321,7 +321,7 @@ echo ""
 # ============================================
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
-echo "4. Installing /magic-start, /magic-continue, /magic-commit, /magic-pr, /magic-review, /magic-resolve and /magic-done skills"
+echo "4. Installing /magic:start, /magic:continue, /magic:commit, /magic:pr, /magic:review, /magic:resolve and /magic:done skills"
 echo ""
 
 SKILLS_DIR="$HOME/.claude/skills"
@@ -331,7 +331,7 @@ mkdir -p "$SKILLS_DIR"
 for skill in start "continue" commit "done"; do
   if [ -d "$SKILLS_DIR/$skill" ]; then
     rm -rf "${SKILLS_DIR:?}/${skill:?}"
-    echo "   ↗️  Migrated: /$skill → /magic-$skill"
+    echo "   ↗️  Migrated: /$skill → /magic:$skill"
   fi
 done
 
@@ -360,8 +360,8 @@ else
   done
 fi
 
-echo "   ✅ Skills installed (magic-start, magic-continue, magic-commit, magic-pr, magic-review, magic-resolve, magic-done)"
-echo "   → Type /magic- to quickly find all commands"
+echo "   ✅ Skills installed (magic:start, magic:continue, magic:commit, magic:pr, magic:review, magic:resolve, magic:done)"
+echo "   → Type /magic: to quickly find all commands"
 echo "   → Or use natural language: 'démarre PROJ-123', 'ready to commit', 'create the PR', 'review my PR'"
 
 # Note: Old commands in ~/.claude/commands/ are no longer used
@@ -633,15 +633,15 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 echo "🚀 You're ready! Try these commands in Claude Code:"
 echo ""
-echo "   /magic-start PROJ-123   Start a Jira ticket"
-echo "   /magic-start #42       Start a GitHub issue"
-echo "   /magic-commit          Create a commit"
-echo "   /magic-pr              Push and create a Pull Request"
-echo "   /magic-review          Review a Pull Request"
-echo "   /magic-resolve         Address review comments"
-echo "   /magic-done            Finalize after PR is merged"
+echo "   /magic:start PROJ-123   Start a Jira ticket"
+echo "   /magic:start #42       Start a GitHub issue"
+echo "   /magic:commit          Create a commit"
+echo "   /magic:pr              Push and create a Pull Request"
+echo "   /magic:review          Review a Pull Request"
+echo "   /magic:resolve         Address review comments"
+echo "   /magic:done            Finalize after PR is merged"
 echo ""
-echo "   💡 Type /magic- to see all commands"
+echo "   💡 Type /magic: to see all commands"
 echo ""
 echo "   Or use natural language:"
 echo "   'démarre PROJ-123'  'ready to commit'  'create the PR'"

--- a/skills/evals/eval_set.json
+++ b/skills/evals/eval_set.json
@@ -2,210 +2,210 @@
   {
     "id": 1,
     "query": "PROJ-123",
-    "expected_skill": "magic-start",
+    "expected_skill": "magic:start",
     "notes": "Bare ticket ID with no context — should default to start, but could also be continue. Ambiguous case.",
     "difficulty": "hard"
   },
   {
     "id": 2,
     "query": "je vais bosser sur PROJ-456 aujourd'hui",
-    "expected_skill": "magic-start",
+    "expected_skill": "magic:start",
     "notes": "French phrase for starting work on a ticket",
     "difficulty": "easy"
   },
   {
     "id": 3,
     "query": "let me resume work on PROJ-789, I was working on it yesterday",
-    "expected_skill": "magic-continue",
+    "expected_skill": "magic:continue",
     "notes": "Clear resume intent with context",
     "difficulty": "easy"
   },
   {
     "id": 4,
     "query": "je reprends PROJ-123",
-    "expected_skill": "magic-continue",
+    "expected_skill": "magic:continue",
     "notes": "French resume keyword",
     "difficulty": "easy"
   },
   {
     "id": 5,
     "query": "switch to PROJ-456",
-    "expected_skill": "magic-continue",
+    "expected_skill": "magic:continue",
     "notes": "Switch implies existing work",
     "difficulty": "medium"
   },
   {
     "id": 6,
     "query": "j'ai fini, on peut pousser tout ça",
-    "expected_skill": "magic-pr",
+    "expected_skill": "magic:pr",
     "notes": "French completion phrase without mentioning PR — should trigger magic-pr, not magic-done",
     "difficulty": "hard"
   },
   {
     "id": 7,
     "query": "I'm done coding, everything looks good",
-    "expected_skill": "magic-pr",
+    "expected_skill": "magic:pr",
     "notes": "'done' + 'coding' context = PR creation, not task finalization",
     "difficulty": "hard"
   },
   {
     "id": 8,
     "query": "the PR has been merged, let's close things out",
-    "expected_skill": "magic-done",
+    "expected_skill": "magic:done",
     "notes": "Clear post-merge finalization",
     "difficulty": "easy"
   },
   {
     "id": 9,
     "query": "la tâche est terminée, la PR est mergée",
-    "expected_skill": "magic-done",
+    "expected_skill": "magic:done",
     "notes": "French — task done + PR merged",
     "difficulty": "easy"
   },
   {
     "id": 10,
     "query": "c'est bon pour moi, ship it",
-    "expected_skill": "magic-pr",
+    "expected_skill": "magic:pr",
     "notes": "Casual completion signal — should be PR, not done",
     "difficulty": "hard"
   },
   {
     "id": 11,
     "query": "commit",
-    "expected_skill": "magic-commit",
+    "expected_skill": "magic:commit",
     "notes": "Single word trigger",
     "difficulty": "easy"
   },
   {
     "id": 12,
     "query": "let's save my changes before I forget",
-    "expected_skill": "magic-commit",
+    "expected_skill": "magic:commit",
     "notes": "Indirect commit intent",
     "difficulty": "medium"
   },
   {
     "id": 13,
     "query": "review the PR please",
-    "expected_skill": "magic-review",
+    "expected_skill": "magic:review",
     "notes": "Direct review request",
     "difficulty": "easy"
   },
   {
     "id": 14,
     "query": "can you do a self-review before I ask my colleague?",
-    "expected_skill": "magic-review",
+    "expected_skill": "magic:review",
     "notes": "Self-review context",
     "difficulty": "easy"
   },
   {
     "id": 15,
     "query": "fix the review comments on my PR",
-    "expected_skill": "magic-resolve",
+    "expected_skill": "magic:resolve",
     "notes": "Fix review comments = resolve, not review",
     "difficulty": "medium"
   },
   {
     "id": 16,
     "query": "il y a des retours sur la PR, faut que je les corrige",
-    "expected_skill": "magic-resolve",
+    "expected_skill": "magic:resolve",
     "notes": "French — feedback on PR that needs fixing",
     "difficulty": "medium"
   },
   {
     "id": 17,
     "query": "the task is done",
-    "expected_skill": "magic-done",
+    "expected_skill": "magic:done",
     "notes": "In magic-done description, but could be confused with magic-pr 'I'm done'",
     "difficulty": "hard"
   },
   {
     "id": 18,
     "query": "I think we're good, time to push",
-    "expected_skill": "magic-pr",
+    "expected_skill": "magic:pr",
     "notes": "'push' is the disambiguator here — PR creation, not finalization",
     "difficulty": "medium"
   },
   {
     "id": 19,
     "query": "envoie la sauce",
-    "expected_skill": "magic-pr",
+    "expected_skill": "magic:pr",
     "notes": "Casual French slang for 'ship it'",
     "difficulty": "medium"
   },
   {
     "id": 20,
     "query": "mark the ticket as done, everything is merged",
-    "expected_skill": "magic-done",
+    "expected_skill": "magic:done",
     "notes": "Explicit done + merged context",
     "difficulty": "easy"
   },
   {
     "id": 21,
     "query": "address the feedback from the code review",
-    "expected_skill": "magic-resolve",
+    "expected_skill": "magic:resolve",
     "notes": "'address feedback' is in the resolve description",
     "difficulty": "easy"
   },
   {
     "id": 22,
     "query": "fermer le ticket",
-    "expected_skill": "magic-done",
+    "expected_skill": "magic:done",
     "notes": "French — close the ticket",
     "difficulty": "easy"
   },
   {
     "id": 23,
     "query": "start #42",
-    "expected_skill": "magic-start",
+    "expected_skill": "magic:start",
     "notes": "GitHub issue format with start keyword",
     "difficulty": "easy"
   },
   {
     "id": 24,
     "query": "#42",
-    "expected_skill": "magic-start",
+    "expected_skill": "magic:start",
     "notes": "Bare GitHub issue number — ambiguous like bare ticket ID",
     "difficulty": "hard"
   },
   {
     "id": 25,
     "query": "ready to commit, everything passes",
-    "expected_skill": "magic-commit",
+    "expected_skill": "magic:commit",
     "notes": "Ready to commit phrase",
     "difficulty": "easy"
   },
   {
     "id": 26,
     "query": "wrap it up and create the pull request",
-    "expected_skill": "magic-pr",
+    "expected_skill": "magic:pr",
     "notes": "Explicit PR creation mention",
     "difficulty": "easy"
   },
   {
     "id": 27,
     "query": "done",
-    "expected_skill": "magic-pr",
+    "expected_skill": "magic:pr",
     "notes": "Single word 'done' — listed in magic-pr description, but magic-done also has 'task is done'. magic-pr should win because bare 'done' usually means 'I finished coding'",
     "difficulty": "hard"
   },
   {
     "id": 28,
     "query": "regarde la PR s'il te plait",
-    "expected_skill": "magic-review",
+    "expected_skill": "magic:review",
     "notes": "French PR review request",
     "difficulty": "easy"
   },
   {
     "id": 29,
     "query": "work on issue #15, it's about adding dark mode to the settings page",
-    "expected_skill": "magic-start",
+    "expected_skill": "magic:start",
     "notes": "Start with context about the issue",
     "difficulty": "easy"
   },
   {
     "id": 30,
     "query": "les changements sont prêts, on peut créer la PR",
-    "expected_skill": "magic-pr",
+    "expected_skill": "magic:pr",
     "notes": "French — changes ready, let's create PR",
     "difficulty": "easy"
   }

--- a/skills/evals/results.json
+++ b/skills/evals/results.json
@@ -5,17 +5,17 @@
   "correct_triggers": 30,
   "accuracy": "100%",
   "ambiguous_cases": [
-    {"ids": [1, 24], "issue": "Bare ticket IDs trigger both magic-start and magic-continue", "resolved": "magic-start", "confidence": "low"},
-    {"ids": [27], "issue": "'done' alone is ambiguous between magic-pr and magic-done", "resolved": "magic-pr", "confidence": "medium"},
-    {"ids": [17], "issue": "'the task is done' could be confused with magic-pr completion signals", "resolved": "magic-done", "confidence": "medium-high"}
+    {"ids": [1, 24], "issue": "Bare ticket IDs trigger both magic:start and magic:continue", "resolved": "magic:start", "confidence": "low"},
+    {"ids": [27], "issue": "'done' alone is ambiguous between magic:pr and magic:done", "resolved": "magic:pr", "confidence": "medium"},
+    {"ids": [17], "issue": "'the task is done' could be confused with magic:pr completion signals", "resolved": "magic:done", "confidence": "medium-high"}
   ],
   "per_skill_stats": {
-    "magic-start": {"queries": [1, 2, 23, 24, 29], "count": 5, "passed": 5, "all_correct": true},
-    "magic-continue": {"queries": [3, 4, 5], "count": 3, "passed": 3, "all_correct": true},
-    "magic-commit": {"queries": [11, 12, 25], "count": 3, "passed": 3, "all_correct": true},
-    "magic-pr": {"queries": [6, 7, 10, 18, 19, 26, 27, 30], "count": 8, "passed": 8, "all_correct": true},
-    "magic-review": {"queries": [13, 14, 28], "count": 3, "passed": 3, "all_correct": true},
-    "magic-resolve": {"queries": [15, 16, 21], "count": 3, "passed": 3, "all_correct": true},
-    "magic-done": {"queries": [8, 9, 17, 20, 22], "count": 5, "passed": 5, "all_correct": true}
+    "magic:start": {"queries": [1, 2, 23, 24, 29], "count": 5, "passed": 5, "all_correct": true},
+    "magic:continue": {"queries": [3, 4, 5], "count": 3, "passed": 3, "all_correct": true},
+    "magic:commit": {"queries": [11, 12, 25], "count": 3, "passed": 3, "all_correct": true},
+    "magic:pr": {"queries": [6, 7, 10, 18, 19, 26, 27, 30], "count": 8, "passed": 8, "all_correct": true},
+    "magic:review": {"queries": [13, 14, 28], "count": 3, "passed": 3, "all_correct": true},
+    "magic:resolve": {"queries": [15, 16, 21], "count": 3, "passed": 3, "all_correct": true},
+    "magic:done": {"queries": [8, 9, 17, 20, 22], "count": 5, "passed": 5, "all_correct": true}
   }
 }

--- a/skills/magic-commit/SKILL.md
+++ b/skills/magic-commit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: magic-commit
+name: magic:commit
 description: This skill should be used when the user says "commit", "je suis pret a committer", "on commit", "create a commit", "faire un commit", "committer les changements", "save my changes", "enregistrer mes changements", "pret a committer", "ready to commit", or indicates they want to save their current changes as a commit.
 allowed-tools: Bash(*), Read, Edit, Write, Glob, Grep
 ---

--- a/skills/magic-continue/SKILL.md
+++ b/skills/magic-continue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: magic-continue
+name: magic:continue
 description: This skill should be used when the user mentions a ticket ID like "PROJ-123", "#456", says "continue", "reprendre", "resume work on", "je reprends", "switch to", "basculer sur", or indicates they want to resume working on an existing task.
 argument-hint: <TICKET-ID>
 allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, mcp__atlassian__*, mcp__github__*

--- a/skills/magic-done/SKILL.md
+++ b/skills/magic-done/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: magic-done
-description: This skill should be used when the user says "the PR is merged", "la PR est mergée", "close the ticket", "fermer le ticket", "finalize the task", "finaliser la tâche", "task is done", "tâche terminée", "mark as done", "marquer comme terminé", or indicates the PR has already been merged and they want to close out the task. Do NOT use this skill if the user just finished coding and wants to create a PR — use /magic-pr instead.
+name: magic:done
+description: This skill should be used when the user says "the PR is merged", "la PR est mergée", "close the ticket", "fermer le ticket", "finalize the task", "finaliser la tâche", "task is done", "tâche terminée", "mark as done", "marquer comme terminé", or indicates the PR has already been merged and they want to close out the task. Do NOT use this skill if the user just finished coding and wants to create a PR — use /magic:pr instead.
 allowed-tools: Bash(*), mcp__github__*, mcp__atlassian__*
 ---
 
@@ -123,7 +123,7 @@ Display a message and stop:
 ```text
 ⚠️ The PR #{PR_NUMBER} is not yet merged.
 
-Please merge the PR on GitHub first, then run /magic-done again.
+Please merge the PR on GitHub first, then run /magic:done again.
 
 🔗 PR: {PR_URL}
 ```
@@ -132,7 +132,7 @@ Please merge the PR on GitHub first, then run /magic-done again.
 ```text
 ⚠️ La PR #{PR_NUMBER} n'est pas encore mergée.
 
-Merci de merger la PR sur GitHub d'abord, puis relance /magic-done.
+Merci de merger la PR sur GitHub d'abord, puis relance /magic:done.
 
 🔗 PR : {PR_URL}
 ```

--- a/skills/magic-pr/SKILL.md
+++ b/skills/magic-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: magic-pr
+name: magic:pr
 description: This skill should be used when the user says "done", "terminé", "I'm done", "c'est fini", "j'ai fini", "finalize", "create PR", "créer la PR", "push and create PR", "on peut créer la PR", "pousser les changements", "push my changes", "create the pull request", "ready for PR", "prêt pour la PR", "open a PR", "ouvrir une PR", or indicates they have finished coding and want to push their code and create a pull request. Also trigger when the user signals completion with phrases like "everything looks good", "let's ship it", "can you push this?", "les changements sont prêts", "j'ai fini de coder", "on peut pousser", "let's get this merged", "ready to submit", "ship it", "envoie la sauce", "go for PR", "wrap it up", "c'est bon pour moi", "I think we're good", "on est bon", "time to push", "pousse tout ça", or any indication that coding is complete and they want to move to the review phase. Use this skill even if the user doesn't explicitly mention "PR" — if they indicate their work is done and want to share it, this is the right skill.
 argument-hint: <base-branch> (optional, e.g., develop, staging)
 allowed-tools: Bash(*), mcp__github__*, mcp__atlassian__*
@@ -39,7 +39,7 @@ Read `~/.config/magic-slash/config.json` and determine the parameters based on t
 Read `~/.config/magic-slash/config.json` to determine the development branch:
 
 1. Once the repo is identified, read `.repositories.<name>.branches.development`
-2. If an argument is provided (e.g., `/magic-pr develop`), use it directly as `$DEV_BRANCH` and skip confirmation.
+2. If an argument is provided (e.g., `/magic:pr develop`), use it directly as `$DEV_BRANCH` and skip confirmation.
 3. Otherwise, **always ask the user for confirmation**, showing the configured default if available:
 
 #### If a default is configured (e.g., `"develop"`)

--- a/skills/magic-pr/references/messages.md
+++ b/skills/magic-pr/references/messages.md
@@ -416,10 +416,10 @@ Passage au repository suivant...
 🎫 Ticket   : {TICKET_ID} → {ticket_status}
 
 Next steps:
-1. Run /magic-review to perform a code review
+1. Run /magic:review to perform a code review
 2. Wait for approval and CI checks
 3. Merge the PR once approved
-4. Run /magic-done to finalize the task
+4. Run /magic:done to finalize the task
 ```
 
 ### fr
@@ -432,10 +432,10 @@ Next steps:
 🎫 Ticket   : {TICKET_ID} → {ticket_status}
 
 Prochaines étapes :
-1. Lance /magic-review pour faire une revue de code
+1. Lance /magic:review pour faire une revue de code
 2. Attend l'approbation et les checks CI
 3. Merge la PR une fois approuvée
-4. Lance /magic-done pour finaliser la tâche
+4. Lance /magic:done pour finaliser la tâche
 ```
 
 ## MSG_MULTI_REPO_FINAL

--- a/skills/magic-resolve/SKILL.md
+++ b/skills/magic-resolve/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: magic-resolve
+name: magic:resolve
 description: This skill should be used when the user says "resolve", "résoudre", "fix review comments", "corriger les commentaires", "address feedback", "traiter les retours", "fix the review", "corriger la review", "apply review changes", "appliquer les corrections", or indicates they want to address code review feedback on a pull request.
 argument-hint: <TICKET-ID> (optional)
 allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, mcp__github__*, mcp__atlassian__*
@@ -188,7 +188,7 @@ If a worktree fails during its resolve cycle (push error, API failure, etc.):
 
 ## Step 1: Detect the ticket and worktree
 
-If an argument is provided (e.g., `/magic-resolve PROJ-123`), use it as the ticket ID.
+If an argument is provided (e.g., `/magic:resolve PROJ-123`), use it as the ticket ID.
 
 Otherwise, use the ticket ID already extracted in **Step 0.2**. If Step 0.2 was skipped (not in a worktree) and no argument was provided, ask the user which PR to resolve.
 

--- a/skills/magic-resolve/references/messages.md
+++ b/skills/magic-resolve/references/messages.md
@@ -432,13 +432,13 @@ Changes have been pushed.
 
 {IF_RE_REQUEST_OK}
 Next step:
-1. Run /magic-review for a self-review of the fixes
+1. Run /magic:review for a self-review of the fixes
 {/IF_RE_REQUEST_OK}
 
 {IF_RE_REQUEST_FAIL}
 Next steps:
 1. Request a re-review from the reviewer
-2. Run /magic-review for a self-review of the fixes
+2. Run /magic:review for a self-review of the fixes
 {/IF_RE_REQUEST_FAIL}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -466,13 +466,13 @@ Les changements ont été pushés.
 
 {IF_RE_REQUEST_OK}
 Prochaine étape :
-1. Lance /magic-review pour une auto-review des corrections
+1. Lance /magic:review pour une auto-review des corrections
 {/IF_RE_REQUEST_OK}
 
 {IF_RE_REQUEST_FAIL}
 Prochaines étapes :
 1. Demande une re-review au reviewer
-2. Lance /magic-review pour une auto-review des corrections
+2. Lance /magic:review pour une auto-review des corrections
 {/IF_RE_REQUEST_FAIL}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/skills/magic-review/SKILL.md
+++ b/skills/magic-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: magic-review
+name: magic:review
 description: This skill should be used when the user says "review", "revue de code", "code review", "review the PR", "regarde la PR", "review my PR", "self-review", "auto-review", "check my PR", "vérifie ma PR", or indicates they want to perform a code review on a pull request.
 argument-hint: <TICKET-ID> (optional)
 allowed-tools: Bash(*), Read, Glob, Grep, mcp__github__*, mcp__atlassian__*
@@ -62,7 +62,7 @@ Voir la documentation : https://github.com/magic-slash/config
 
 ## Step 1: Detect the ticket
 
-If an argument is provided (e.g., `/magic-review PROJ-123`), use it as the ticket ID.
+If an argument is provided (e.g., `/magic:review PROJ-123`), use it as the ticket ID.
 
 Otherwise, extract the ticket ID from the current worktree:
 
@@ -210,11 +210,11 @@ Display a summary of the review based on `.languages.discussion`:
 Next steps:
 1. Wait for CI checks to pass
 2. Merge the PR once approved
-3. Run /magic-done to finalize the task
+3. Run /magic:done to finalize the task
 
 {If REQUEST_CHANGES}
 Next steps:
-1. Run /magic-resolve to address the review comments
+1. Run /magic:resolve to address the review comments
 2. Request a re-review after fixing
 
 {If COMMENT}
@@ -243,11 +243,11 @@ Next steps:
 Prochaines étapes :
 1. Attend que les checks CI passent
 2. Merge la PR une fois approuvée
-3. Lance /magic-done pour finaliser la tâche
+3. Lance /magic:done pour finaliser la tâche
 
 {Si REQUEST_CHANGES}
 Prochaines étapes :
-1. Lance /magic-resolve pour corriger les commentaires de review
+1. Lance /magic:resolve pour corriger les commentaires de review
 2. Demande une re-review après correction
 
 {Si COMMENT}

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: magic-start
+name: magic:start
 description: This skill should be used when the user mentions a ticket ID like "PROJ-123", "#456", says "start", "commencer", "travailler sur", "je vais bosser sur", "begin work on", "work on ticket", "work on issue", "démarre", "démarrer", or indicates they want to start working on a specific task.
 argument-hint: <TICKET-ID>
 allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, Agent, mcp__atlassian__*, mcp__github__*


### PR DESCRIPTION
## Description\n\nRename all 7 skill names from `magic-*` to `magic:*` (e.g. `/magic-start` → `/magic:start`) for better visual identity and a clear namespace distinction. Folder names remain unchanged (`skills/magic-start/`, etc.) to avoid cross-platform filesystem issues with `:`.\n\n## Related Issue\n\nFixes #41\n\n## Type of Change\n\n- [ ] Bug fix (non-breaking change that fixes an issue)\n- [ ] New feature (non-breaking change that adds functionality)\n- [ ] Breaking change (fix or feature that would cause existing functionality to change)\n- [ ] Documentation update\n- [x] Refactoring (no functional changes)\n- [ ] CI/CD changes\n- [ ] Other (please describe):\n\n## Changes Made\n\n- Updated `name:` frontmatter in all 7 SKILL.md files (`magic-start` → `magic:start`, etc.)\n- Updated textual references `/magic-*` → `/magic:*` in SKILL.md bodies and reference messages\n- Updated install script display names and autocomplete hint (`/magic-` → `/magic:`)\n- Updated README.md skill table, examples, section headers\n- Updated CLAUDE.md skill descriptions\n- Updated docs (index.html, documentation.html, script.js) — i18n translations, terminal animation commands, skill reference cards\n- Updated evals (eval_set.json expected_skill values, results.json per-skill stats)\n- Fixed GitHub source URLs in documentation.html to keep folder paths as `magic-*`\n\n## What does NOT change\n\n- Folder names (`skills/magic-start/`, etc.)\n- `package.json`, `CHANGELOG.md`\n- Desktop app `skills-updater.ts` SKILLS array (uses folder names)\n- Config file paths (`~/.config/magic-slash/`)\n- GitHub/project URLs\n- `uninstall.sh` (references are directory paths)\n\n## Testing\n\n- [x] Tested locally with Claude Code\n- [ ] Ran linters (`npm run lint`) — YAML lint passes, JS lint has pre-existing Node version incompatibility\n- [ ] Tested installation script\n- [ ] Tested affected slash commands\n\n### Test Steps\n\n1. Verify all 7 SKILL.md files have `name: magic:*` in frontmatter: `grep -r '^name:' skills/*/SKILL.md`\n2. Verify no remaining `/magic-start` (etc.) skill name references outside of paths: `grep -rn '/magic-\\(start\\|commit\\|continue\\|pr\\|review\\|resolve\\|done\\)' --include='*.md' --include='*.sh' --include='*.html' --include='*.js' --include='*.json' --exclude-dir=node_modules --exclude='CHANGELOG.md' --exclude='package-lock.json' | grep -v 'skills/magic-' | grep -v '~/.claude/skills/magic-' | grep -v 'github.com'`\n3. Verify folder paths are intact: `ls skills/` should show `magic-start`, `magic-continue`, etc.\n4. Open `docs/index.html` in a browser and verify skill names display as `/magic:start`, `/magic:commit`, etc.\n\n## Checklist\n\n- [x] My code follows the project's style guidelines\n- [x] I have performed a self-review of my code\n- [ ] I have commented my code where necessary\n- [x] I have updated the documentation accordingly\n- [ ] My changes generate no new warnings\n- [ ] I have added/updated tests if applicable\n- [ ] All linters pass locally\n- [ ] I have updated CHANGELOG.md (if applicable)\n\n## Additional Notes\n\nThis is a pure text rename — 208 insertions and 208 deletions across 17 files, perfectly symmetrical. The key distinction is between **skill names** (changed to `magic:*`) and **folder/path names** (kept as `magic-*`).