### PR TITLE
[#85] Add Spotlight settings section with shortcut picker

### DIFF
--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import * as os from 'os'
 import type { Config, RepositoryConfig } from '../../types'
 import { validateConfig, hasCriticalErrors } from './schema-validator'
-import { DEFAULT_REPOSITORY_FIELDS } from './defaults'
+import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig } from './defaults'
 import { expandPath } from './validation'
 
 /** Settings input where each field can be its normal type, 'default', or null (to reset) */
@@ -94,6 +94,15 @@ export function readConfig(): Config {
 
     if (!config.integrations) {
       config.integrations = { github: true, atlassian: true }
+      needsWrite = true
+    }
+
+    if (!isValidSpotlightConfig(config.spotlight)) {
+      config.spotlight = { ...DEFAULT_SPOTLIGHT, ...(typeof config.spotlight === 'object' && config.spotlight !== null ? config.spotlight : {}) }
+      // Re-validate after merge; if still invalid, reset to pure defaults
+      if (!isValidSpotlightConfig(config.spotlight)) {
+        config.spotlight = { ...DEFAULT_SPOTLIGHT }
+      }
       needsWrite = true
     }
 

--- a/desktop/src/main/config/defaults.ts
+++ b/desktop/src/main/config/defaults.ts
@@ -1,4 +1,27 @@
-import type { RepositoryConfig } from '../../types'
+import type { RepositoryConfig, SpotlightConfig, SpotlightShortcut } from '../../types'
+
+export const VALID_SPOTLIGHT_SHORTCUTS: readonly SpotlightShortcut[] = [
+  'Control+Space',
+  'Control+Shift+Space',
+  'Alt+Space',
+  'Alt+Shift+Space',
+  'Control+M',
+  'Control+Shift+M',
+  'Alt+M',
+  'Alt+Shift+M',
+] as const
+
+export function isValidSpotlightShortcut(value: unknown): value is SpotlightShortcut {
+  return typeof value === 'string' && (VALID_SPOTLIGHT_SHORTCUTS as readonly string[]).includes(value)
+}
+
+export function isValidSpotlightConfig(obj: unknown): obj is SpotlightConfig {
+  if (typeof obj !== 'object' || obj === null) return false
+  const record = obj as Record<string, unknown>
+  return typeof record.enabled === 'boolean' && isValidSpotlightShortcut(record.shortcut)
+}
+
+export const DEFAULT_SPOTLIGHT: SpotlightConfig = { enabled: true, shortcut: 'Control+Space' }
 
 export const DEFAULT_REPOSITORY_FIELDS: Omit<RepositoryConfig, 'path' | 'keywords'> = {
   color: '#3B82F6',

--- a/desktop/src/main/config/migrate.test.ts
+++ b/desktop/src/main/config/migrate.test.ts
@@ -99,6 +99,11 @@ describe('migrateConfig — agents migration', () => {
     }))
 
     // Mock defaults
+    const VALID_SHORTCUTS = [
+      'Control+Space', 'Control+Shift+Space', 'Alt+Space', 'Alt+Shift+Space',
+      'Control+M', 'Control+Shift+M', 'Alt+M', 'Alt+Shift+M',
+    ]
+    const mockDefaultSpotlight = { enabled: true, shortcut: 'Control+Space' }
     vi.doMock('./defaults', () => ({
       DEFAULT_REPOSITORY_FIELDS: {
         color: '#3B82F6',
@@ -112,6 +117,17 @@ describe('migrateConfig — agents migration', () => {
         issues: { commentOnPR: true, jiraUrl: '', githubIssuesUrl: '' },
         branches: { development: '' },
         worktreeFiles: [],
+      },
+      DEFAULT_SPOTLIGHT: mockDefaultSpotlight,
+      VALID_SPOTLIGHT_SHORTCUTS: VALID_SHORTCUTS,
+      isValidSpotlightShortcut: (value: unknown) =>
+        typeof value === 'string' && VALID_SHORTCUTS.includes(value),
+      isValidSpotlightConfig: (obj: unknown) => {
+        if (typeof obj !== 'object' || obj === null) return false
+        const record = obj as Record<string, unknown>
+        return typeof record.enabled === 'boolean' &&
+          typeof record.shortcut === 'string' &&
+          VALID_SHORTCUTS.includes(record.shortcut)
       },
     }))
 

--- a/desktop/src/main/config/migrate.ts
+++ b/desktop/src/main/config/migrate.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import { readConfig, writeConfig, CONFIG_DIR, CONFIG_FILE } from './config'
 import { writeAgents, AGENTS_FILE } from './agents'
 import { validateConfig } from './schema-validator'
-import { DEFAULT_REPOSITORY_FIELDS } from './defaults'
+import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig } from './defaults'
 import type { RepositoryConfig } from '../../types'
 
 const CONFIG_BACKUP = path.join(CONFIG_DIR, 'config.json.bak')
@@ -98,6 +98,15 @@ export function migrateConfig(appVersion?: string): boolean {
   // Migrate integrations (default: both enabled for backward compatibility)
   if (!config.integrations) {
     config.integrations = { github: true, atlassian: true }
+    changed = true
+  }
+
+  if (!isValidSpotlightConfig(config.spotlight)) {
+    config.spotlight = { ...DEFAULT_SPOTLIGHT, ...(typeof config.spotlight === 'object' && config.spotlight !== null ? config.spotlight : {}) }
+    // Re-validate after merge; if still invalid, reset to pure defaults
+    if (!isValidSpotlightConfig(config.spotlight)) {
+      config.spotlight = { ...DEFAULT_SPOTLIGHT }
+    }
     changed = true
   }
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -15,7 +15,8 @@ import { readConfig, writeConfig } from './config/config'
 import { TrayManager } from './tray/tray-manager'
 import { AgentStateAggregator } from './tray/agent-state-aggregator'
 import { destroyPopover } from './windows/popover-window'
-import { showQuickLaunch, hideQuickLaunch, isQuickLaunchVisible, resizeQuickLaunch, destroyQuickLaunch } from './windows/quick-launch-window'
+import { hideQuickLaunch, resizeQuickLaunch, destroyQuickLaunch } from './windows/quick-launch-window'
+import { reRegisterSpotlightShortcut } from './spotlight-shortcut'
 
 let mainWindow: BrowserWindow | null = null
 let isQuitting = false
@@ -358,15 +359,8 @@ app.whenReady().then(async () => {
     })
   }
 
-  // Register global shortcut: Ctrl+Space for Quick Launch
-  const registered = globalShortcut.register('Control+Space', () => {
-    if (isQuickLaunchVisible()) {
-      hideQuickLaunch()
-    } else {
-      showQuickLaunch()
-    }
-  })
-  console.log(`[QuickLaunch] Global shortcut registered: ${registered}`)
+  // Register global shortcut for Quick Launch (from config)
+  reRegisterSpotlightShortcut()
 
   // Check for app updates on startup
   checkForUpdatesOnStartup()

--- a/desktop/src/main/ipc/config-handlers.ts
+++ b/desktop/src/main/ipc/config-handlers.ts
@@ -1,6 +1,7 @@
 import { ipcMain, type BrowserWindow } from 'electron'
 import {
   readConfig,
+  writeConfig,
   CONFIG_FILE,
   addRepository,
   updateRepository,
@@ -16,7 +17,9 @@ import {
   updateSplitEnabled,
   updateSplitActive,
 } from '../config/config'
+import { reRegisterSpotlightShortcut } from '../spotlight-shortcut'
 import { repairConfig } from '../config/migrate'
+import { isValidSpotlightShortcut } from '../config/defaults'
 import { validateConfig } from '../config/schema-validator'
 import {
   validateRepoName,
@@ -159,6 +162,21 @@ export function setupConfigHandlers(getMainWindow: () => BrowserWindow | null) {
   ipcMain.handle('config:updateSplitActive', async (_event, { active }) => {
     const config = updateSplitActive(active)
     return { config }
+  })
+
+  // Update spotlight settings (enable/disable + shortcut)
+  ipcMain.handle('config:updateSpotlight', async (_event, { enabled, shortcut }: { enabled: boolean; shortcut: string }) => {
+    if (typeof enabled !== 'boolean') {
+      throw new Error('Invalid spotlight enabled value: must be a boolean')
+    }
+    if (!isValidSpotlightShortcut(shortcut)) {
+      throw new Error(`Invalid spotlight shortcut: '${shortcut}'. Must be one of the supported accelerators.`)
+    }
+    const config = readConfig()
+    config.spotlight = { enabled, shortcut }
+    writeConfig(config)
+    const result = reRegisterSpotlightShortcut()
+    return { config, registered: result.registered }
   })
 
   // Validate path

--- a/desktop/src/main/spotlight-shortcut.ts
+++ b/desktop/src/main/spotlight-shortcut.ts
@@ -1,0 +1,39 @@
+import { globalShortcut } from 'electron'
+import { readConfig } from './config/config'
+import { DEFAULT_SPOTLIGHT, isValidSpotlightShortcut } from './config/defaults'
+import { showQuickLaunch, hideQuickLaunch, isQuickLaunchVisible } from './windows/quick-launch-window'
+
+let currentSpotlightShortcut: string | null = null
+
+export function reRegisterSpotlightShortcut(): { registered: boolean; disabled: boolean } {
+  if (currentSpotlightShortcut) {
+    globalShortcut.unregister(currentSpotlightShortcut)
+    currentSpotlightShortcut = null
+  }
+
+  const config = readConfig()
+  const spotlight = config.spotlight ?? DEFAULT_SPOTLIGHT
+
+  if (!spotlight.enabled) {
+    return { registered: false, disabled: true }
+  }
+
+  const shortcut = isValidSpotlightShortcut(spotlight.shortcut)
+    ? spotlight.shortcut
+    : DEFAULT_SPOTLIGHT.shortcut
+
+  const registered = globalShortcut.register(shortcut, () => {
+    if (isQuickLaunchVisible()) {
+      hideQuickLaunch()
+    } else {
+      showQuickLaunch()
+    }
+  })
+
+  if (registered) {
+    currentSpotlightShortcut = shortcut
+  }
+
+  console.log(`[QuickLaunch] Global shortcut '${shortcut}' registered: ${registered}`)
+  return { registered, disabled: false }
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -54,6 +54,9 @@ const configApi = {
   updateSplitActive: (active: boolean) =>
     ipcRenderer.invoke('config:updateSplitActive', { active }),
 
+  updateSpotlight: (spotlight: { enabled: boolean; shortcut: string }) =>
+    ipcRenderer.invoke('config:updateSpotlight', spotlight),
+
   repair: (): Promise<{ repaired: boolean; fixes: string[] }> =>
     ipcRenderer.invoke('config:repair'),
 

--- a/desktop/src/renderer/hooks/useConfig.ts
+++ b/desktop/src/renderer/hooks/useConfig.ts
@@ -87,6 +87,12 @@ export function useConfig() {
     return result
   }, [setConfig])
 
+  const updateSpotlight = useCallback(async (spotlight: { enabled: boolean; shortcut: string }) => {
+    const result = await window.electronAPI.config.updateSpotlight(spotlight)
+    setConfig(result.config)
+    return result
+  }, [setConfig])
+
   const validatePath = useCallback(async (path: string) => {
     return window.electronAPI.config.validatePath(path)
   }, [])
@@ -120,6 +126,7 @@ export function useConfig() {
     updateRepositoryBranchSettings,
     updateRepositoryWorktreeFilesSettings,
     updateSplitEnabled,
+    updateSpotlight,
     validatePath,
     getPRTemplate,
     createPRTemplate,

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -1,19 +1,69 @@
 import { useState, useEffect, useMemo } from 'react'
-import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone } from 'lucide-react'
+import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle } from 'lucide-react'
 import { RepoPage } from './RepoPage'
 import { useStore } from '../../store'
 import { useConfig } from '../../hooks/useConfig'
+import type { SpotlightShortcut } from '../../../types'
 import { showToast } from '../../components/Toast'
 import { getProjectColorMap } from '../../utils/projectColors'
 
+const SPOTLIGHT_OPTIONS: { label: string; value: string }[] = [
+  { label: '\u2303 Space', value: 'Control+Space' },
+  { label: '\u2303\u21E7 Space', value: 'Control+Shift+Space' },
+  { label: '\u2325 Space', value: 'Alt+Space' },
+  { label: '\u2325\u21E7 Space', value: 'Alt+Shift+Space' },
+  { label: '\u2303 M', value: 'Control+M' },
+  { label: '\u2303\u21E7 M', value: 'Control+Shift+M' },
+  { label: '\u2325 M', value: 'Alt+M' },
+  { label: '\u2325\u21E7 M', value: 'Alt+Shift+M' },
+]
+
 function WelcomePage() {
   const { config, terminals, splitEnabled, toggleSplitEnabled } = useStore()
-  const { addRepository, updateSplitEnabled } = useConfig()
+  const { addRepository, updateSplitEnabled, updateSpotlight } = useConfig()
   const [githubStatus, setGithubStatus] = useState<Record<string, boolean>>({})
   const [isAdding, setIsAdding] = useState(false)
   const [appVersion, setAppVersion] = useState('')
   const [loadingWhatsNew, setLoadingWhatsNew] = useState(false)
   const [autoStart, setAutoStart] = useState(false)
+  const [spotlightEnabled, setSpotlightEnabled] = useState(config?.spotlight?.enabled ?? true)
+  const [spotlightShortcut, setSpotlightShortcut] = useState(config?.spotlight?.shortcut ?? 'Control+Space')
+  const [spotlightError, setSpotlightError] = useState(false)
+
+  const configSpotlightEnabled = config?.spotlight?.enabled
+  const configSpotlightShortcut = config?.spotlight?.shortcut
+  useEffect(() => {
+    if (configSpotlightEnabled !== undefined) setSpotlightEnabled(configSpotlightEnabled)
+    if (configSpotlightShortcut !== undefined) setSpotlightShortcut(configSpotlightShortcut)
+  }, [configSpotlightEnabled, configSpotlightShortcut])
+
+  const handleSpotlightToggle = async () => {
+    const newEnabled = !spotlightEnabled
+    setSpotlightEnabled(newEnabled)
+    setSpotlightError(false)
+    try {
+      const result = await updateSpotlight({ enabled: newEnabled, shortcut: spotlightShortcut })
+      if (newEnabled && !result.registered) {
+        setSpotlightError(true)
+      }
+    } catch {
+      setSpotlightEnabled(!newEnabled) // revert on error
+    }
+  }
+
+  const handleSpotlightShortcutChange = async (newShortcut: SpotlightShortcut) => {
+    const previousShortcut = spotlightShortcut
+    setSpotlightShortcut(newShortcut)
+    setSpotlightError(false)
+    try {
+      const result = await updateSpotlight({ enabled: spotlightEnabled, shortcut: newShortcut })
+      if (spotlightEnabled && !result.registered) {
+        setSpotlightError(true)
+      }
+    } catch {
+      setSpotlightShortcut(previousShortcut)
+    }
+  }
 
   const repos = Object.entries(config?.repositories || {})
   const projectNames = repos.map(([name]) => name)
@@ -238,6 +288,59 @@ function WelcomePage() {
         </div>
       </div>
 
+      {/* Spotlight Section */}
+      <div>
+        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
+          <Search className="w-4 h-4" />
+          <span>Spotlight</span>
+        </div>
+        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium">Enable global shortcut</div>
+              <div className="text-xs text-text-secondary/50 mt-0.5">Open the Quick Launch panel from anywhere with a keyboard shortcut</div>
+            </div>
+            <button
+              onClick={handleSpotlightToggle}
+              className={`relative w-10 h-[22px] rounded-full transition-colors duration-200 flex-shrink-0 ${
+                spotlightEnabled ? 'bg-accent' : 'bg-white/20'
+              }`}
+            >
+              <div className={`absolute top-[3px] left-[3px] w-4 h-4 rounded-full bg-white transition-transform duration-200 ${
+                spotlightEnabled ? 'translate-x-[18px]' : 'translate-x-0'
+              }`} />
+            </button>
+          </div>
+          <div className="border-t border-white/5 pt-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm font-medium">Shortcut</div>
+                <div className="text-xs text-text-secondary/50 mt-0.5">Choose the keyboard shortcut to toggle Quick Launch</div>
+              </div>
+              <div className="relative">
+                <select
+                  value={spotlightShortcut}
+                  onChange={(e) => handleSpotlightShortcutChange(e.target.value as SpotlightShortcut)}
+                  disabled={!spotlightEnabled}
+                  className="w-52 px-3 py-2 bg-bg border border-white/10 rounded-lg text-sm focus:outline-none focus:border-accent transition-colors appearance-none cursor-pointer disabled:opacity-50"
+                >
+                  {SPOTLIGHT_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+                <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary/50 pointer-events-none" />
+              </div>
+            </div>
+          </div>
+          {spotlightError && (
+            <div className="flex items-center gap-2 px-3 py-2 bg-red/10 border border-red/20 rounded-lg text-xs text-red">
+              <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+              <span>Failed to register shortcut. It may be in use by another application. Try a different shortcut.</span>
+            </div>
+          )}
+        </div>
+      </div>
+
       {/* Background App Section */}
       <div>
         <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
@@ -328,7 +431,13 @@ function WelcomePage() {
             </div>
             <div className="flex items-center justify-between">
               <span className="text-text-secondary">Quick Launch</span>
-              <kbd className="px-2 py-0.5 bg-white/5 border border-white/10 rounded text-xs text-text-secondary"><span className="text-sm">⌘</span> <span className="text-sm">⇧</span> M</kbd>
+              {spotlightEnabled ? (
+                <kbd className="px-2 py-0.5 bg-white/5 border border-white/10 rounded text-xs text-text-secondary">
+                  {SPOTLIGHT_OPTIONS.find(o => o.value === spotlightShortcut)?.label ?? spotlightShortcut}
+                </kbd>
+              ) : (
+                <span className="px-2 py-0.5 text-xs text-text-secondary/40">Disabled</span>
+              )}
             </div>
           </div>
         </div>

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -74,6 +74,21 @@ export interface Agent {
   splitPane?: 'left' | 'right'
 }
 
+export type SpotlightShortcut =
+  | 'Control+Space'
+  | 'Control+Shift+Space'
+  | 'Alt+Space'
+  | 'Alt+Shift+Space'
+  | 'Control+M'
+  | 'Control+Shift+M'
+  | 'Alt+M'
+  | 'Alt+Shift+M'
+
+export interface SpotlightConfig {
+  enabled: boolean
+  shortcut: SpotlightShortcut
+}
+
 export interface Config {
   version: string
   repositories: Record<string, RepositoryConfig>
@@ -84,6 +99,7 @@ export interface Config {
     github: true
     atlassian?: boolean
   }
+  spotlight?: SpotlightConfig
 }
 
 export interface PRTemplate {

--- a/install/config-schema.json
+++ b/install/config-schema.json
@@ -42,6 +42,29 @@
     "installationMode": {
       "type": "string",
       "description": "Installation mode identifier"
+    },
+    "spotlight": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "shortcut": {
+          "type": "string",
+          "enum": [
+            "Control+Space",
+            "Control+Shift+Space",
+            "Alt+Space",
+            "Alt+Shift+Space",
+            "Control+M",
+            "Control+Shift+M",
+            "Alt+M",
+            "Alt+Shift+M"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "description": "Spotlight (Quick Launch) global shortcut settings"
     }
   },
   "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-slash",
-  "version": "0.36.4",
+  "version": "0.39.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-slash",
-      "version": "0.36.4",
+      "version": "0.39.8",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",


### PR DESCRIPTION
## Description

Add a dedicated **Spotlight** section in the desktop app Settings page that allows users to:
- **Enable/disable** the Quick Launch global shortcut via a toggle
- **Choose** the keyboard shortcut from 8 predefined options (Control/Alt + Space/M combinations)

Changes take effect immediately (hot-swap) without requiring an app restart. The previously hardcoded `Control+Space` shortcut is now fully configurable and persisted in the user's config.

## Related Issue

Closes #85

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **Types** (`desktop/src/types.ts`): Added `SpotlightShortcut` union type (8 Electron accelerators) and `SpotlightConfig` interface
- **JSON Schema** (`install/config-schema.json`): Added `spotlight` object property with validation (critical for `additionalProperties: false`)
- **Config defaults & validation** (`desktop/src/main/config/defaults.ts`): Added `DEFAULT_SPOTLIGHT`, `VALID_SPOTLIGHT_SHORTCUTS`, `isValidSpotlightShortcut()`, `isValidSpotlightConfig()` validators
- **Config migration** (`config.ts` + `migrate.ts`): Dual migration path (inline + persistent) with merge-then-fallback for partially corrupt configs
- **Main process** (`desktop/src/main/index.ts`): Replaced hardcoded `Control+Space` registration with `reRegisterSpotlightShortcut()` call
- **New module** (`desktop/src/main/spotlight-shortcut.ts`): Encapsulates global shortcut lifecycle (unregister old → read config → register new) with fallback to default on invalid shortcut
- **IPC handler** (`config-handlers.ts`): `config:updateSpotlight` with server-side validation before persisting
- **Preload + Hook** (`preload/index.ts`, `useConfig.ts`): Exposed `updateSpotlight` through the full IPC bridge
- **Settings UI** (`Config/index.tsx`): New Spotlight section with toggle + select dropdown (8 options with macOS Unicode symbols), error feedback on registration failure, and dynamic Keyboard Shortcuts display

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [x] All 76 existing tests pass

### Test Steps

1. Start the app with `npm run desktop`, open Settings — verify the **Spotlight** section appears between "Split View" and "Background App"
2. Toggle the Spotlight off → the select becomes disabled (grayed out), the global shortcut stops working, and the Keyboard Shortcuts section shows "Disabled" for Quick Launch
3. Toggle back on → the shortcut works again immediately
4. Change the shortcut (e.g., to `⌥ Space`) → the new shortcut activates immediately, the old one no longer triggers Quick Launch
5. Quit and relaunch the app → verify the settings persist (toggle state + selected shortcut)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All linters pass locally

## Linked Issues

- Closes #85