### PR TITLE
[#21] Add descriptive slug to branch names in /start

### DIFF
--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -72,7 +72,7 @@ Use `mcp__atlassian__getJiraIssue` to retrieve ticket details. If you don't know
 
 If the MCP call fails (timeout, auth error), retry once. If it fails again, ask the user to provide the ticket title and description manually so the workflow can continue.
 
-→ Continue to Step 2.5, then Step 2.6.
+→ Continue to Step 2.5, then Step 2.6, then Step 2.7.
 
 ## Step 2B: Retrieve the GitHub issue
 
@@ -100,7 +100,7 @@ Use `mcp__github__get_issue` for each repo — launch all calls in parallel for 
 - **Single issue**: Use it. Scope = that repo.
 - **Multiple issues**: Use `AskUserQuestion` with the list of issues as options. Display `MSG_GITHUB_MULTI_ISSUE` as the question text.
 
-→ Continue to Step 2.5, then Step 2.6.
+→ Continue to Step 2.5, then Step 2.6, then Step 2.7.
 
 ## Step 2.5: Update Magic Slash Desktop metadata
 
@@ -135,6 +135,19 @@ This step never blocks the process. On failure, display a warning and continue.
 2. If found: Add via `mcp__github__update_issue` (keep existing labels)
 3. If not found: Continue without modification (do not create a label)
 4. On failure: Display `MSG_LABEL_FAILED`
+
+## Step 2.7: Generate branch slug
+
+Generate a short, human-readable slug from the ticket title to append to the branch name.
+
+```bash
+SLUG=$(echo "$TICKET_TITLE" | \
+  tr '[:upper:]' '[:lower:]' | \
+  sed 's/[^a-z0-9]/-/g; s/--*/-/g; s/^-//; s/-$//' | \
+  cut -d'-' -f1-5 | cut -c1-30 | sed 's/-$//')
+```
+
+If `$SLUG` is empty after processing (e.g., title with only special characters), skip the slug — the branch name falls back to the ticket ID alone.
 
 ## Step 3: Analyze ticket scope (smart repo selection)
 
@@ -204,17 +217,20 @@ If `git pull --rebase` fails with conflicts, use `AskUserQuestion` with `MSG_REB
 **Create the worktree:**
 
 ```bash
-git worktree add -b feature/$TICKET_ID ../${REPO_NAME}-$TICKET_ID $DEV_BRANCH
+BRANCH_NAME="feature/$TICKET_ID"
+[ -n "$SLUG" ] && BRANCH_NAME="feature/$TICKET_ID-$SLUG"
+git worktree add -b "$BRANCH_NAME" ../${REPO_NAME}-$TICKET_ID $DEV_BRANCH
 ```
 
 If this fails because the branch already exists, use `AskUserQuestion` with `MSG_BRANCH_ALREADY_EXISTS` options:
-- Option 1: `git worktree add ../${REPO_NAME}-$TICKET_ID feature/$TICKET_ID` (use existing branch)
-- Option 2: `git branch -D feature/$TICKET_ID` then retry creation
+- Option 1: `git worktree add ../${REPO_NAME}-$TICKET_ID $BRANCH_NAME` (use existing branch)
+- Option 2: `git branch -D $BRANCH_NAME` then retry creation
 - Option 3: Stop
 
 **Branch naming**:
-- Jira: `feature/PROJ-1234`
-- GitHub: `feature/repo-name-123` (prefix with repo name to avoid conflicts)
+- Jira: `feature/PROJ-1234-implement-stripe-refunds`
+- GitHub: `feature/repo-name-123-add-user-profile` (prefix with repo name to avoid conflicts)
+- If the slug is empty, falls back to `feature/$TICKET_ID` (no trailing hyphen)
 
 **Change to the worktree** — the rest of the skill operates from inside the worktree, so all subsequent file operations and commands target the right directory:
 

--- a/skills/magic-start/references/messages.md
+++ b/skills/magic-start/references/messages.md
@@ -219,7 +219,7 @@ Choix (1/2/3) :
 ### en
 
 ```text
-⚠️ Branch feature/{TICKET_ID} already exists.
+⚠️ Branch {BRANCH_NAME} already exists.
 
 Options:
 1. Use the existing branch (checkout into worktree)
@@ -232,7 +232,7 @@ Choose (1/2/3):
 ### fr
 
 ```text
-⚠️ La branche feature/{TICKET_ID} existe déjà.
+⚠️ La branche {BRANCH_NAME} existe déjà.
 
 Options :
 1. Utiliser la branche existante (checkout dans le worktree)


### PR DESCRIPTION
## Description

When working on several feature branches, it's hard to identify which branch corresponds to which task. This PR appends a short, human-readable slug derived from the ticket title to branch names created by `/start`.

Example: `feature/PROJ-1234-implement-stripe-refunds` instead of `feature/PROJ-1234`.

## Related Issue

Closes #21

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- Added **Step 2.7: Generate branch slug** in `magic-start/SKILL.md` — a bash pipeline that converts the ticket title to a short kebab-case slug (lowercase, max 5 words / 30 chars)
- Updated **Step 4.1** branch creation to use `feature/$TICKET_ID-$SLUG` with graceful fallback when slug is empty
- Updated **branch-already-exists** error handling to reference `$BRANCH_NAME` variable
- Updated **branch naming documentation** with new examples
- Updated flow references in Steps 2A and 2B.4 to include Step 2.7
- Updated **MSG_BRANCH_ALREADY_EXISTS** messages (EN + FR) to use `{BRANCH_NAME}` placeholder

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [x] Tested affected slash commands

### Test Steps

1. Run `/start` with a Jira ticket (e.g., `PER-1234` titled "Implement Stripe refunds") and verify the created branch is `feature/PER-1234-implement-stripe-refunds`
2. Run `/start` with a GitHub issue (e.g., `#42` titled "Add user profile page") and verify the branch is `feature/repo-name-42-add-user-profile-page`
3. Test with a long title (>5 words, >30 chars) and verify the slug is truncated correctly
4. Test with a title containing special characters or accents and verify they are sanitized to hyphens
5. Test creating a branch that already exists and verify the error message shows the full branch name with slug

## Screenshots

N/A — skill changes (Markdown), no UI impact.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

- The **worktree directory name** stays as `../${REPO_NAME}-$TICKET_ID` (unchanged) — only the git branch name includes the slug, to avoid side effects on `magic-continue` and the Desktop app
- The separator is `-` (not `:`) because colons are forbidden on Windows/NTFS file systems
- Downstream skills (`magic-commit`, `magic-continue`, `magic-pr`) remain compatible: they extract ticket IDs via non-anchored regex patterns that match the ID regardless of suffix