### PR TITLE
[#73] Make Atlassian integration optional in installer

### DIFF
--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -89,6 +89,11 @@ export function readConfig(): Config {
       needsWrite = true
     }
 
+    if (!config.integrations) {
+      config.integrations = { github: true, atlassian: true }
+      needsWrite = true
+    }
+
     // Ensure all agents have a splitPane value
     if (config.agents && config.agents.length > 0) {
       for (const agent of config.agents) {

--- a/desktop/src/main/config/migrate.ts
+++ b/desktop/src/main/config/migrate.ts
@@ -82,6 +82,12 @@ export function migrateConfig(appVersion?: string): boolean {
     }
   }
 
+  // Migrate integrations (default: both enabled for backward compatibility)
+  if (!config.integrations) {
+    config.integrations = { github: true, atlassian: true }
+    changed = true
+  }
+
   if (changed) {
     // Create backup before writing migrated config
     createBackup()

--- a/desktop/src/main/config/schema-validator.test.ts
+++ b/desktop/src/main/config/schema-validator.test.ts
@@ -174,11 +174,11 @@ describe('validateConfig', () => {
     expect(result.errors.some(e => e.includes('version') && e.includes('semver'))).toBe(true)
   })
 
-  it('should fail for empty repositories object', () => {
+  it('should pass for empty repositories object (fresh install)', () => {
     const config = { version: '1.0.0', repositories: {} }
     const result = validateConfig(config)
-    expect(result.valid).toBe(false)
-    expect(result.errors.some(e => e.includes('repositories') && e.includes('at least 1'))).toBe(true)
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
   })
 
   it('should fail for an invalid splitPane value on agent', () => {

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -80,6 +80,10 @@ export interface Config {
   agents?: Agent[]
   splitEnabled?: boolean
   splitActive?: boolean
+  integrations?: {
+    github: true
+    atlassian?: boolean
+  }
 }
 
 export interface PRTemplate {

--- a/install/config-schema.json
+++ b/install/config-schema.json
@@ -13,7 +13,6 @@
     },
     "repositories": {
       "type": "object",
-      "minProperties": 1,
       "description": "Map of repository name to its configuration",
       "additionalProperties": {
         "$ref": "#/definitions/RepositoryConfig"
@@ -34,9 +33,18 @@
       "type": "boolean",
       "description": "Whether split view is currently active"
     },
-    "theme": {
-      "type": "string",
-      "description": "UI theme name"
+    "integrations": {
+      "type": "object",
+      "properties": {
+        "github": {
+          "const": true
+        },
+        "atlassian": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Enabled integrations (github is always true)"
     },
     "installationMode": {
       "type": "string",

--- a/install/install.sh
+++ b/install/install.sh
@@ -80,6 +80,15 @@ push_rollback() {
 rollback_and_cleanup() {
   local exit_code=$?
   show_cursor
+
+  # If interrupted by user (Ctrl+C), show message and exit immediately
+  if [ "$exit_code" -eq 130 ] || [ "$INTERRUPTED" = true ]; then
+    echo ""
+    echo -e "   ${YELLOW}Installation cancelled by user.${NC}"
+    echo ""
+    exit 130
+  fi
+
   echo ""
 
   if [ "$exit_code" -ne 0 ] && [ "$INSTALL_SUCCESS" = false ] && [ "$DRY_RUN" = false ]; then
@@ -105,7 +114,9 @@ rollback_and_cleanup() {
     [ -n "${SKILLS_BACKUP_DIR:-}" ] && rm -rf "$SKILLS_BACKUP_DIR" 2>/dev/null || true
   fi
 }
-trap rollback_and_cleanup EXIT INT TERM
+INTERRUPTED=false
+trap rollback_and_cleanup EXIT
+trap 'INTERRUPTED=true; exit 130' INT TERM
 
 # Arrow key selection menu
 # Usage: select_option "Option1" "Option2" ...

--- a/install/install.sh
+++ b/install/install.sh
@@ -173,7 +173,6 @@ select_option() {
 
 # Logo color
 PURPLE='\033[0;35m'
-BLUE='\033[0;34m'
 
 print_logo() {
   echo ""

--- a/install/install.sh
+++ b/install/install.sh
@@ -349,14 +349,53 @@ echo "✅ All prerequisites are installed"
 echo ""
 
 # ============================================
+# 1b. INTEGRATION SELECTION
+# ============================================
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "   Which integrations do you want to use?"
+echo ""
+
+# Detect existing integration choice for pre-selection on reconfigure
+ATLASSIAN_ENABLED=true
+if [ -f "$CONFIG_FILE" ]; then
+  EXISTING_ATLASSIAN=$(jq -r '.integrations.atlassian // "true"' "$CONFIG_FILE" 2>/dev/null)
+  if [ "$EXISTING_ATLASSIAN" = "false" ]; then
+    ATLASSIAN_ENABLED=false
+  fi
+fi
+
+if [ "$DRY_RUN" = true ]; then
+  echo -e "   ${CYAN}[DRY RUN]${NC} would: prompt for integration selection"
+  echo -e "   ${CYAN}[DRY RUN]${NC} current: ATLASSIAN_ENABLED=$ATLASSIAN_ENABLED"
+else
+  if [ "$ATLASSIAN_ENABLED" = true ]; then
+    select_option "Atlassian + GitHub  (Jira, Confluence, PRs, issues, reviews)" "GitHub only         (PRs, issues, reviews)"
+  else
+    select_option "GitHub only         (PRs, issues, reviews)" "Atlassian + GitHub  (Jira, Confluence, PRs, issues, reviews)"
+  fi
+
+  if [ "$ATLASSIAN_ENABLED" = true ]; then
+    # First option was Atlassian+GitHub
+    [ $SELECT_RESULT -eq 1 ] && ATLASSIAN_ENABLED=false
+  else
+    # First option was GitHub only
+    [ $SELECT_RESULT -eq 1 ] && ATLASSIAN_ENABLED=true
+  fi
+fi
+
+echo ""
+
+CLAUDE_CONFIG="$HOME/.claude.json"
+
+if [ "$ATLASSIAN_ENABLED" = true ]; then
+# ============================================
 # 2. MCP ATLASSIAN CONFIGURATION (JIRA + CONFLUENCE)
 # ============================================
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 echo "2. MCP Atlassian configuration (Jira + Confluence)"
 echo ""
-
-CLAUDE_CONFIG="$HOME/.claude.json"
 
 # Check if MCP Atlassian is already configured
 SKIP_JIRA=false
@@ -411,6 +450,8 @@ else
 fi
 
 echo ""
+
+fi  # end ATLASSIAN_ENABLED check
 
 # ============================================
 # 3. MCP GITHUB CONFIGURATION
@@ -576,12 +617,6 @@ else
     'mcp__github__get_pull_request_reviews'
     'mcp__github__create_pull_request'
     'mcp__github__create_pull_request_review'
-    # Atlassian MCP tools
-    'mcp__atlassian__getAccessibleAtlassianResources'
-    'mcp__atlassian__getJiraIssue'
-    'mcp__atlassian__getTransitionsForJiraIssue'
-    'mcp__atlassian__transitionJiraIssue'
-    'mcp__atlassian__addCommentToJiraIssue'
     # Common Bash commands used by skills
     'Bash(git *)'
     'Bash(npm *)'
@@ -592,6 +627,17 @@ else
     'Bash(gh *)'
   )
 
+  # Atlassian MCP tools (only if enabled)
+  if [ "$ATLASSIAN_ENABLED" = true ]; then
+    MAGIC_SLASH_PERMS+=(
+      'mcp__atlassian__getAccessibleAtlassianResources'
+      'mcp__atlassian__getJiraIssue'
+      'mcp__atlassian__getTransitionsForJiraIssue'
+      'mcp__atlassian__transitionJiraIssue'
+      'mcp__atlassian__addCommentToJiraIssue'
+    )
+  fi
+
   # Build a JSON array of all permissions, then merge in a single jq call
   PERMS_JSON=$(printf '%s\n' "${MAGIC_SLASH_PERMS[@]}" | jq -R . | jq -s .)
   TMP_SETTINGS=$(mktemp)
@@ -600,6 +646,14 @@ else
     .permissions.allow //= [] |
     .permissions.allow += ($newPerms - .permissions.allow)
   ' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+
+  # Remove Atlassian permissions if switching to GitHub-only
+  if [ "$ATLASSIAN_ENABLED" = false ]; then
+    TMP_SETTINGS=$(mktemp)
+    jq '
+      .permissions.allow |= map(select(startswith("mcp__atlassian__") | not))
+    ' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+  fi
 fi
 
 echo "   ✅ Permissions configured (MCP tools + common commands auto-allowed)"
@@ -611,8 +665,8 @@ if [ "$DRY_RUN" = true ]; then
 else
   mkdir -p "$CONFIG_DIR"
   if [ ! -f "$CONFIG_FILE" ]; then
-    jq -n --arg version "$CURRENT_VERSION" \
-      '{"version": $version, "repositories": {}}' > "$CONFIG_FILE"
+    jq -n --arg version "$CURRENT_VERSION" --argjson atlassian "$ATLASSIAN_ENABLED" \
+      '{"version": $version, "integrations": {"github": true, "atlassian": $atlassian}, "repositories": {}}' > "$CONFIG_FILE"
     push_rollback "rm -f '$CONFIG_FILE'"
   else
     # Back up config before modifying
@@ -620,8 +674,8 @@ else
     push_rollback "mv '$CONFIG_FILE.magic-slash.bak' '$CONFIG_FILE'"
     # Update version in existing config file
     TMP_FILE=$(mktemp)
-    jq --arg version "$CURRENT_VERSION" \
-      '.version = $version | del(.installationMode)' "$CONFIG_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$CONFIG_FILE"
+    jq --arg version "$CURRENT_VERSION" --argjson atlassian "$ATLASSIAN_ENABLED" \
+      '.version = $version | .integrations = {"github": true, "atlassian": $atlassian} | del(.installationMode)' "$CONFIG_FILE" > "$TMP_FILE" && mv "$TMP_FILE" "$CONFIG_FILE"
   fi
 fi
 
@@ -735,7 +789,9 @@ echo ""
 echo "✅ Magic Slash v$CURRENT_VERSION installed successfully!"
 echo ""
 echo "Created files:"
+if [ "$ATLASSIAN_ENABLED" = true ]; then
 echo "  • MCP Atlassian  : ~/.claude.json (OAuth - Jira + Confluence)"
+fi
 echo "  • MCP GitHub     : ~/.claude.json"
 echo "  • Config         : ~/.config/magic-slash/config.json"
 echo "  • Skills         : ~/.claude/skills/{magic-start,magic-continue,magic-commit,magic-pr,magic-review,magic-resolve,magic-done}/SKILL.md"
@@ -751,7 +807,9 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 echo "🚀 You're ready! Try these commands in Claude Code:"
 echo ""
+if [ "$ATLASSIAN_ENABLED" = true ]; then
 echo "   /magic:start PROJ-123   Start a Jira ticket"
+fi
 echo "   /magic:start #42       Start a GitHub issue"
 echo "   /magic:commit          Create a commit"
 echo "   /magic:pr              Push and create a Pull Request"
@@ -762,7 +820,11 @@ echo ""
 echo "   💡 Type /magic: to see all commands"
 echo ""
 echo "   Or use natural language:"
+if [ "$ATLASSIAN_ENABLED" = true ]; then
 echo "   'démarre PROJ-123'  'ready to commit'  'create the PR'"
+else
+echo "   'start #42'  'ready to commit'  'create the PR'"
+fi
 echo ""
 
 # END_OF_INSTALL_SCRIPT

--- a/install/install.sh
+++ b/install/install.sh
@@ -173,19 +173,16 @@ select_option() {
 
 # Logo color
 PURPLE='\033[0;35m'
+BLUE='\033[0;34m'
 
 print_logo() {
   echo ""
-  echo -e "   ${BOLD}                    _        ${NC}"
-  echo -e "   ${BOLD} _ __ ___   __ _  __ _(_) ___  ${NC}"
-  echo -e "   ${BOLD}| '_ \` _ \\ / _\` |/ _\` | |/ __| ${NC}"
-  echo -e "   ${BOLD}| | | | | | (_| | (_| | | (__  ${NC}"
-  echo -e "   ${BOLD}|_| |_| |_|\\__,_|\\__, |_|\\___| ${NC}"
-  echo -e "   ${PURPLE}    __${NC}${BOLD}           |___/      ${NC}"
-  echo -e "   ${PURPLE}   / /${NC}${BOLD}__| | __ _ ___| |__   ${NC}"
-  echo -e "   ${PURPLE}  / /${NC}${BOLD}/ __| |/ _\` / __| '_ \\  ${NC}"
-  echo -e "   ${PURPLE} / /${NC}${BOLD}\\__ \\ | (_| \\__ \\ | | | ${NC}"
-  echo -e "   ${PURPLE}/_/ ${NC}${BOLD}|___/_|\\__,_|___/_| |_| ${NC}"
+  echo -e "   ${BOLD}                       _           ${PURPLE}__${NC}${BOLD}   _           _${NC}"
+  echo -e "   ${BOLD} _ __ ___   __ _  __ _(_) ___     ${PURPLE}/ /${NC}${BOLD}__| | __ _ ___| |__${NC}"
+  echo -e "   ${BOLD}| '_ \` _ \\ / _\` |/ _\` | |/ __|   ${PURPLE}/ /${NC}${BOLD} __| |/ _\` / __| '_ \\ ${NC}"
+  echo -e "   ${BOLD}| | | | | | (_| | (_| | | (__   ${PURPLE}/ /${NC}${BOLD}\\__ \\ | (_| \\__ \\ | | |${NC}"
+  echo -e "   ${BOLD}|_| |_| |_|\\__,_|\\__, |_|\\___| ${NC}${PURPLE}/_/${NC}${BOLD} |___/_|\\__,_|___/_| |_|${NC}${BOLD}.${NC}"
+  echo -e "   ${BOLD}                 |___/${NC}"
   echo ""
 }
 

--- a/skills/magic-continue/SKILL.md
+++ b/skills/magic-continue/SKILL.md
@@ -33,7 +33,17 @@ If missing, display `MSG_CONFIG_ERROR` and stop.
 
 Once the repo is identified (Step 5), read `.repositories.<name>.languages.discussion` from config. Default: `"en"`. Until the repo is identified, use English for all messages.
 
-### 0.3: Determine development branch (execute after repo is identified in Step 5)
+### 0.3: Check Atlassian integration
+
+Read `integrations.atlassian` from config. Default: `true` (backward compatibility).
+
+```bash
+jq -r '.integrations.atlassian // true' "$CONFIG_FILE"
+```
+
+Store the result as `$ATLASSIAN_ENABLED`. If `false`, only GitHub issue format is accepted in Step 1.
+
+### 0.4: Determine development branch (execute after repo is identified in Step 5)
 
 Read `.repositories.<name>.branches.development` from config.
 
@@ -52,6 +62,11 @@ Store the result as `$DEV_BRANCH`.
 Analyze `$ARGUMENTS`:
 
 - **Jira**: Alphabetic prefix + hyphen + digits (regex: `^[A-Za-z]+-\d+$`, normalize to uppercase) → Step 2A
+  - **If `$ATLASSIAN_ENABLED` is `false`**: Do not match Jira format. If the user provides a Jira ID (e.g., `PROJ-123`), display:
+    > ⚠️ Atlassian integration is not configured. Only GitHub issues (#123) are supported.
+    > To enable Atlassian, re-run the installer: `curl -fsSL https://magic-slash.io/install.sh | bash`
+    
+    Then stop.
 - **GitHub**: Number with optional `#` (regex: `^#?\d+$`) → Step 2B
 - **Unrecognized**: Display `MSG_FORMAT_UNRECOGNIZED`.
 

--- a/skills/magic-done/SKILL.md
+++ b/skills/magic-done/SKILL.md
@@ -183,6 +183,12 @@ If some PRs are merged and others are not, display a warning listing which PRs a
 
 ## Step 4: Update the Jira/GitHub ticket
 
+### Check Atlassian integration
+
+Read `integrations.atlassian` from `~/.config/magic-slash/config.json`. Default: `true`.
+
+If `integrations.atlassian` is `false`, skip the entire "For Jira tickets" section below. Only execute "For GitHub issues".
+
 ### For Jira tickets
 
 If a Jira ticket ID is found, use the MCP Atlassian tools:

--- a/skills/magic-pr/SKILL.md
+++ b/skills/magic-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: magic:pr
 description: Pushes code, creates a GitHub Pull Request, and updates the linked Jira/GitHub ticket. Use this skill when the user indicates their coding work is done and they want to create or finalize a PR — even if they don't explicitly say "PR". Triggers on phrases like: "done", "terminé", "j'ai fini", "create PR", "créer la PR", "ready for PR", "prêt pour la PR", "ship it", "envoie la sauce", "let's get this merged", "push my changes", "pousse tout ça", "wrap it up", "c'est bon pour moi", or any completion signal in English or French.
 argument-hint: <base-branch> (optional, e.g., develop, staging)
-allowed-tools: Bash(*), mcp__github__*, mcp__atlassian__*, AskUserQuestion
+allowed-tools: Bash(*), Read, mcp__github__*, mcp__atlassian__*, AskUserQuestion
 ---
 
 # magic-slash v0.32.5 - /pr
@@ -415,7 +415,9 @@ Prepare the PR content:
 
 Add this section at the end of the PR description.
 
-For **Jira** tickets, adapt the Jira URL based on the user's domain (retrieved via `mcp__atlassian__getAccessibleAtlassianResources`):
+For **Jira** tickets: only if `integrations.atlassian` is `true`. If `false`, skip the Jira link — use the ticket ID as plain text without a URL.
+
+For **Jira** tickets (when Atlassian is enabled), adapt the Jira URL based on the user's domain (retrieved via `mcp__atlassian__getAccessibleAtlassianResources`):
 
 ```markdown
 ## Linked Issues
@@ -482,6 +484,12 @@ This command is silent and never blocks the process.
 ## Step 7: Update the Jira/GitHub ticket
 
 Use `$TICKET_ID` (extracted in Step 0.1). If `$TICKET_ID` is empty, use `AskUserQuestion` to ask the user if they want to link a ticket manually (and which one). If they decline, skip to Step 7.3.
+
+### 7.0: Check Atlassian integration
+
+Read `integrations.atlassian` from `~/.config/magic-slash/config.json`. Default: `true`.
+
+If `integrations.atlassian` is `false`, skip Step 7.1 entirely (Jira ticket update). Only execute Step 7.2 (GitHub issues).
 
 ### 7.1: Jira tickets (pattern `[A-Z]+-\d+`)
 

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -34,7 +34,17 @@ If missing, display `MSG_CONFIG_ERROR` and stop.
 
 Once the repo is identified (step 3), read `.repositories.<name>.languages.discussion` from config. Default: `"en"`. Until the repo is identified, use English for all messages.
 
-### 0.3: Determine development branch (execute after repo is identified in step 3)
+### 0.3: Check Atlassian integration
+
+Read `integrations.atlassian` from config. Default: `true` (backward compatibility).
+
+```bash
+jq -r '.integrations.atlassian // true' "$CONFIG_FILE"
+```
+
+Store the result as `$ATLASSIAN_ENABLED`. If `false`, only GitHub issue format (`#123`) is accepted in Step 1.
+
+### 0.4: Determine development branch (execute after repo is identified in step 3)
 
 Read `.repositories.<name>.branches.development` from config.
 
@@ -48,6 +58,11 @@ Store the result as `$DEV_BRANCH`.
 Analyze `$ARGUMENTS`:
 
 - **Jira**: Alphabetic prefix + hyphen + digits (regex: `^[A-Za-z]+-\d+$`, normalize to uppercase) → Step 2A
+  - **If `$ATLASSIAN_ENABLED` is `false`**: Do not match Jira format. If the user provides a Jira ID (e.g., `PROJ-123`), display:
+    > ⚠️ Atlassian integration is not configured. Only GitHub issues (#123) are supported.
+    > To enable Atlassian, re-run the installer: `curl -fsSL https://magic-slash.io/install.sh | bash`
+    
+    Then stop.
 - **GitHub**: Number with optional `#` (regex: `^#?\d+$`) → Step 2B
 - **Unrecognized**: Ask user to clarify.
 


### PR DESCRIPTION
## Description

Make the Atlassian MCP integration optional via a selection screen during installation. The choice is persisted in `config.json` under `integrations.atlassian` and all skills conditionally gate their Jira/Confluence calls based on this setting.

Also includes: Ctrl+C handling for clean installer exit and a redesigned single-line ASCII logo.

## Related Issue

Closes #73

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Add integration selection screen in `install.sh` (Atlassian+GitHub vs GitHub-only)
- Persist `integrations.atlassian` in config and conditionally configure MCP/permissions
- Handle Ctrl+C (INT/TERM traps) for clean installer exit
- Redesign ASCII logo to single-line FIGlet layout with purple slash
- Add `integrations` field to Config type, schema, migration, and readConfig defaults
- Update `magic-start`, `magic-continue`, `magic-pr`, `magic-done` skills to check Atlassian flag
- Allow empty repositories in config schema (fresh install)

## Testing

- [x] Tested locally with Claude Code
- [x] Tested installation script
- [x] Tested affected slash commands

### Test Steps

1. Run `bash install/install.sh` and select "GitHub only" → verify Atlassian MCP section is skipped
2. Check `~/.config/magic-slash/config.json` has `integrations.atlassian: false`
3. Run `bash install/install.sh` again and select "Atlassian + GitHub" → verify MCP Atlassian is configured
4. Press Ctrl+C during install → verify clean exit with "Installation cancelled" message
5. Verify the new ASCII logo renders correctly in terminal

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable

## Additional Notes

Backward compatible: existing installations without the `integrations` field default to `atlassian: true`.