### PR TITLE
[magic-slash-83] Add History page with daily agent activity timeline

### DIFF
--- a/desktop/src/main/config/activity-history.test.ts
+++ b/desktop/src/main/config/activity-history.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'activity-history-test-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function writeHistoryFile(data: unknown): void {
+  fs.writeFileSync(path.join(tmpDir, 'history.json'), JSON.stringify(data, null, 2))
+}
+
+function readHistoryFile(): unknown {
+  return JSON.parse(fs.readFileSync(path.join(tmpDir, 'history.json'), 'utf8'))
+}
+
+describe('readHistory', () => {
+  let readHistory: typeof import('./activity-history').readHistory
+
+  beforeEach(async () => {
+    vi.doMock('./config', () => ({
+      CONFIG_DIR: tmpDir,
+    }))
+    vi.resetModules()
+    const mod = await import('./activity-history')
+    readHistory = mod.readHistory
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should return [] when history.json does not exist', () => {
+    expect(readHistory()).toEqual([])
+  })
+
+  it('should return [] when file contains non-array', () => {
+    writeHistoryFile({ foo: 'bar' })
+    expect(readHistory()).toEqual([])
+  })
+
+  it('should return [] when file contains invalid JSON', () => {
+    fs.writeFileSync(path.join(tmpDir, 'history.json'), '{broken')
+    expect(readHistory()).toEqual([])
+  })
+
+  it('should return entries when file contains a valid array', () => {
+    const entries = [
+      { id: '1', agentId: 'a1', agentName: 'Claude 1', action: 'started', repositories: [], timestamp: 1000 },
+    ]
+    writeHistoryFile(entries)
+    const result = readHistory()
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('1')
+  })
+})
+
+describe('addHistoryEntry', () => {
+  let addHistoryEntry: typeof import('./activity-history').addHistoryEntry
+  let readHistory: typeof import('./activity-history').readHistory
+
+  beforeEach(async () => {
+    vi.doMock('./config', () => ({
+      CONFIG_DIR: tmpDir,
+    }))
+    vi.resetModules()
+    const mod = await import('./activity-history')
+    addHistoryEntry = mod.addHistoryEntry
+    readHistory = mod.readHistory
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should create an entry with all fields', () => {
+    const entry = addHistoryEntry({
+      agentId: 'a1',
+      agentName: 'Claude 1',
+      action: 'started',
+      ticketId: 'PROJ-123',
+      description: 'Fix login',
+      repositories: ['/repo1'],
+    })
+
+    expect(entry.id).toBeDefined()
+    expect(entry.agentId).toBe('a1')
+    expect(entry.agentName).toBe('Claude 1')
+    expect(entry.action).toBe('started')
+    expect(entry.ticketId).toBe('PROJ-123')
+    expect(entry.description).toBe('Fix login')
+    expect(entry.repositories).toEqual(['/repo1'])
+    expect(entry.timestamp).toBeGreaterThan(0)
+  })
+
+  it('should persist to history.json', () => {
+    addHistoryEntry({
+      agentId: 'a1',
+      agentName: 'Claude 1',
+      action: 'committed',
+      repositories: [],
+    })
+
+    const data = readHistoryFile() as unknown[]
+    expect(data).toHaveLength(1)
+  })
+
+  it('should append to existing entries', () => {
+    writeHistoryFile([
+      { id: 'existing', agentId: 'a0', agentName: 'Old', action: 'started', repositories: [], timestamp: 1000 },
+    ])
+
+    addHistoryEntry({
+      agentId: 'a1',
+      agentName: 'Claude 1',
+      action: 'committed',
+      repositories: [],
+    })
+
+    const result = readHistory()
+    expect(result).toHaveLength(2)
+    expect(result[0].id).toBe('existing')
+  })
+
+  it('should cap entries at 500 by removing oldest', () => {
+    const existing = Array.from({ length: 500 }, (_, i) => ({
+      id: `entry-${i}`,
+      agentId: 'a1',
+      agentName: 'Claude',
+      action: 'started',
+      repositories: [],
+      timestamp: i,
+    }))
+    writeHistoryFile(existing)
+
+    addHistoryEntry({
+      agentId: 'a2',
+      agentName: 'Claude 2',
+      action: 'committed',
+      repositories: [],
+    })
+
+    const result = readHistory()
+    expect(result).toHaveLength(500)
+    expect(result[0].id).toBe('entry-1')
+    expect(result[result.length - 1].agentName).toBe('Claude 2')
+  })
+})
+
+describe('clearHistory', () => {
+  let clearHistory: typeof import('./activity-history').clearHistory
+  let readHistory: typeof import('./activity-history').readHistory
+
+  beforeEach(async () => {
+    vi.doMock('./config', () => ({
+      CONFIG_DIR: tmpDir,
+    }))
+    vi.resetModules()
+    const mod = await import('./activity-history')
+    clearHistory = mod.clearHistory
+    readHistory = mod.readHistory
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should clear all entries', () => {
+    writeHistoryFile([
+      { id: '1', agentId: 'a1', agentName: 'Claude', action: 'started', repositories: [], timestamp: 1000 },
+      { id: '2', agentId: 'a1', agentName: 'Claude', action: 'committed', repositories: [], timestamp: 2000 },
+    ])
+
+    clearHistory()
+    expect(readHistory()).toEqual([])
+  })
+
+  it('should handle clearing when file does not exist', () => {
+    clearHistory()
+    expect(readHistory()).toEqual([])
+  })
+})

--- a/desktop/src/main/config/activity-history.ts
+++ b/desktop/src/main/config/activity-history.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import * as crypto from 'crypto'
+import type { HistoryEntry, HistoryAction } from '../../types'
+import { CONFIG_DIR } from './config'
+
+const HISTORY_FILE = path.join(CONFIG_DIR, 'history.json')
+const MAX_ENTRIES = 500
+
+export function readHistory(): HistoryEntry[] {
+  try {
+    if (!fs.existsSync(HISTORY_FILE)) {
+      return []
+    }
+    const content = fs.readFileSync(HISTORY_FILE, 'utf8')
+    const data = JSON.parse(content)
+    if (!Array.isArray(data)) {
+      return []
+    }
+    return data
+  } catch (error) {
+    console.error('Error reading activity history:', error)
+    return []
+  }
+}
+
+function writeHistory(entries: HistoryEntry[]): void {
+  try {
+    if (!fs.existsSync(CONFIG_DIR)) {
+      fs.mkdirSync(CONFIG_DIR, { recursive: true })
+    }
+    fs.writeFileSync(HISTORY_FILE, JSON.stringify(entries, null, 2))
+  } catch (error) {
+    console.error('Error writing activity history:', error)
+  }
+}
+
+export function addHistoryEntry(params: {
+  agentId: string
+  agentName: string
+  action: HistoryAction
+  ticketId?: string
+  description?: string
+  repositories: string[]
+}): HistoryEntry {
+  const entry: HistoryEntry = {
+    id: crypto.randomUUID(),
+    agentId: params.agentId,
+    agentName: params.agentName,
+    action: params.action,
+    ticketId: params.ticketId,
+    description: params.description,
+    repositories: params.repositories,
+    timestamp: Date.now(),
+  }
+
+  const entries = readHistory()
+  entries.push(entry)
+
+  // Purge oldest entries if over the limit
+  if (entries.length > MAX_ENTRIES) {
+    entries.splice(0, entries.length - MAX_ENTRIES)
+  }
+
+  writeHistory(entries)
+  return entry
+}
+
+export function clearHistory(): void {
+  writeHistory([])
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ import { setupAutoUpdater, setUpdaterMainWindow, checkForUpdatesOnStartup, isUpd
 import { updateSkills } from './skills-updater'
 import { setupSkillsHandlers } from './ipc/skills-handlers'
 import { setupScriptHandlers } from './ipc/script-handlers'
+import { registerActivityHistoryHandlers } from './ipc/activity-history-handlers'
 import { migrateConfig } from './config/migrate'
 import { readConfig, writeConfig } from './config/config'
 import { TrayManager } from './tray/tray-manager'
@@ -38,7 +39,7 @@ function createMenu() {
               { type: 'separator' as const },
               { role: 'services' as const },
               { type: 'separator' as const },
-              { role: 'hide' as const },
+              { role: 'hide' as const, accelerator: '' },
               { role: 'hideOthers' as const },
               { role: 'unhide' as const },
               { type: 'separator' as const },
@@ -173,6 +174,7 @@ function setupHandlers() {
   setupConfigHandlers(() => mainWindow)
   setupSkillsHandlers()
   setupScriptHandlers(() => mainWindow)
+  registerActivityHistoryHandlers()
   setupTerminalHandlers(
     () => mainWindow,
     // Notification callback - only show when window is not focused

--- a/desktop/src/main/ipc/activity-history-handlers.ts
+++ b/desktop/src/main/ipc/activity-history-handlers.ts
@@ -1,0 +1,11 @@
+import { ipcMain } from 'electron'
+import { readHistory, addHistoryEntry, clearHistory } from '../config/activity-history'
+
+export function registerActivityHistoryHandlers(): void {
+  ipcMain.handle('activityHistory:getAll', async () => readHistory())
+  ipcMain.handle('activityHistory:add', async (_event, params) => {
+    if (typeof params?.agentId !== 'string' || typeof params?.agentName !== 'string' || typeof params?.action !== 'string') return
+    return addHistoryEntry(params)
+  })
+  ipcMain.handle('activityHistory:clear', async () => clearHistory())
+}

--- a/desktop/src/main/ipc/terminal-handlers.ts
+++ b/desktop/src/main/ipc/terminal-handlers.ts
@@ -20,6 +20,8 @@ import {
   readAgents,
   updateAgentSplitPane,
 } from '../config/agents'
+import { addHistoryEntry } from '../config/activity-history'
+import type { HistoryAction } from '../../types'
 
 let getMainWindow: () => BrowserWindow | null
 let showNotification: (title: string, body: string) => void
@@ -27,6 +29,8 @@ let onAgentChange: (() => void) | null = null
 
 // Track last notification time per terminal to avoid spam
 const lastNotificationTime = new Map<string, number>()
+// Track previous metadata status per terminal for history entries
+const previousStatus = new Map<string, string>()
 const NOTIFICATION_COOLDOWN = 30000 // 30 seconds between notifications per terminal
 
 // Helper to show notification with cooldown and focus check
@@ -95,6 +99,7 @@ function createTerminalCallbacks(id: string, name: string) {
       if (mainWindow) {
         mainWindow.webContents.send('terminal:exit', { id, exitCode })
       }
+      previousStatus.delete(id)
     },
     onBranchChange: (branchName: string | null) => {
       const mainWindow = getMainWindow()
@@ -106,6 +111,32 @@ function createTerminalCallbacks(id: string, name: string) {
       const mainWindow = getMainWindow()
       if (mainWindow) {
         mainWindow.webContents.send('terminal:metadata', { id, metadata })
+      }
+
+      // Track status changes and create history entries
+      const newStatus = metadata.status || ''
+      const oldStatus = previousStatus.get(id) || ''
+      if (newStatus && newStatus !== oldStatus) {
+        const statusToAction: Record<string, HistoryAction> = {
+          'in progress': 'started',
+          'committed': 'committed',
+          'PR created': 'pr_created',
+          'in review': 'review',
+          'PR merged': 'merged',
+        }
+        const action = statusToAction[newStatus]
+        if (action) {
+          const t = getTerminal(id)
+          addHistoryEntry({
+            agentId: id,
+            agentName: t?.metadata?.title || t?.name || name,
+            action,
+            ticketId: t?.metadata?.ticketId,
+            description: t?.metadata?.description,
+            repositories: t?.repositories || [],
+          })
+        }
+        previousStatus.set(id, newStatus)
       }
     },
     onRepositoriesChange: (repositories: string[]) => {

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -213,6 +213,14 @@ const historyApi = {
     ipcRenderer.invoke('history:getLast', { repoPath }),
 }
 
+// Activity History API
+const activityHistoryApi = {
+  getAll: () => ipcRenderer.invoke('activityHistory:getAll'),
+  add: (params: { agentId: string; agentName: string; action: string; ticketId?: string; description?: string; repositories: string[] }) =>
+    ipcRenderer.invoke('activityHistory:add', params),
+  clear: () => ipcRenderer.invoke('activityHistory:clear'),
+}
+
 // Window API
 const windowApi = {
   minimize: () => ipcRenderer.invoke('window:minimize'),
@@ -323,6 +331,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   config: configApi,
   terminal: terminalApi,
   history: historyApi,
+  activityHistory: activityHistoryApi,
   window: windowApi,
   dialog: dialogApi,
   shell: shellApi,
@@ -340,6 +349,7 @@ declare global {
       config: typeof configApi
       terminal: typeof terminalApi
       history: typeof historyApi
+      activityHistory: typeof activityHistoryApi
       window: typeof windowApi
       dialog: typeof dialogApi
       shell: typeof shellApi

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -13,6 +13,7 @@ import { WhatsNewModal } from './components/WhatsNewModal'
 import { ConfigPage } from './pages/Config'
 import { TerminalsPage } from './pages/Terminals'
 import { SkillsPage } from './pages/Skills'
+import { HistoryPage } from './pages/History'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { useWindowSplitMode } from './hooks/useWindowSplitMode'
 
@@ -251,6 +252,13 @@ export function App() {
           <div className={`absolute inset-0 overflow-auto ${currentPage === 'skills' ? 'block' : 'hidden'}`}>
             <div className="max-w-5xl mx-auto p-6 h-full">
               <SkillsPage />
+            </div>
+          </div>
+
+          {/* History Page */}
+          <div className={`absolute inset-0 overflow-auto ${currentPage === 'history' ? 'block' : 'hidden'}`}>
+            <div className="max-w-5xl mx-auto p-6 h-full">
+              <HistoryPage />
             </div>
           </div>
 

--- a/desktop/src/renderer/components/IconSidebar.tsx
+++ b/desktop/src/renderer/components/IconSidebar.tsx
@@ -1,4 +1,4 @@
-import { Bot, Settings, Circle, AlertTriangle, Sparkles } from 'lucide-react'
+import { Bot, Settings, Circle, AlertTriangle, Sparkles, Clock } from 'lucide-react'
 import { useStore } from '../store'
 import { stateColorsIcon as stateColors, stateBgColorsIcon as stateBgColors } from '../utils/stateColors'
 import { useMemo } from 'react'
@@ -66,6 +66,19 @@ export function IconSidebar() {
         title="Skills"
       >
         <Sparkles className="w-5 h-5" />
+      </button>
+
+      {/* History button */}
+      <button
+        onClick={() => setCurrentPage('history')}
+        className={`w-10 h-10 flex items-center justify-center rounded-lg transition-colors ${
+          currentPage === 'history'
+            ? 'text-accent bg-accent/20'
+            : 'text-text-secondary hover:text-white hover:bg-bg-tertiary'
+        }`}
+        title="History"
+      >
+        <Clock className="w-5 h-5" />
       </button>
 
       {/* Spacer to push Configuration to bottom */}

--- a/desktop/src/renderer/components/Sidebar.tsx
+++ b/desktop/src/renderer/components/Sidebar.tsx
@@ -389,6 +389,7 @@ export function Sidebar() {
   const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
   const shortcutKey = isMac ? '⌘N' : 'Ctrl+N'
   const skillsShortcutKey = isMac ? '⌘;' : 'Ctrl+;'
+  const historyShortcutKey = isMac ? '⌘H' : 'Ctrl+H'
   const settingsShortcutKey = isMac ? '⌘,' : 'Ctrl+,'
 
   // Listen for Command+; keyboard shortcut to open skills
@@ -397,6 +398,20 @@ export function Sidebar() {
       if ((e.metaKey || e.ctrlKey) && e.key === ';') {
         e.preventDefault()
         setCurrentPage('skills')
+        setActiveTerminal(null)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [setCurrentPage, setActiveTerminal])
+
+  // Listen for Command+H keyboard shortcut to open history
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'h') {
+        e.preventDefault()
+        setCurrentPage('history')
         setActiveTerminal(null)
       }
     }
@@ -462,6 +477,23 @@ export function Sidebar() {
           <Sparkles className="w-4 h-4" />
           <span>Skills</span>
           <span className="ml-auto text-xs opacity-50">{skillsShortcutKey}</span>
+        </button>
+
+        {/* History button */}
+        <button
+          onClick={() => {
+            setCurrentPage('history')
+            setActiveTerminal(null)
+          }}
+          className={`w-full flex items-center justify-center gap-2 px-2.5 py-2.5 text-sm font-medium rounded-lg transition-all ${
+            currentPage === 'history'
+              ? 'bg-white/10 text-white'
+              : 'text-text-secondary hover:bg-text-secondary/10 hover:text-white'
+          }`}
+        >
+          <Clock className="w-4 h-4" />
+          <span>History</span>
+          <span className="ml-auto text-xs opacity-50">{historyShortcutKey}</span>
         </button>
 
         {/* Settings button */}

--- a/desktop/src/renderer/hooks/useActivityHistory.ts
+++ b/desktop/src/renderer/hooks/useActivityHistory.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import type { HistoryEntry } from '../../types'
+
+export interface HistoryGroup {
+  label: string
+  date: string
+  entries: HistoryEntry[]
+}
+
+function getDateKey(timestamp: number): string {
+  const d = new Date(timestamp)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function getDayLabel(dateKey: string): string {
+  const today = new Date()
+  const todayKey = getDateKey(today.getTime())
+
+  const yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+  const yesterdayKey = getDateKey(yesterday.getTime())
+
+  const [year, month, day] = dateKey.split('-').map(Number)
+  const d = new Date(year, month - 1, day)
+  const fullDate = d.toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' })
+
+  if (dateKey === todayKey) return `Today — ${fullDate}`
+  if (dateKey === yesterdayKey) return `Yesterday — ${fullDate}`
+
+  return fullDate
+}
+
+export function useActivityHistory() {
+  const [entries, setEntries] = useState<HistoryEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadHistory = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await window.electronAPI.activityHistory.getAll()
+      setEntries(data)
+    } catch (err) {
+      console.error('Error loading activity history:', err)
+      setError('Failed to load activity history')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadHistory()
+  }, [loadHistory])
+
+  const groups: HistoryGroup[] = useMemo(() => {
+    if (entries.length === 0) return []
+
+    const grouped = new Map<string, HistoryEntry[]>()
+
+    // Group entries by day
+    for (const entry of entries) {
+      const key = getDateKey(entry.timestamp)
+      if (!grouped.has(key)) {
+        grouped.set(key, [])
+      }
+      grouped.get(key)!.push(entry)
+    }
+
+    // Sort groups by date descending, entries within each group by timestamp descending
+    const sortedKeys = Array.from(grouped.keys()).sort((a, b) => b.localeCompare(a))
+
+    return sortedKeys.map(key => ({
+      label: getDayLabel(key),
+      date: key,
+      entries: grouped.get(key)!.sort((a, b) => b.timestamp - a.timestamp),
+    }))
+  }, [entries])
+
+  const clear = useCallback(async () => {
+    try {
+      await window.electronAPI.activityHistory.clear()
+      setEntries([])
+    } catch (err) {
+      console.error('Error clearing activity history:', err)
+    }
+  }, [])
+
+  return { groups, loading, error, refresh: loadHistory, clear }
+}

--- a/desktop/src/renderer/pages/History/index.tsx
+++ b/desktop/src/renderer/pages/History/index.tsx
@@ -1,0 +1,139 @@
+import { useState, useCallback } from 'react'
+import { Clock, Trash2 } from 'lucide-react'
+import { useActivityHistory } from '../../hooks/useActivityHistory'
+import type { HistoryAction } from '../../../types'
+
+const ACTION_CONFIG: Record<HistoryAction, { label: string; color: string }> = {
+  started: { label: 'Started', color: 'bg-green' },
+  committed: { label: 'Committed', color: 'bg-yellow' },
+  pr_created: { label: 'PR created', color: 'bg-blue' },
+  review: { label: 'In review', color: 'bg-purple' },
+  merged: { label: 'Merged', color: 'bg-green' },
+  done: { label: 'Done', color: 'bg-teal' },
+}
+
+function formatTime(timestamp: number): string {
+  const d = new Date(timestamp)
+  return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+export function HistoryPage() {
+  const { groups, loading, clear } = useActivityHistory()
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  const handleClear = useCallback(async () => {
+    await clear()
+    setShowConfirm(false)
+  }, [clear])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="w-8 h-8 border-3 border-white/20 border-t-accent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  if (groups.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4">
+        <div className="p-4 rounded-2xl bg-white/[0.04] border border-white/[0.08]">
+          <Clock className="w-8 h-8 text-text-secondary/50" />
+        </div>
+        <div className="text-center">
+          <h3 className="text-lg font-semibold text-white mb-1">No history yet</h3>
+          <p className="text-sm text-text-secondary">
+            Actions will appear here as your agents work.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6 pb-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Clock className="w-5 h-5 text-text-secondary" />
+          <h2 className="text-lg font-semibold text-white">History</h2>
+        </div>
+        {!showConfirm ? (
+          <button
+            onClick={() => setShowConfirm(true)}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/[0.08] rounded-lg hover:bg-white/[0.04] hover:text-white transition-all"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+            <span>Clear</span>
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowConfirm(false)}
+              className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/[0.08] rounded-lg hover:bg-white/[0.04] hover:text-white transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleClear}
+              className="px-3 py-1.5 text-xs font-medium text-red border border-red/20 rounded-lg hover:bg-red/10 transition-all"
+            >
+              Confirm clear
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Day groups */}
+      {groups.map(group => (
+        <div key={group.date} className="flex flex-col gap-2">
+          {/* Day header */}
+          <div className="flex items-center gap-3">
+            <h3 className="text-sm font-medium text-text-secondary">
+              {group.label}
+            </h3>
+            <div className="flex-1 h-px bg-white/[0.08]" />
+          </div>
+
+          {/* Entries */}
+          <div className="flex flex-col gap-1">
+            {group.entries.map(entry => {
+              const config = ACTION_CONFIG[entry.action]
+              return (
+                <div
+                  key={entry.id}
+                  className="flex items-center gap-3 px-4 py-3 rounded-lg bg-white/[0.04] border border-white/[0.08] hover:bg-white/[0.06] transition-colors"
+                >
+                  {/* Color dot */}
+                  <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${config.color}`} />
+
+                  {/* Time */}
+                  <span className="text-xs text-text-secondary/60 font-mono flex-shrink-0">
+                    {formatTime(entry.timestamp)}
+                  </span>
+
+                  {/* Agent name */}
+                  <span className="text-sm font-medium text-white truncate">
+                    {entry.agentName}
+                  </span>
+
+                  {/* Ticket ID */}
+                  {entry.ticketId && (
+                    <span className="text-xs text-accent/80 bg-accent/10 px-2 py-0.5 rounded flex-shrink-0">
+                      {entry.ticketId}
+                    </span>
+                  )}
+
+                  {/* Action label */}
+                  <span className="text-xs text-text-secondary ml-auto flex-shrink-0">
+                    {config.label}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/desktop/src/renderer/store/index.ts
+++ b/desktop/src/renderer/store/index.ts
@@ -27,7 +27,7 @@ interface AppState {
   rightPaneTerminalIds: string[]
 
   // UI
-  currentPage: 'config' | 'terminals' | 'skills'
+  currentPage: 'config' | 'terminals' | 'skills' | 'history'
   rightSidebar: 'info' | null
   leftSidebarVisible: boolean
   iconSidebarVisible: boolean
@@ -61,7 +61,7 @@ interface AppState {
   toggleSplitActive: () => void
   moveTerminalToPane: (id: string, pane: 'left' | 'right') => void
 
-  setCurrentPage: (page: 'config' | 'terminals' | 'skills') => void
+  setCurrentPage: (page: 'config' | 'terminals' | 'skills' | 'history') => void
   setRightSidebar: (sidebar: 'info' | null) => void
   toggleRightSidebar: (sidebar: 'info') => void
   toggleLeftSidebar: () => void

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -121,6 +121,19 @@ export interface CommandHistoryEntry {
   count: number  // Usage frequency
 }
 
+export type HistoryAction = 'started' | 'committed' | 'pr_created' | 'review' | 'merged' | 'done'
+
+export interface HistoryEntry {
+  id: string
+  agentId: string
+  agentName: string
+  action: HistoryAction
+  ticketId?: string
+  description?: string
+  repositories: string[]
+  timestamp: number
+}
+
 export type ScriptCategory = 'dev' | 'build' | 'test' | 'lint' | 'other'
 export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-slash",
-  "version": "0.39.8",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-slash",
-      "version": "0.39.8",
+      "version": "0.40.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",


### PR DESCRIPTION
## Description

Add a new **History** page to the desktop app that displays agent activity grouped by day. Each entry shows when an agent started, committed, created a PR, reviewed, or merged — auto-created when the agent's metadata status changes. Data persists in `~/.config/magic-slash/history.json`, capped at 500 entries with automatic purge of oldest.

## Related Issue

Closes #83

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

### Data layer (main process)
- Added `HistoryAction` type and `HistoryEntry` interface in `types.ts`
- Created `main/config/activity-history.ts` — persistence layer with `readHistory()`, `addHistoryEntry()`, `clearHistory()`, capped at 500 entries
- Created `main/ipc/activity-history-handlers.ts` — dedicated IPC handlers (`activityHistory:getAll`, `activityHistory:add`, `activityHistory:clear`) with input validation
- Modified `terminal-handlers.ts` — tracks status changes via a `previousStatus` map and auto-creates history entries when agent metadata status transitions (e.g. `in progress` → `started`, `committed` → `committed`, `PR created` → `pr_created`, etc.)

### Preload bridge
- Added `activityHistoryApi` in `preload/index.ts` and exposed it in the `Window` type declaration

### UI (renderer)
- Created `hooks/useActivityHistory.ts` — loads entries, groups them by day (Today / Yesterday / full date) with `useMemo`
- Created `pages/History/index.tsx` — page component with color-coded action dots, timestamps, agent names, ticket badges, empty state, and clear button with confirmation
- Added `'history'` to `currentPage` union type in the Zustand store
- Added History page routing in `App.tsx`
- Added History button (Clock icon) in `Sidebar.tsx` and `IconSidebar.tsx`
- Added `⌘H` keyboard shortcut (overrode native macOS Hide accelerator in `main/index.ts`)

### Tests
- Created `activity-history.test.ts` with 10 unit tests covering read, add (with 500-entry cap), clear, and error handling

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

### Test Steps

1. Run the desktop app (`npm run desktop` in the worktree)
2. Verify the **History** button (Clock icon) appears in the sidebar between Skills and Settings
3. Click the History button → the History page should display with an empty state ("No history yet")
4. Press `⌘H` from any page → should navigate to the History page
5. Start an agent and run `/magic:start` on a ticket → a "Started" entry should appear in the history after navigation refresh
6. Verify `~/.config/magic-slash/history.json` is created with the entry data
7. Click "Clear" → confirmation appears → confirm → all entries are removed
8. Run `npm test` → all 10 activity-history tests pass

## Screenshots

N/A — UI follows existing design system patterns (dark mode, Tailwind, lucide icons).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

- The `done` action type is defined in `HistoryAction` but intentionally has no automated trigger from metadata status changes — it is designed to be called by external skills (e.g., `/magic:done`) via the `activityHistory:add` API.
- The native macOS `⌘H` (Hide) accelerator was overridden with `accelerator: ''` on the menu item to allow the renderer to capture the shortcut for History navigation.
- The `previousStatus` map in `terminal-handlers.ts` is cleaned up on terminal exit to prevent memory leaks.