### PR TITLE
[#71] feat(install): add preflight checks, rollback mechanism, and dry-run mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run yamllint
         run: |
-          pip install yamllint
+          pip install --break-system-packages yamllint
           npm run lint:yaml
 
       - name: Run ESLint
@@ -160,6 +160,25 @@ jobs:
       - name: Verify prerequisites check
         run: |
           # Test that the script correctly identifies missing prerequisites
-          # (claude won't be installed in CI, so it should fail gracefully)
-          bash install/install.sh 2>&1 | grep -q "prerequisites" || true
+          # (claude won't be installed in CI, so it should fail with actionable message)
+          OUTPUT=$(bash install/install.sh 2>&1 || true)
+          echo "$OUTPUT"
+          # Should mention the missing tool name
+          echo "$OUTPUT" | grep -q "claude" || { echo "FAIL: output should mention 'claude'"; exit 1; }
+          # Should include an install suggestion
+          HAS_HINT=false
+          echo "$OUTPUT" | grep -q "Install:" && HAS_HINT=true
+          echo "$OUTPUT" | grep -q "claude.ai/download" && HAS_HINT=true
+          [ "$HAS_HINT" = true ] || { echo "FAIL: should include install suggestion"; exit 1; }
+          # Should report missing prerequisites
+          echo "$OUTPUT" | grep -q "prerequisites" || { echo "FAIL: output should mention prerequisites"; exit 1; }
+        shell: bash
+
+      - name: Test --dry-run flag
+        run: |
+          # --dry-run should exit 0 (preflight will still fail for missing claude)
+          # but we can verify it prints the dry-run banner before failing
+          OUTPUT=$(bash install/install.sh --dry-run 2>&1 || true)
+          echo "$OUTPUT"
+          echo "$OUTPUT" | grep -q "\[DRY RUN\]" || { echo "FAIL: output should contain [DRY RUN]"; exit 1; }
         shell: bash

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
 # Magic Slash - Installation script
 # Usage: curl -fsSL https://magic-slash.io/install.sh | bash
+# Flags: --dry-run  (preview changes without modifying anything)
 
 set -e
+
+# ============================================
+# ARGUMENT PARSING
+# ============================================
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=true
+      ;;
+  esac
+done
 
 # ============================================
 # COLORS AND HELPERS
@@ -10,6 +23,7 @@ set -e
 GREEN='\033[0;32m'
 CYAN='\033[0;36m'
 YELLOW='\033[1;33m'
+RED='\033[0;31m'
 BOLD='\033[1m'
 DIM='\033[2m'
 NC='\033[0m'
@@ -17,11 +31,81 @@ NC='\033[0m'
 hide_cursor() { printf '\033[?25l'; }
 show_cursor() { printf '\033[?25h'; }
 
-cleanup() {
+# ============================================
+# PLATFORM DETECTION
+# ============================================
+detect_platform() {
+  case "$(uname -s)" in
+    Darwin) PLATFORM="macOS" ;;
+    Linux)  PLATFORM="Linux" ;;
+    *)      PLATFORM="unknown" ;;
+  esac
+}
+detect_platform
+
+# Platform-aware install suggestion for a given tool
+suggest_install_cmd() {
+  local tool="$1"
+  case "$tool" in
+    claude)
+      echo "https://claude.ai/download"
+      ;;
+    node|jq|gh|git)
+      # apt package for node is "nodejs", everything else matches the tool name
+      local pkg="$tool"
+      [ "$tool" = "node" ] && pkg="nodejs"
+      if [ "$PLATFORM" = "macOS" ]; then
+        echo "brew install $tool"
+      else
+        echo "sudo apt install $pkg"
+      fi
+      ;;
+    *)
+      echo "(see https://google.com/search?q=install+$tool)"
+      ;;
+  esac
+}
+
+# ============================================
+# ROLLBACK MECHANISM
+# ============================================
+ROLLBACK_ACTIONS=()
+INSTALL_SUCCESS=false
+
+# Push a rollback action (will be executed in reverse order on failure)
+push_rollback() {
+  ROLLBACK_ACTIONS+=("$1")
+}
+
+rollback_and_cleanup() {
+  local exit_code=$?
   show_cursor
   echo ""
+
+  if [ "$exit_code" -ne 0 ] && [ "$INSTALL_SUCCESS" = false ] && [ "$DRY_RUN" = false ]; then
+    if [ ${#ROLLBACK_ACTIONS[@]} -gt 0 ]; then
+      echo -e "   ${RED}Installation failed — rolling back changes...${NC}"
+      echo ""
+      # Execute rollback actions in reverse order
+      for (( i=${#ROLLBACK_ACTIONS[@]}-1; i>=0; i-- )); do
+        local action="${ROLLBACK_ACTIONS[$i]}"
+        echo -e "   ${DIM}Rollback: $action${NC}"
+        eval "$action" 2>/dev/null || true
+      done
+      echo ""
+      echo -e "   ${YELLOW}Rollback complete. Your system has been restored.${NC}"
+    fi
+  fi
+
+  # Clean up backup files on success
+  if [ "$INSTALL_SUCCESS" = true ]; then
+    rm -f "$HOME/.claude/settings.json.magic-slash.bak" 2>/dev/null || true
+    rm -f "$HOME/.config/magic-slash/config.json.magic-slash.bak" 2>/dev/null || true
+    # Clean up skills backup temp directory
+    [ -n "${SKILLS_BACKUP_DIR:-}" ] && rm -rf "$SKILLS_BACKUP_DIR" 2>/dev/null || true
+  fi
 }
-trap cleanup EXIT INT TERM
+trap rollback_and_cleanup EXIT INT TERM
 
 # Arrow key selection menu
 # Usage: select_option "Option1" "Option2" ...
@@ -42,7 +126,7 @@ select_option() {
 
     # Display options
     for i in "${!options[@]}"; do
-      if [ $i -eq $selected ]; then
+      if [ "$i" -eq "$selected" ]; then
         echo -e "   ${GREEN}→ ${BOLD}${options[$i]}${NC}   "
       else
         echo -e "     ${DIM}${options[$i]}${NC}   "
@@ -60,11 +144,11 @@ select_option() {
       case $key in
         '[A') # Up
           ((selected--))
-          [ $selected -lt 0 ] && selected=$((count - 1))
+          [ "$selected" -lt 0 ] && selected=$((count - 1))
           ;;
         '[B') # Down
           ((selected++))
-          [ $selected -ge $count ] && selected=0
+          [ "$selected" -ge "$count" ] && selected=0
           ;;
       esac
     elif [[ $key == '' ]]; then # Enter
@@ -95,6 +179,14 @@ print_logo() {
 }
 
 print_logo
+
+if [ "$DRY_RUN" = true ]; then
+  echo -e "   ${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo -e "   ${CYAN}[DRY RUN] No changes will be made${NC}"
+  echo -e "   ${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo ""
+fi
+
 echo "  Installing /magic:start, /magic:continue, /magic:commit, /magic:pr, /magic:review, /magic:resolve and /magic:done"
 echo ""
 
@@ -129,7 +221,12 @@ if [ -f "$CONFIG_FILE" ]; then
       echo -e "   ${DIM}What would you like to do?${NC}"
       echo ""
 
-      select_option "Reconfigure (GitHub auth, repositories...)" "Cancel"
+      if [ "$DRY_RUN" = true ]; then
+        echo -e "   ${CYAN}[DRY RUN]${NC} would: prompt for reconfigure or cancel"
+        SELECT_RESULT=0
+      else
+        select_option "Reconfigure (GitHub auth, repositories...)" "Cancel"
+      fi
 
       if [ $SELECT_RESULT -eq 1 ]; then
         echo ""
@@ -144,7 +241,12 @@ if [ -f "$CONFIG_FILE" ]; then
       echo -e "   ${DIM}What would you like to do?${NC}"
       echo ""
 
-      select_option "Update to v$CURRENT_VERSION" "Keep v$INSTALLED_VERSION"
+      if [ "$DRY_RUN" = true ]; then
+        echo -e "   ${CYAN}[DRY RUN]${NC} would: prompt for update or keep"
+        SELECT_RESULT=0
+      else
+        select_option "Update to v$CURRENT_VERSION" "Keep v$INSTALLED_VERSION"
+      fi
 
       if [ $SELECT_RESULT -eq 1 ]; then
         echo ""
@@ -161,37 +263,76 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 
 # ============================================
-# 1. PREREQUISITES CHECK
+# 1. PREFLIGHT CHECKS
 # ============================================
 echo "1. Checking prerequisites..."
 echo ""
 
+# Check a required command, optionally with minimum major version
+# Usage: check_command "tool" [min_major_version]
 check_command() {
-  if ! command -v "$1" &> /dev/null; then
-    echo "   ❌ $1 is not installed"
+  local tool="$1"
+  local min_version="${2:-}"
+
+  if ! command -v "$tool" &> /dev/null; then
+    local install_hint
+    install_hint=$(suggest_install_cmd "$tool")
+    echo -e "   ${RED}❌ $tool is not installed${NC}"
+    echo -e "      → Install: ${BOLD}$install_hint${NC}"
     return 1
-  else
-    echo "   ✓ $1"
+  fi
+
+  # Version check if minimum version specified
+  if [ -n "$min_version" ]; then
+    local actual_version
+    case "$tool" in
+      node)
+        actual_version=$(node -v | sed 's/^v//')
+        ;;
+      *)
+        actual_version=$("$tool" --version 2>/dev/null | head -1 | sed 's/[^0-9.]//g')
+        ;;
+    esac
+
+    local actual_major
+    actual_major=$(echo "$actual_version" | cut -d. -f1)
+
+    if [ -n "$actual_major" ] && [ "$actual_major" -lt "$min_version" ] 2>/dev/null; then
+      local install_hint
+      install_hint=$(suggest_install_cmd "$tool")
+      echo -e "   ${RED}❌ $tool v$actual_version found, but v$min_version+ is required${NC}"
+      echo -e "      → Upgrade: ${BOLD}$install_hint${NC}"
+      return 1
+    fi
+
+    echo "   ✓ $tool (v$actual_version)"
     return 0
   fi
+
+  echo "   ✓ $tool"
+  return 0
 }
 
 MISSING=false
 
 check_command "claude" || MISSING=true
-check_command "node" || MISSING=true
+check_command "node" 20 || MISSING=true
 check_command "git" || MISSING=true
 check_command "jq" || MISSING=true
+
+# Optional: gh CLI (informational warning only)
+if ! command -v "gh" &> /dev/null; then
+  gh_install_cmd=$(suggest_install_cmd "gh")
+  echo ""
+  echo -e "   ${YELLOW}ℹ️  gh CLI not found${NC} — threaded reply resolution in magic:resolve will use a fallback."
+  echo "      All other skills work normally."
+  echo -e "      Install it later with ${BOLD}$gh_install_cmd${NC}"
+fi
 
 echo ""
 
 if [ "$MISSING" = true ]; then
-  echo "❌ Some prerequisites are missing. Please install them before continuing."
-  echo ""
-  echo "   • Claude Code : https://claude.ai/download"
-  echo "   • Node.js     : https://nodejs.org"
-  echo "   • Git         : https://git-scm.com"
-  echo "   • jq          : brew install jq (macOS) / apt install jq (Linux)"
+  echo -e "${RED}❌ Some required prerequisites are missing. Please install them before continuing.${NC}"
   echo ""
   exit 1
 fi
@@ -214,8 +355,13 @@ SKIP_JIRA=false
 if [ -f "$CLAUDE_CONFIG" ] && jq -e '.mcpServers.atlassian' "$CLAUDE_CONFIG" > /dev/null 2>&1; then
   echo "   MCP Atlassian already configured (OAuth)"
   echo ""
-  read -p "   Reconfigure? (y/N) " RECONFIG < /dev/tty
-  [ "$RECONFIG" != "y" ] && SKIP_JIRA=true
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "   ${CYAN}[DRY RUN]${NC} would: prompt to reconfigure Atlassian MCP"
+    SKIP_JIRA=true
+  else
+    read -rp "   Reconfigure? (y/N) " RECONFIG < /dev/tty
+    [ "$RECONFIG" != "y" ] && SKIP_JIRA=true
+  fi
   echo ""
 fi
 
@@ -228,21 +374,29 @@ if [ "$SKIP_JIRA" = false ]; then
   echo "   • An Atlassian Cloud site (Jira and/or Confluence)"
   echo "   • Being logged into your Atlassian account in your browser"
   echo ""
-  read -p "   Continue installation? (Y/n) " CONTINUE_JIRA < /dev/tty
 
-  if [ "$CONTINUE_JIRA" = "n" ] || [ "$CONTINUE_JIRA" = "N" ]; then
-    echo "   ⏭️  MCP Atlassian configuration skipped"
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "   ${CYAN}[DRY RUN]${NC} would: prompt to continue Atlassian setup"
+    echo -e "   ${CYAN}[DRY RUN]${NC} would: claude mcp add atlassian --scope user --transport http https://mcp.atlassian.com/v1/mcp"
   else
-    # Add MCP Atlassian via claude mcp add (HTTP server with OAuth)
-    claude mcp add atlassian \
-      --scope user \
-      --transport http \
-      https://mcp.atlassian.com/v1/mcp
+    read -rp "   Continue installation? (Y/n) " CONTINUE_JIRA < /dev/tty
 
-    echo "   ✅ MCP Atlassian configured"
-    echo ""
-    echo "   ℹ️  On first use, an OAuth window will open in your browser"
-    echo "      to authorize Claude to access your Atlassian workspace."
+    if [ "$CONTINUE_JIRA" = "n" ] || [ "$CONTINUE_JIRA" = "N" ]; then
+      echo "   ⏭️  MCP Atlassian configuration skipped"
+    else
+      # Add MCP Atlassian via claude mcp add (HTTP server with OAuth)
+      claude mcp add atlassian \
+        --scope user \
+        --transport http \
+        https://mcp.atlassian.com/v1/mcp
+
+      push_rollback "claude mcp remove atlassian --scope user 2>/dev/null || true"
+
+      echo "   ✅ MCP Atlassian configured"
+      echo ""
+      echo "   ℹ️  On first use, an OAuth window will open in your browser"
+      echo "      to authorize Claude to access your Atlassian workspace."
+    fi
   fi
 else
   echo "   ✅ MCP Atlassian kept"
@@ -262,8 +416,13 @@ SKIP_GITHUB=false
 if [ -f "$CLAUDE_CONFIG" ] && jq -e '.mcpServers.github' "$CLAUDE_CONFIG" > /dev/null 2>&1; then
   echo "   MCP GitHub already configured"
   echo ""
-  read -p "   Reconfigure? (y/N) " RECONFIG_GH < /dev/tty
-  [ "$RECONFIG_GH" != "y" ] && SKIP_GITHUB=true
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "   ${CYAN}[DRY RUN]${NC} would: prompt to reconfigure GitHub MCP"
+    SKIP_GITHUB=true
+  else
+    read -rp "   Reconfigure? (y/N) " RECONFIG_GH < /dev/tty
+    [ "$RECONFIG_GH" != "y" ] && SKIP_GITHUB=true
+  fi
   echo ""
 fi
 
@@ -273,17 +432,24 @@ if [ "$SKIP_GITHUB" = false ]; then
   echo "   (Required permissions: repo, read:org)"
   echo ""
 
-  read -sp "   GitHub Personal Access Token: " GITHUB_TOKEN < /dev/tty
-  echo ""
-  echo ""
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "   ${CYAN}[DRY RUN]${NC} would: prompt for GitHub Personal Access Token"
+    echo -e "   ${CYAN}[DRY RUN]${NC} would: claude mcp add github --scope user -e GITHUB_PERSONAL_ACCESS_TOKEN=*** -- npx -y @modelcontextprotocol/server-github"
+  else
+    read -rsp "   GitHub Personal Access Token: " GITHUB_TOKEN < /dev/tty
+    echo ""
+    echo ""
 
-  # Add MCP GitHub via claude mcp add
-  claude mcp add github \
-    --scope user \
-    -e GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_TOKEN" \
-    -- npx -y @modelcontextprotocol/server-github
+    # Add MCP GitHub via claude mcp add
+    claude mcp add github \
+      --scope user \
+      -e GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_TOKEN" \
+      -- npx -y @modelcontextprotocol/server-github
 
-  echo "   ✅ MCP GitHub configured"
+    push_rollback "claude mcp remove github --scope user 2>/dev/null || true"
+
+    echo "   ✅ MCP GitHub configured"
+  fi
 else
   echo "   ✅ MCP GitHub kept"
 fi
@@ -299,39 +465,56 @@ echo "4. Installing /magic:start, /magic:continue, /magic:commit, /magic:pr, /ma
 echo ""
 
 SKILLS_DIR="$HOME/.claude/skills"
-mkdir -p "$SKILLS_DIR"
 
-# Remove old unprefixed skills from previous versions
-for skill in start "continue" commit "done"; do
-  if [ -d "$SKILLS_DIR/$skill" ]; then
-    rm -rf "${SKILLS_DIR:?}/${skill:?}"
-    echo "   ↗️  Migrated: /$skill → /magic:$skill"
-  fi
-done
-
-# Copy skills from local or download from GitHub
-if [ -d "$SCRIPT_DIR/../skills" ]; then
-  # Local installation
-  cp -r "$SCRIPT_DIR/../skills/"* "$SKILLS_DIR/"
+if [ "$DRY_RUN" = true ]; then
+  echo -e "   ${CYAN}[DRY RUN]${NC} would: create $SKILLS_DIR"
+  echo -e "   ${CYAN}[DRY RUN]${NC} would: install skills (magic-start, magic-continue, magic-commit, magic-pr, magic-review, magic-resolve, magic-done)"
 else
-  # Remote installation - download full skill folders from GitHub
-  TREE_JSON=$(curl -fsSL "https://api.github.com/repos/xrequillart/magic-slash/git/trees/main?recursive=1")
+  mkdir -p "$SKILLS_DIR"
+
+  # Track skills that existed before for rollback
+  SKILLS_BACKUP_DIR=$(mktemp -d)
   for skill in magic-start magic-continue magic-commit magic-pr magic-review magic-resolve magic-done; do
-    mkdir -p "$SKILLS_DIR/$skill"
-    # Extract file paths for this skill from the tree
-    SKILL_FILES=$(echo "$TREE_JSON" | grep -o "\"path\" *: *\"skills/$skill/[^\"]*\"" | sed 's/"path" *: *"skills\///;s/"//' | sed "s|^$skill/||")
-    if [ -z "$SKILL_FILES" ]; then
-      # Fallback: download SKILL.md and image.png directly
-      curl -fsSL "https://raw.githubusercontent.com/xrequillart/magic-slash/main/skills/$skill/SKILL.md" > "$SKILLS_DIR/$skill/SKILL.md"
-      curl -fsSL "https://raw.githubusercontent.com/xrequillart/magic-slash/main/skills/$skill/image.png" -o "$SKILLS_DIR/$skill/image.png" 2>/dev/null || true
+    if [ -d "$SKILLS_DIR/$skill" ]; then
+      cp -r "$SKILLS_DIR/$skill" "$SKILLS_BACKUP_DIR/$skill"
+      push_rollback "rm -rf '${SKILLS_DIR:?}/${skill:?}' && cp -r '$SKILLS_BACKUP_DIR/$skill' '$SKILLS_DIR/$skill'"
     else
-      echo "$SKILL_FILES" | while IFS= read -r file; do
-        [ -z "$file" ] && continue
-        mkdir -p "$SKILLS_DIR/$skill/$(dirname "$file")"
-        curl -fsSL "https://raw.githubusercontent.com/xrequillart/magic-slash/main/skills/$skill/$file" -o "$SKILLS_DIR/$skill/$file" 2>/dev/null || true
-      done
+      push_rollback "rm -rf '${SKILLS_DIR:?}/${skill:?}'"
     fi
   done
+
+  # Remove old unprefixed skills from previous versions
+  for skill in start "continue" commit "done"; do
+    if [ -d "$SKILLS_DIR/$skill" ]; then
+      rm -rf "${SKILLS_DIR:?}/${skill:?}"
+      echo "   ↗️  Migrated: /$skill → /magic:$skill"
+    fi
+  done
+
+  # Copy skills from local or download from GitHub
+  if [ -d "$SCRIPT_DIR/../skills" ]; then
+    # Local installation
+    cp -r "$SCRIPT_DIR/../skills/"* "$SKILLS_DIR/"
+  else
+    # Remote installation - download full skill folders from GitHub
+    TREE_JSON=$(curl -fsSL "https://api.github.com/repos/xrequillart/magic-slash/git/trees/main?recursive=1")
+    for skill in magic-start magic-continue magic-commit magic-pr magic-review magic-resolve magic-done; do
+      mkdir -p "$SKILLS_DIR/$skill"
+      # Extract file paths for this skill from the tree
+      SKILL_FILES=$(echo "$TREE_JSON" | grep -o "\"path\" *: *\"skills/$skill/[^\"]*\"" | sed 's/"path" *: *"skills\///;s/"//' | sed "s|^$skill/||")
+      if [ -z "$SKILL_FILES" ]; then
+        # Fallback: download SKILL.md and image.png directly
+        curl -fsSL "https://raw.githubusercontent.com/xrequillart/magic-slash/main/skills/$skill/SKILL.md" > "$SKILLS_DIR/$skill/SKILL.md"
+        curl -fsSL "https://raw.githubusercontent.com/xrequillart/magic-slash/main/skills/$skill/image.png" -o "$SKILLS_DIR/$skill/image.png" 2>/dev/null || true
+      else
+        echo "$SKILL_FILES" | while IFS= read -r file; do
+          [ -z "$file" ] && continue
+          mkdir -p "$SKILLS_DIR/$skill/$(dirname "$file")"
+          curl -fsSL "https://raw.githubusercontent.com/xrequillart/magic-slash/main/skills/$skill/$file" -o "$SKILLS_DIR/$skill/$file" 2>/dev/null || true
+        done
+      fi
+    done
+  fi
 fi
 
 echo "   ✅ Skills installed (magic:start, magic:continue, magic:commit, magic:pr, magic:review, magic:resolve, magic:done)"
@@ -355,70 +538,83 @@ echo ""
 echo "   Configuring permissions for Magic Slash..."
 
 CLAUDE_SETTINGS="$HOME/.claude/settings.json"
-mkdir -p "$HOME/.claude"
 
-if [ ! -f "$CLAUDE_SETTINGS" ]; then
-  echo '{}' > "$CLAUDE_SETTINGS"
-fi
+if [ "$DRY_RUN" = true ]; then
+  echo -e "   ${CYAN}[DRY RUN]${NC} would: update $CLAUDE_SETTINGS with MCP tool permissions"
+else
+  mkdir -p "$HOME/.claude"
 
-# Permissions needed by magic:* skills
-MAGIC_SLASH_PERMS=(
-  # Desktop communication
-  'Bash(*http://127.0.0.1:*)'
-  # GitHub MCP tools
-  'mcp__github__get_issue'
-  'mcp__github__add_issue_comment'
-  'mcp__github__update_issue'
-  'mcp__github__list_pull_requests'
-  'mcp__github__get_pull_request'
-  'mcp__github__get_pull_request_files'
-  'mcp__github__get_pull_request_comments'
-  'mcp__github__get_pull_request_reviews'
-  'mcp__github__create_pull_request'
-  'mcp__github__create_pull_request_review'
-  # Atlassian MCP tools
-  'mcp__atlassian__getAccessibleAtlassianResources'
-  'mcp__atlassian__getJiraIssue'
-  'mcp__atlassian__getTransitionsForJiraIssue'
-  'mcp__atlassian__transitionJiraIssue'
-  'mcp__atlassian__addCommentToJiraIssue'
-  # Common Bash commands used by skills
-  'Bash(git *)'
-  'Bash(npm *)'
-  'Bash(yarn *)'
-  'Bash(pnpm *)'
-  'Bash(bun *)'
-  'Bash(jq *)'
-  'Bash(gh *)'
-)
+  if [ ! -f "$CLAUDE_SETTINGS" ]; then
+    echo '{}' > "$CLAUDE_SETTINGS"
+    push_rollback "rm -f '$CLAUDE_SETTINGS'"
+  else
+    # Back up settings before modifying
+    cp "$CLAUDE_SETTINGS" "$CLAUDE_SETTINGS.magic-slash.bak"
+    push_rollback "mv '$CLAUDE_SETTINGS.magic-slash.bak' '$CLAUDE_SETTINGS'"
+  fi
 
-TMP_SETTINGS=$(mktemp)
-cp "$CLAUDE_SETTINGS" "$TMP_SETTINGS"
-for perm in "${MAGIC_SLASH_PERMS[@]}"; do
-  NEXT_TMP=$(mktemp)
-  jq --arg perm "$perm" '
+  # Permissions needed by magic:* skills
+  MAGIC_SLASH_PERMS=(
+    # Desktop communication
+    'Bash(*http://127.0.0.1:*)'
+    # GitHub MCP tools
+    'mcp__github__get_issue'
+    'mcp__github__add_issue_comment'
+    'mcp__github__update_issue'
+    'mcp__github__list_pull_requests'
+    'mcp__github__get_pull_request'
+    'mcp__github__get_pull_request_files'
+    'mcp__github__get_pull_request_comments'
+    'mcp__github__get_pull_request_reviews'
+    'mcp__github__create_pull_request'
+    'mcp__github__create_pull_request_review'
+    # Atlassian MCP tools
+    'mcp__atlassian__getAccessibleAtlassianResources'
+    'mcp__atlassian__getJiraIssue'
+    'mcp__atlassian__getTransitionsForJiraIssue'
+    'mcp__atlassian__transitionJiraIssue'
+    'mcp__atlassian__addCommentToJiraIssue'
+    # Common Bash commands used by skills
+    'Bash(git *)'
+    'Bash(npm *)'
+    'Bash(yarn *)'
+    'Bash(pnpm *)'
+    'Bash(bun *)'
+    'Bash(jq *)'
+    'Bash(gh *)'
+  )
+
+  # Build a JSON array of all permissions, then merge in a single jq call
+  PERMS_JSON=$(printf '%s\n' "${MAGIC_SLASH_PERMS[@]}" | jq -R . | jq -s .)
+  TMP_SETTINGS=$(mktemp)
+  jq --argjson newPerms "$PERMS_JSON" '
     .permissions //= {} |
     .permissions.allow //= [] |
-    if (.permissions.allow | index($perm)) then .
-    else .permissions.allow += [$perm]
-    end
-  ' "$TMP_SETTINGS" > "$NEXT_TMP" && mv "$NEXT_TMP" "$TMP_SETTINGS"
-done
-mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+    .permissions.allow += ($newPerms - .permissions.allow)
+  ' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+fi
 
 echo "   ✅ Permissions configured (MCP tools + common commands auto-allowed)"
 echo ""
 
 # Create initial config file (repositories will be configured in desktop app)
-mkdir -p "$CONFIG_DIR"
-if [ ! -f "$CONFIG_FILE" ]; then
-  jq -n --arg version "$CURRENT_VERSION" \
-    '{"version": $version, "repositories": {}}' > "$CONFIG_FILE"
+if [ "$DRY_RUN" = true ]; then
+  echo -e "   ${CYAN}[DRY RUN]${NC} would: create or update $CONFIG_FILE with version $CURRENT_VERSION"
 else
-  # Update version in existing config file
-  TMP_FILE=$(mktemp)
-  jq --arg version "$CURRENT_VERSION" \
-    '.version = $version | del(.installationMode)' "$CONFIG_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$CONFIG_FILE"
+  mkdir -p "$CONFIG_DIR"
+  if [ ! -f "$CONFIG_FILE" ]; then
+    jq -n --arg version "$CURRENT_VERSION" \
+      '{"version": $version, "repositories": {}}' > "$CONFIG_FILE"
+    push_rollback "rm -f '$CONFIG_FILE'"
+  else
+    # Back up config before modifying
+    cp "$CONFIG_FILE" "$CONFIG_FILE.magic-slash.bak"
+    push_rollback "mv '$CONFIG_FILE.magic-slash.bak' '$CONFIG_FILE'"
+    # Update version in existing config file
+    TMP_FILE=$(mktemp)
+    jq --arg version "$CURRENT_VERSION" \
+      '.version = $version | del(.installationMode)' "$CONFIG_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$CONFIG_FILE"
+  fi
 fi
 
 # ============================================
@@ -436,8 +632,13 @@ if [ -d "/Applications/Magic Slash.app" ]; then
   INSTALLED_APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "/Applications/Magic Slash.app/Contents/Info.plist" 2>/dev/null || echo "unknown")
   echo "   Magic Slash Desktop already installed (v$INSTALLED_APP_VERSION)"
   echo ""
-  read -p "   Reinstall/Update? (y/N) " REINSTALL_DESKTOP < /dev/tty
-  [ "$REINSTALL_DESKTOP" != "y" ] && SKIP_DESKTOP=true
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "   ${CYAN}[DRY RUN]${NC} would: prompt to reinstall/update desktop app"
+    SKIP_DESKTOP=true
+  else
+    read -rp "   Reinstall/Update? (y/N) " REINSTALL_DESKTOP < /dev/tty
+    [ "$REINSTALL_DESKTOP" != "y" ] && SKIP_DESKTOP=true
+  fi
   echo ""
 fi
 
@@ -458,50 +659,55 @@ if [ "$SKIP_DESKTOP" = false ]; then
   echo "   Architecture: ${ARCH}"
   echo ""
 
-  # Download DMG from GitHub releases
-  if curl -fsSL -o "$TMP_DMG" "$DMG_URL"; then
-    echo "   ✅ Downloaded successfully"
-    echo ""
-
-    # Open DMG for manual installation
-    echo "   Opening the disk image..."
-    echo ""
-    open "$TMP_DMG"
-
-    echo "   ┌─────────────────────────────────────────────────┐"
-    echo "   │                                                 │"
-    echo "   │   A Finder window should have opened.           │"
-    echo "   │                                                 │"
-    echo "   │   → Drag 'Magic Slash' into the                 │"
-    echo "   │     'Applications' folder.                      │"
-    echo "   │                                                 │"
-    echo "   │   If prompted to replace, click 'Replace'.      │"
-    echo "   │                                                 │"
-    echo "   └─────────────────────────────────────────────────┘"
-    echo ""
-    read -p "   Press Enter once you've dragged the app to Applications... " < /dev/tty
-    echo ""
-
-    # Verify installation
-    if [ -d "/Applications/Magic Slash.app" ]; then
-      echo "   ✅ Desktop app installed"
-    else
-      echo -e "   ${YELLOW}⚠️  Magic Slash.app not found in /Applications${NC}"
-      echo "   → Make sure you dragged it to the Applications folder."
-      echo "   → You can also do it later from the DMG."
-    fi
-
-    # Eject DMG
-    MOUNT_POINT=$(hdiutil info | grep "Magic" | awk -F'\t' '{print $NF}' | head -1 | xargs)
-    if [ -n "$MOUNT_POINT" ]; then
-      hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
-    fi
-
-    # Cleanup
-    rm -f "$TMP_DMG" 2>/dev/null
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "   ${CYAN}[DRY RUN]${NC} would: download $DMG_URL"
+    echo -e "   ${CYAN}[DRY RUN]${NC} would: open DMG and prompt to drag app to /Applications"
   else
-    echo "   ⚠️  Could not download DMG from GitHub releases"
-    echo "   → Download manually: https://github.com/xrequillart/magic-slash/releases"
+    # Download DMG from GitHub releases
+    if curl -fsSL -o "$TMP_DMG" "$DMG_URL"; then
+      echo "   ✅ Downloaded successfully"
+      echo ""
+
+      # Open DMG for manual installation
+      echo "   Opening the disk image..."
+      echo ""
+      open "$TMP_DMG"
+
+      echo "   ┌─────────────────────────────────────────────────┐"
+      echo "   │                                                 │"
+      echo "   │   A Finder window should have opened.           │"
+      echo "   │                                                 │"
+      echo "   │   → Drag 'Magic Slash' into the                 │"
+      echo "   │     'Applications' folder.                      │"
+      echo "   │                                                 │"
+      echo "   │   If prompted to replace, click 'Replace'.      │"
+      echo "   │                                                 │"
+      echo "   └─────────────────────────────────────────────────┘"
+      echo ""
+      read -rp "   Press Enter once you've dragged the app to Applications... " < /dev/tty
+      echo ""
+
+      # Verify installation
+      if [ -d "/Applications/Magic Slash.app" ]; then
+        echo "   ✅ Desktop app installed"
+      else
+        echo -e "   ${YELLOW}⚠️  Magic Slash.app not found in /Applications${NC}"
+        echo "   → Make sure you dragged it to the Applications folder."
+        echo "   → You can also do it later from the DMG."
+      fi
+
+      # Eject DMG
+      MOUNT_POINT=$(hdiutil info | grep "Magic" | awk -F'\t' '{print $NF}' | head -1 | xargs)
+      if [ -n "$MOUNT_POINT" ]; then
+        hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+      fi
+
+      # Cleanup
+      rm -f "$TMP_DMG" 2>/dev/null
+    else
+      echo "   ⚠️  Could not download DMG from GitHub releases"
+      echo "   → Download manually: https://github.com/xrequillart/magic-slash/releases"
+    fi
   fi
 else
   echo "   ✅ Desktop app kept"
@@ -512,6 +718,10 @@ echo ""
 # ============================================
 # 6. DONE
 # ============================================
+
+# Mark installation as successful (prevents rollback in trap)
+INSTALL_SUCCESS=true
+
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 echo "✅ Magic Slash v$CURRENT_VERSION installed successfully!"


### PR DESCRIPTION
## Description

Improve `install.sh` robustness with preflight checks (node >= 20, claude, jq required; gh optional), platform-aware error messages, trap-based rollback on failure, and `--dry-run` mode.

## Related Issue

Closes #71

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **Preflight checks**: `node` >= 20 with version validation, `claude`/`jq`/`git` required with platform-aware install suggestions (`brew` on macOS, `apt` on Ubuntu), `gh` optional with informational warning
- **`--dry-run` flag**: previews all operations without executing them, bypasses interactive prompts, prints `[DRY RUN] would: ...` for each mutating step
- **Rollback mechanism**: `ROLLBACK_ACTIONS[]` array tracks every mutation (MCP add, skills copy, settings.json, config.json); `rollback_and_cleanup()` trap executes inverse actions in LIFO order on failure; backups created before modifying existing files
- **Platform detection**: `uname -s` → macOS/Linux; `suggest_install_cmd()` returns platform-specific install commands
- **Performance**: replaced 22 sequential `jq` invocations for permissions with a single `jq` call using array subtraction
- **CI improvements**: enhanced `install-test` job with assertions on missing tool names and install suggestions; new `Test --dry-run flag` step; fixed `pip install --break-system-packages` for Ubuntu 24.04+

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint:yaml` — passes clean)
- [x] Tested installation script (`--dry-run` mode end-to-end)

### Test Steps

1. Run `bash install/install.sh --dry-run` — should display `[DRY RUN] No changes will be made` banner and preview all steps without modifying anything
2. Verify preflight checks: temporarily rename `jq` and run the script — should display `❌ jq is not installed` with the platform-specific install command (`brew install jq` on macOS)
3. Verify `gh` optional check: uninstall `gh` and run — should display informational warning, not block installation
4. Verify rollback: add `exit 1` after the skills installation step and run — should clean up skills, restore settings.json from backup
5. Verify CI: push and check the `install-test` job passes on both Ubuntu and macOS runners

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All linters pass locally

## Linked Issues

- Closes #71