### PR TITLE
[#88] Add launch mode setting for Claude Code permission mode

### DIFF
--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
-import type { Config, RepositoryConfig } from '../../types'
+import type { Config, RepositoryConfig, LaunchMode } from '../../types'
 import { validateConfig, hasCriticalErrors } from './schema-validator'
 import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig } from './defaults'
 import { expandPath } from './validation'
@@ -380,6 +380,13 @@ export function updateSplitEnabled(enabled: boolean): Config {
 export function updateSplitActive(active: boolean): Config {
   const config = readConfig()
   config.splitActive = active
+  writeConfig(config)
+  return config
+}
+
+export function updateLaunchMode(mode: LaunchMode): Config {
+  const config = readConfig()
+  config.launchMode = mode
   writeConfig(config)
   return config
 }

--- a/desktop/src/main/config/defaults.test.ts
+++ b/desktop/src/main/config/defaults.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { isValidLaunchMode } from './defaults'
+
+describe('isValidLaunchMode', () => {
+  it('should return true for "plan"', () => {
+    expect(isValidLaunchMode('plan')).toBe(true)
+  })
+
+  it('should return true for "default"', () => {
+    expect(isValidLaunchMode('default')).toBe(true)
+  })
+
+  it('should return true for "acceptEdits"', () => {
+    expect(isValidLaunchMode('acceptEdits')).toBe(true)
+  })
+
+  it('should return true for "auto"', () => {
+    expect(isValidLaunchMode('auto')).toBe(true)
+  })
+
+  it('should return true for "bypassPermissions"', () => {
+    expect(isValidLaunchMode('bypassPermissions')).toBe(true)
+  })
+
+  it('should return false for an invalid string', () => {
+    expect(isValidLaunchMode('invalid')).toBe(false)
+  })
+
+  it('should return false for an empty string', () => {
+    expect(isValidLaunchMode('')).toBe(false)
+  })
+
+  it('should return false for a number', () => {
+    expect(isValidLaunchMode(42)).toBe(false)
+  })
+
+  it('should return false for null', () => {
+    expect(isValidLaunchMode(null)).toBe(false)
+  })
+
+  it('should return false for undefined', () => {
+    expect(isValidLaunchMode(undefined)).toBe(false)
+  })
+
+  it('should return false for a boolean', () => {
+    expect(isValidLaunchMode(true)).toBe(false)
+  })
+
+  it('should return false for an object', () => {
+    expect(isValidLaunchMode({ mode: 'plan' })).toBe(false)
+  })
+})

--- a/desktop/src/main/config/defaults.ts
+++ b/desktop/src/main/config/defaults.ts
@@ -1,4 +1,4 @@
-import type { RepositoryConfig, SpotlightConfig, SpotlightShortcut } from '../../types'
+import type { RepositoryConfig, SpotlightConfig, SpotlightShortcut, LaunchMode } from '../../types'
 
 export const VALID_SPOTLIGHT_SHORTCUTS: readonly SpotlightShortcut[] = [
   'Control+Space',
@@ -22,6 +22,18 @@ export function isValidSpotlightConfig(obj: unknown): obj is SpotlightConfig {
 }
 
 export const DEFAULT_SPOTLIGHT: SpotlightConfig = { enabled: true, shortcut: 'Control+Space' }
+
+const VALID_LAUNCH_MODES: readonly LaunchMode[] = [
+  'plan',
+  'default',
+  'acceptEdits',
+  'auto',
+  'bypassPermissions',
+] as const
+
+export function isValidLaunchMode(value: unknown): value is LaunchMode {
+  return typeof value === 'string' && (VALID_LAUNCH_MODES as readonly string[]).includes(value)
+}
 
 export const DEFAULT_REPOSITORY_FIELDS: Omit<RepositoryConfig, 'path' | 'keywords'> = {
   color: '#3B82F6',

--- a/desktop/src/main/config/migrate.test.ts
+++ b/desktop/src/main/config/migrate.test.ts
@@ -103,6 +103,7 @@ describe('migrateConfig — agents migration', () => {
       'Control+Space', 'Control+Shift+Space', 'Alt+Space', 'Alt+Shift+Space',
       'Control+M', 'Control+Shift+M', 'Alt+M', 'Alt+Shift+M',
     ]
+    const VALID_LAUNCH_MODES = ['plan', 'default', 'acceptEdits', 'auto', 'bypassPermissions']
     const mockDefaultSpotlight = { enabled: true, shortcut: 'Control+Space' }
     vi.doMock('./defaults', () => ({
       DEFAULT_REPOSITORY_FIELDS: {
@@ -129,6 +130,8 @@ describe('migrateConfig — agents migration', () => {
           typeof record.shortcut === 'string' &&
           VALID_SHORTCUTS.includes(record.shortcut)
       },
+      isValidLaunchMode: (value: unknown) =>
+        typeof value === 'string' && VALID_LAUNCH_MODES.includes(value),
     }))
 
     vi.resetModules()
@@ -219,5 +222,118 @@ describe('migrateConfig — agents migration', () => {
 
     // agents.json should NOT be created (not a valid array)
     expect(fs.existsSync(agentsFile)).toBe(false)
+  })
+})
+
+describe('migrateConfig — launchMode sanitization', () => {
+  let migrateConfig: typeof import('./migrate').migrateConfig
+
+  beforeEach(async () => {
+    vi.doMock('./config', () => ({
+      CONFIG_DIR: tmpDir,
+      CONFIG_FILE: configFile,
+      readConfig: () => {
+        try {
+          return JSON.parse(fs.readFileSync(configFile, 'utf8'))
+        } catch {
+          return { version: 'unknown', repositories: {}, splitEnabled: false, splitActive: false }
+        }
+      },
+      writeConfig: (config: unknown) => {
+        fs.writeFileSync(configFile, JSON.stringify(config, null, 2))
+      },
+      filterValidRepositories: (repos: string[]) => repos,
+    }))
+
+    vi.doMock('./agents', () => ({
+      writeAgents: (agents: unknown[]) => {
+        fs.writeFileSync(agentsFile, JSON.stringify(agents, null, 2))
+      },
+      AGENTS_FILE: agentsFile,
+    }))
+
+    vi.doMock('./schema-validator', () => ({
+      validateConfig: () => ({ valid: true, errors: [] }),
+      hasCriticalErrors: () => false,
+    }))
+
+    const VALID_SHORTCUTS = [
+      'Control+Space', 'Control+Shift+Space', 'Alt+Space', 'Alt+Shift+Space',
+      'Control+M', 'Control+Shift+M', 'Alt+M', 'Alt+Shift+M',
+    ]
+    const VALID_LAUNCH_MODES = ['plan', 'default', 'acceptEdits', 'auto', 'bypassPermissions']
+    const mockDefaultSpotlight = { enabled: true, shortcut: 'Control+Space' }
+    vi.doMock('./defaults', () => ({
+      DEFAULT_REPOSITORY_FIELDS: {
+        color: '#3B82F6',
+        languages: { commit: 'en', pullRequest: 'en', jiraComment: 'en', discussion: 'en' },
+        commit: { style: 'single-line', format: 'angular', coAuthor: true, includeTicketId: true },
+        resolve: {
+          commitMode: 'new', format: 'angular', style: 'single-line',
+          useCommitConfig: true, replyToComments: true, replyLanguage: 'en',
+        },
+        pullRequest: { autoLinkTickets: true },
+        issues: { commentOnPR: true, jiraUrl: '', githubIssuesUrl: '' },
+        branches: { development: '' },
+        worktreeFiles: [],
+      },
+      DEFAULT_SPOTLIGHT: mockDefaultSpotlight,
+      VALID_SPOTLIGHT_SHORTCUTS: VALID_SHORTCUTS,
+      isValidSpotlightShortcut: (value: unknown) =>
+        typeof value === 'string' && VALID_SHORTCUTS.includes(value),
+      isValidSpotlightConfig: (obj: unknown) => {
+        if (typeof obj !== 'object' || obj === null) return false
+        const record = obj as Record<string, unknown>
+        return typeof record.enabled === 'boolean' &&
+          typeof record.shortcut === 'string' &&
+          VALID_SHORTCUTS.includes(record.shortcut)
+      },
+      isValidLaunchMode: (value: unknown) =>
+        typeof value === 'string' && VALID_LAUNCH_MODES.includes(value),
+    }))
+
+    vi.resetModules()
+    const mod = await import('./migrate')
+    migrateConfig = mod.migrateConfig
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should reset an invalid launchMode to undefined', () => {
+    writeConfigFile(minimalConfig({ launchMode: 'turbo' }))
+
+    migrateConfig('1.0.0')
+
+    const config = readConfigFile() as Record<string, unknown>
+    expect(config).not.toHaveProperty('launchMode')
+  })
+
+  it('should preserve a valid launchMode during migration', () => {
+    writeConfigFile(minimalConfig({ launchMode: 'auto' }))
+
+    migrateConfig('1.0.0')
+
+    const config = readConfigFile() as Record<string, unknown>
+    expect(config.launchMode).toBe('auto')
+  })
+
+  it('should not add launchMode when it is absent from config', () => {
+    writeConfigFile(minimalConfig())
+
+    migrateConfig('1.0.0')
+
+    const config = readConfigFile() as Record<string, unknown>
+    expect(config).not.toHaveProperty('launchMode')
+  })
+
+  it('should reset launchMode when it is a non-string value', () => {
+    writeConfigFile(minimalConfig({ launchMode: 123 }))
+
+    migrateConfig('1.0.0')
+
+    const config = readConfigFile() as Record<string, unknown>
+    expect(config).not.toHaveProperty('launchMode')
   })
 })

--- a/desktop/src/main/config/migrate.ts
+++ b/desktop/src/main/config/migrate.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import { readConfig, writeConfig, CONFIG_DIR, CONFIG_FILE } from './config'
 import { writeAgents, AGENTS_FILE } from './agents'
 import { validateConfig } from './schema-validator'
-import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig } from './defaults'
+import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig, isValidLaunchMode } from './defaults'
 import type { RepositoryConfig } from '../../types'
 
 const CONFIG_BACKUP = path.join(CONFIG_DIR, 'config.json.bak')
@@ -107,6 +107,11 @@ export function migrateConfig(appVersion?: string): boolean {
     if (!isValidSpotlightConfig(config.spotlight)) {
       config.spotlight = { ...DEFAULT_SPOTLIGHT }
     }
+    changed = true
+  }
+
+  if (config.launchMode !== undefined && !isValidLaunchMode(config.launchMode)) {
+    config.launchMode = undefined
     changed = true
   }
 

--- a/desktop/src/main/config/schema-validator.test.ts
+++ b/desktop/src/main/config/schema-validator.test.ts
@@ -190,6 +190,49 @@ describe('validateConfig', () => {
     expect(result.valid).toBe(false)
     expect(result.errors.some(e => e.includes('unknown property') && e.includes('agents'))).toBe(true)
   })
+
+  // --- launchMode tests ---
+
+  it('should pass for a valid launchMode', () => {
+    const config = {
+      ...validConfig(),
+      launchMode: 'auto'
+    }
+    const result = validateConfig(config)
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  it('should pass for each valid launchMode value', () => {
+    for (const mode of ['plan', 'default', 'acceptEdits', 'auto', 'bypassPermissions']) {
+      const config = {
+        ...validConfig(),
+        launchMode: mode
+      }
+      const result = validateConfig(config)
+      expect(result.valid).toBe(true)
+      expect(result.errors).toHaveLength(0)
+    }
+  })
+
+  it('should fail for an invalid launchMode value', () => {
+    const config = {
+      ...validConfig(),
+      launchMode: 'turbo'
+    }
+    const result = validateConfig(config)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('launchMode') && e.includes('must be one of'))).toBe(true)
+  })
+
+  it('should pass when launchMode is omitted (it is optional)', () => {
+    const config = validConfig()
+    // Ensure launchMode is not set
+    delete (config as Record<string, unknown>).launchMode
+    const result = validateConfig(config)
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+  })
 })
 
 describe('hasCriticalErrors', () => {

--- a/desktop/src/main/ipc/config-handlers.ts
+++ b/desktop/src/main/ipc/config-handlers.ts
@@ -16,10 +16,11 @@ import {
   updateRepositoryWorktreeFilesSettings,
   updateSplitEnabled,
   updateSplitActive,
+  updateLaunchMode,
 } from '../config/config'
 import { reRegisterSpotlightShortcut } from '../spotlight-shortcut'
 import { repairConfig } from '../config/migrate'
-import { isValidSpotlightShortcut } from '../config/defaults'
+import { isValidSpotlightShortcut, isValidLaunchMode } from '../config/defaults'
 import { validateConfig } from '../config/schema-validator'
 import {
   validateRepoName,
@@ -177,6 +178,14 @@ export function setupConfigHandlers(getMainWindow: () => BrowserWindow | null) {
     writeConfig(config)
     const result = reRegisterSpotlightShortcut()
     return { config, registered: result.registered }
+  })
+
+  ipcMain.handle('config:updateLaunchMode', async (_event, { mode }: { mode: string }) => {
+    if (!isValidLaunchMode(mode)) {
+      throw new Error(`Invalid launch mode: '${mode}'. Must be one of: plan, default, acceptEdits, auto, bypassPermissions.`)
+    }
+    const config = updateLaunchMode(mode)
+    return { config }
   })
 
   // Validate path

--- a/desktop/src/main/pty/terminal-manager.ts
+++ b/desktop/src/main/pty/terminal-manager.ts
@@ -3,6 +3,7 @@ import * as os from 'os'
 import * as fs from 'fs'
 import * as path from 'path'
 import { execSync, execFileSync } from 'child_process'
+import { readConfig } from '../config/config'
 import { updateAgentMetadata, updateAgentRepositories, createDefaultMetadata, mergeMetadata } from '../config/agents'
 import { expandPath } from '../config/validation'
 import { getCommonPaths } from '../utils/paths'
@@ -427,9 +428,11 @@ export function launchClaude(
 
   // Function to create and attach a new PTY process
   const createPtyProcess = (currentCwd: string, cols: number = 120, rows: number = DEFAULT_PTY_ROWS) => {
+    const launchMode = readConfig().launchMode
+    const modeFlag = launchMode && launchMode !== 'default' ? ` --permission-mode ${launchMode}` : ''
     const claudeCmd = pendingPrompt
-      ? `claude ${JSON.stringify(pendingPrompt)}`
-      : 'claude'
+      ? `claude${modeFlag} ${JSON.stringify(pendingPrompt)}`
+      : `claude${modeFlag}`
     pendingPrompt = null
     const ptyProcess = pty.spawn(shell, ['-li', '-c', claudeCmd], {
       name: 'xterm-256color',

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -57,6 +57,9 @@ const configApi = {
   updateSpotlight: (spotlight: { enabled: boolean; shortcut: string }) =>
     ipcRenderer.invoke('config:updateSpotlight', spotlight),
 
+  updateLaunchMode: (mode: string) =>
+    ipcRenderer.invoke('config:updateLaunchMode', { mode }),
+
   repair: (): Promise<{ repaired: boolean; fixes: string[] }> =>
     ipcRenderer.invoke('config:repair'),
 

--- a/desktop/src/renderer/hooks/useConfig.ts
+++ b/desktop/src/renderer/hooks/useConfig.ts
@@ -93,6 +93,12 @@ export function useConfig() {
     return result
   }, [setConfig])
 
+  const updateLaunchMode = useCallback(async (mode: string) => {
+    const result = await window.electronAPI.config.updateLaunchMode(mode)
+    setConfig(result.config)
+    return result
+  }, [setConfig])
+
   const validatePath = useCallback(async (path: string) => {
     return window.electronAPI.config.validatePath(path)
   }, [])
@@ -127,6 +133,7 @@ export function useConfig() {
     updateRepositoryWorktreeFilesSettings,
     updateSplitEnabled,
     updateSpotlight,
+    updateLaunchMode,
     validatePath,
     getPRTemplate,
     createPRTemplate,

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useMemo } from 'react'
-import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle } from 'lucide-react'
+import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield } from 'lucide-react'
 import { RepoPage } from './RepoPage'
 import { useStore } from '../../store'
 import { useConfig } from '../../hooks/useConfig'
-import type { SpotlightShortcut } from '../../../types'
+import type { SpotlightShortcut, LaunchMode } from '../../../types'
 import { showToast } from '../../components/Toast'
 import { getProjectColorMap } from '../../utils/projectColors'
 
@@ -18,9 +18,17 @@ const SPOTLIGHT_OPTIONS: { label: string; value: string }[] = [
   { label: '\u2325\u21E7 M', value: 'Alt+Shift+M' },
 ]
 
+const LAUNCH_MODE_OPTIONS: { value: LaunchMode; label: string; description: string }[] = [
+  { value: 'plan', label: 'Plan', description: 'Read-only — Claude explores and analyzes but never modifies anything' },
+  { value: 'default', label: 'Standard', description: 'Claude asks permission for every sensitive action' },
+  { value: 'acceptEdits', label: 'Accept Edits', description: 'Auto-accepts file edits, still asks for bash commands' },
+  { value: 'auto', label: 'Auto', description: 'Auto-approves most actions based on configured allowlists' },
+  { value: 'bypassPermissions', label: 'Bypass', description: 'No permission checks — for sandboxed environments only' },
+]
+
 function WelcomePage() {
   const { config, terminals, splitEnabled, toggleSplitEnabled } = useStore()
-  const { addRepository, updateSplitEnabled, updateSpotlight } = useConfig()
+  const { addRepository, updateSplitEnabled, updateSpotlight, updateLaunchMode } = useConfig()
   const [githubStatus, setGithubStatus] = useState<Record<string, boolean>>({})
   const [isAdding, setIsAdding] = useState(false)
   const [appVersion, setAppVersion] = useState('')
@@ -29,6 +37,8 @@ function WelcomePage() {
   const [spotlightEnabled, setSpotlightEnabled] = useState(config?.spotlight?.enabled ?? true)
   const [spotlightShortcut, setSpotlightShortcut] = useState(config?.spotlight?.shortcut ?? 'Control+Space')
   const [spotlightError, setSpotlightError] = useState(false)
+  const [launchMode, setLaunchMode] = useState<LaunchMode>(config?.launchMode ?? 'default')
+  const [showBypassWarning, setShowBypassWarning] = useState(false)
 
   const configSpotlightEnabled = config?.spotlight?.enabled
   const configSpotlightShortcut = config?.spotlight?.shortcut
@@ -36,6 +46,11 @@ function WelcomePage() {
     if (configSpotlightEnabled !== undefined) setSpotlightEnabled(configSpotlightEnabled)
     if (configSpotlightShortcut !== undefined) setSpotlightShortcut(configSpotlightShortcut)
   }, [configSpotlightEnabled, configSpotlightShortcut])
+
+  const configLaunchMode = config?.launchMode
+  useEffect(() => {
+    if (configLaunchMode !== undefined) setLaunchMode(configLaunchMode)
+  }, [configLaunchMode])
 
   const handleSpotlightToggle = async () => {
     const newEnabled = !spotlightEnabled
@@ -63,6 +78,26 @@ function WelcomePage() {
     } catch {
       setSpotlightShortcut(previousShortcut)
     }
+  }
+
+  const applyLaunchMode = async (mode: LaunchMode) => {
+    const previous = launchMode
+    setLaunchMode(mode)
+    setShowBypassWarning(false)
+    try {
+      await updateLaunchMode(mode)
+      showToast('Launch mode updated', 'success')
+    } catch {
+      setLaunchMode(previous)
+    }
+  }
+
+  const handleLaunchModeChange = (mode: LaunchMode) => {
+    if (mode === 'bypassPermissions') {
+      setShowBypassWarning(true)
+      return
+    }
+    applyLaunchMode(mode)
   }
 
   const repos = Object.entries(config?.repositories || {})
@@ -260,6 +295,59 @@ function WelcomePage() {
             })}
           </div>
         )}
+      </div>
+
+      {/* Launch Mode Section */}
+      <div>
+        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
+          <Shield className="w-4 h-4" />
+          <span>Launch Mode</span>
+        </div>
+        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium">Permission mode</div>
+              <div className="text-xs text-text-secondary/50 mt-0.5">Controls the level of autonomy for all Claude Code agents</div>
+            </div>
+            <div className="relative">
+              <select
+                value={launchMode}
+                onChange={(e) => handleLaunchModeChange(e.target.value as LaunchMode)}
+                className="w-52 px-3 py-2 bg-bg border border-white/10 rounded-lg text-sm focus:outline-none focus:border-accent transition-colors appearance-none cursor-pointer"
+              >
+                {LAUNCH_MODE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+              <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary/50 pointer-events-none" />
+            </div>
+          </div>
+          <div className="text-xs text-text-secondary/50">
+            {LAUNCH_MODE_OPTIONS.find(o => o.value === launchMode)?.description}
+          </div>
+          {showBypassWarning && (
+            <div className="flex flex-col gap-3 px-3 py-3 bg-red/10 border border-red/20 rounded-lg">
+              <div className="flex items-center gap-2 text-xs text-red">
+                <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+                <span className="font-medium">Security warning: Bypass mode disables all permission checks. Only use in sandboxed environments with no internet access.</span>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => applyLaunchMode('bypassPermissions')}
+                  className="px-3 py-1.5 bg-red/20 hover:bg-red/30 text-red text-xs rounded-lg transition-colors"
+                >
+                  I understand, enable Bypass
+                </button>
+                <button
+                  onClick={() => setShowBypassWarning(false)}
+                  className="px-3 py-1.5 bg-white/10 hover:bg-white/15 text-text-secondary text-xs rounded-lg transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Split View Section */}

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -89,6 +89,8 @@ export interface SpotlightConfig {
   shortcut: SpotlightShortcut
 }
 
+export type LaunchMode = 'plan' | 'default' | 'acceptEdits' | 'auto' | 'bypassPermissions'
+
 export interface Config {
   version: string
   repositories: Record<string, RepositoryConfig>
@@ -100,6 +102,7 @@ export interface Config {
     atlassian?: boolean
   }
   spotlight?: SpotlightConfig
+  launchMode?: LaunchMode
 }
 
 export interface PRTemplate {

--- a/install/config-schema.json
+++ b/install/config-schema.json
@@ -65,6 +65,11 @@
       },
       "additionalProperties": false,
       "description": "Spotlight (Quick Launch) global shortcut settings"
+    },
+    "launchMode": {
+      "type": "string",
+      "enum": ["plan", "default", "acceptEdits", "auto", "bypassPermissions"],
+      "description": "Permission mode for Claude Code agents"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Description

Add a global "Launch Mode" setting in the desktop app that controls the `--permission-mode` flag passed to Claude Code when spawning agents. Five modes available: Plan (read-only), Standard (default), Accept Edits, Auto, and Bypass (with security warning).

## Related Issue

Closes #88

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- Added `LaunchMode` type and `Config.launchMode` field in `types.ts`
- Added validation (`isValidLaunchMode`) and constants in `defaults.ts`
- Added `updateLaunchMode()` config persistence function in `config.ts`
- Added `launchMode` property to JSON Schema in `config-schema.json`
- Added migration sanitization for invalid values in `migrate.ts`
- Added IPC handler `config:updateLaunchMode` in `config-handlers.ts`
- Added preload bridge in `preload/index.ts` and React hook in `useConfig.ts`
- Added "Launch Mode" settings section with dropdown selector and Bypass security warning in `Config/index.tsx`
- Modified `terminal-manager.ts` to inject `--permission-mode <mode>` flag when spawning agents (skipped for default mode)

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

### Test Steps

1. Run `npm run desktop` to launch the desktop app
2. Open Settings (gear icon) — verify the "Launch Mode" section appears with a dropdown showing 5 modes
3. Select "Auto" → verify toast "Launch mode updated" appears → check `~/.config/magic-slash/config.json` contains `"launchMode": "auto"`
4. Select "Bypass" → verify a red security warning appears with "I understand, enable Bypass" and "Cancel" buttons
5. Click "Cancel" → verify the mode did not change; click Bypass again → confirm → verify persistence
6. Launch an agent and verify the terminal command includes `--permission-mode auto` (or whichever mode is selected)
7. Select "Standard" → verify no `--permission-mode` flag is passed (default Claude behavior)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

- 20 new tests added: validator tests (`defaults.test.ts`), schema validation tests, and migration sanitization tests
- 106 total tests passing (86 existing + 20 new)
- The `readConfig()` call in `createPtyProcess` reads from disk at each PTY spawn to always pick up the latest config — acceptable since spawns are infrequent