### PR TITLE
[#65] feat(desktop): add user profile onboarding wizard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,16 @@ npm run desktop:package  # Package for macOS (.dmg, .zip)
 Config file: `~/.config/magic-slash/config.json`
 
 Contains configured repositories, each with: path, keywords, languages (commit/PR/Jira), commit format (angular), and PR/issues options.
+
+## User Profile
+
+Profile file: `~/.config/magic-slash/profile.md` (YAML frontmatter + markdown body).
+
+At the start of any `/magic:*` skill execution:
+1. Check if `~/.config/magic-slash/profile.md` exists; if not, continue with default behavior
+2. Read the YAML frontmatter fields: `name`, `role`, `technical_level`, `communication_style`, `languages`
+3. Adapt vocabulary and technical depth based on `technical_level` (beginner = simple terms, expert = precise jargon)
+4. Adapt detail level based on `role` (e.g., product/manager gets high-level summaries, dev gets code-level details)
+5. Use `communication_style` to control response format (simple = concise, technical = code-focused, detailed = thorough)
+6. Communicate in the language(s) listed in `languages` when present
+7. Address the user by `name` when natural to do so

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ npm run desktop:package
 | ----------------------------------- | ------------------------------------- |
 | `~/.claude/settings.json`           | Atlassian & GitHub MCP configuration  |
 | `~/.config/magic-slash/config.json` | Repository paths, keywords, settings  |
+| `~/.config/magic-slash/profile.md`  | User profile (role, level, preferences) |
 | `~/.local/bin/magic-slash`          | CLI command to launch the desktop app |
 | `~/.claude/skills/magic-slash/`     | Installed skills (all 7 skills)       |
 
@@ -377,6 +378,21 @@ Each repository can be independently configured:
 | `worktreeFiles` | Files to auto-copy from main repo to worktrees (e.g., `.env`) | `[]`    |
 
 > When creating a worktree, Magic Slash copies these files from the main repository. If not configured, it auto-detects common untracked files and offers to save them for future use.
+
+### User profile
+
+On first launch, the Desktop app presents an onboarding wizard to create a user profile. The profile is stored at `~/.config/magic-slash/profile.md` and contains:
+
+| Field                | Type         | Required | Description                                           |
+| -------------------- | ------------ | -------- | ----------------------------------------------------- |
+| `name`               | text         | yes      | First name, used to personalize responses             |
+| `role`               | select       | yes      | Product / Dev / Design / QA / Ops / Manager / Other   |
+| `technical_level`    | select       | yes      | Beginner / Intermediate / Expert                      |
+| `communication_style`| select       | no       | Simple / Technical / Detailed                         |
+| `languages`          | multi-select | no       | Preferred languages (English, Français)               |
+| Free text            | textarea     | no       | Anything else Claude should know                      |
+
+All `/magic:*` skills read this profile to adapt their communication — vocabulary, detail level, and language — based on the user's role and technical level. The profile can be edited anytime from **Settings > Profile** in the Desktop app.
 
 ### Keywords
 

--- a/desktop/src/main/config/profile.test.ts
+++ b/desktop/src/main/config/profile.test.ts
@@ -1,0 +1,599 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'profile-test-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+/** Write a profile.md file in the temp dir. */
+function writeProfileFile(content: string): void {
+  fs.writeFileSync(path.join(tmpDir, 'profile.md'), content, 'utf8')
+}
+
+/** Read profile.md from the temp dir. */
+function readProfileFile(): string {
+  return fs.readFileSync(path.join(tmpDir, 'profile.md'), 'utf8')
+}
+
+// ---------------------------------------------------------------------------
+// readProfile
+// ---------------------------------------------------------------------------
+
+describe('readProfile', () => {
+  let readProfile: typeof import('./profile').readProfile
+
+  beforeEach(async () => {
+    vi.doMock('./config', () => ({ CONFIG_DIR: tmpDir }))
+    vi.resetModules()
+    const mod = await import('./profile')
+    readProfile = mod.readProfile
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should return null when profile.md does not exist', () => {
+    expect(readProfile()).toBeNull()
+  })
+
+  it('should parse a valid profile with all fields', () => {
+    writeProfileFile([
+      '---',
+      'name: Alice',
+      'role: dev',
+      'technical_level: expert',
+      'communication_style: technical',
+      'languages:',
+      '  - English',
+      '  - French',
+      'free_text: Prefers concise answers',
+      '---',
+      '',
+      'I am a Developer. My technical level is expert.',
+    ].join('\n'))
+
+    const profile = readProfile()
+    expect(profile).not.toBeNull()
+    expect(profile!.name).toBe('Alice')
+    expect(profile!.role).toBe('dev')
+    expect(profile!.technical_level).toBe('expert')
+    expect(profile!.communication_style).toBe('technical')
+    expect(profile!.languages).toEqual(['English', 'French'])
+    expect(profile!.freeText).toBe('Prefers concise answers')
+  })
+
+  it('should parse a minimal profile (required fields only)', () => {
+    writeProfileFile([
+      '---',
+      'name: Bob',
+      'role: product',
+      'technical_level: beginner',
+      '---',
+      '',
+      'I am a Product Manager.',
+    ].join('\n'))
+
+    const profile = readProfile()
+    expect(profile).not.toBeNull()
+    expect(profile!.name).toBe('Bob')
+    expect(profile!.role).toBe('product')
+    expect(profile!.technical_level).toBe('beginner')
+    expect(profile!.communication_style).toBeUndefined()
+    expect(profile!.languages).toBeUndefined()
+    expect(profile!.freeText).toBeUndefined()
+  })
+
+  it('should return null when frontmatter delimiters are missing', () => {
+    writeProfileFile('name: Alice\nrole: dev\ntechnical_level: expert')
+    expect(readProfile()).toBeNull()
+  })
+
+  it('should return null when frontmatter is malformed (no closing ---)', () => {
+    writeProfileFile('---\nname: Alice\nrole: dev\ntechnical_level: expert\n')
+    expect(readProfile()).toBeNull()
+  })
+
+  it('should return null when required field "name" is missing', () => {
+    writeProfileFile('---\nrole: dev\ntechnical_level: expert\n---\n')
+    expect(readProfile()).toBeNull()
+  })
+
+  it('should return null when required field "role" is missing', () => {
+    writeProfileFile('---\nname: Alice\ntechnical_level: expert\n---\n')
+    expect(readProfile()).toBeNull()
+  })
+
+  it('should return null when required field "technical_level" is missing', () => {
+    writeProfileFile('---\nname: Alice\nrole: dev\n---\n')
+    expect(readProfile()).toBeNull()
+  })
+
+  it('should handle a name containing colons (quoted)', () => {
+    writeProfileFile([
+      '---',
+      "name: 'Dr. Smith: Surgeon'",
+      'role: other',
+      'technical_level: expert',
+      '---',
+    ].join('\n'))
+
+    const profile = readProfile()
+    expect(profile).not.toBeNull()
+    expect(profile!.name).toBe('Dr. Smith: Surgeon')
+  })
+
+  it('should handle a free_text value containing colons (quoted)', () => {
+    writeProfileFile([
+      '---',
+      'name: Alice',
+      'role: dev',
+      'technical_level: intermediate',
+      "free_text: 'Note: prefers short answers'",
+      '---',
+    ].join('\n'))
+
+    const profile = readProfile()
+    expect(profile).not.toBeNull()
+    expect(profile!.freeText).toBe('Note: prefers short answers')
+  })
+
+  it('should handle double-quoted values', () => {
+    writeProfileFile([
+      '---',
+      'name: "Jane Doe"',
+      'role: qa',
+      'technical_level: beginner',
+      '---',
+    ].join('\n'))
+
+    const profile = readProfile()
+    expect(profile).not.toBeNull()
+    expect(profile!.name).toBe('Jane Doe')
+  })
+
+  it('should unescape doubled single quotes', () => {
+    writeProfileFile([
+      '---',
+      "name: 'O''Brien'",
+      'role: dev',
+      'technical_level: expert',
+      '---',
+    ].join('\n'))
+
+    const profile = readProfile()
+    expect(profile).not.toBeNull()
+    expect(profile!.name).toBe("O'Brien")
+  })
+
+  it('should skip empty optional fields gracefully', () => {
+    writeProfileFile([
+      '---',
+      'name: Alice',
+      'role: dev',
+      'technical_level: expert',
+      'communication_style:',
+      '---',
+    ].join('\n'))
+
+    const profile = readProfile()
+    expect(profile).not.toBeNull()
+    // communication_style was empty so it should be treated as an empty array key (not set on profile)
+    expect(profile!.communication_style).toBeUndefined()
+  })
+
+  it('should parse a single language in the array', () => {
+    writeProfileFile([
+      '---',
+      'name: Alice',
+      'role: dev',
+      'technical_level: expert',
+      'languages:',
+      '  - English',
+      '---',
+    ].join('\n'))
+
+    const profile = readProfile()
+    expect(profile).not.toBeNull()
+    expect(profile!.languages).toEqual(['English'])
+  })
+
+  it('should return null for completely empty file', () => {
+    writeProfileFile('')
+    expect(readProfile()).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// writeProfile
+// ---------------------------------------------------------------------------
+
+describe('writeProfile', () => {
+  let writeProfile: typeof import('./profile').writeProfile
+
+  beforeEach(async () => {
+    vi.doMock('./config', () => ({ CONFIG_DIR: tmpDir }))
+    vi.resetModules()
+    const mod = await import('./profile')
+    writeProfile = mod.writeProfile
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should generate correct YAML frontmatter and body for a full profile', () => {
+    writeProfile({
+      name: 'Alice',
+      role: 'dev',
+      technical_level: 'expert',
+      communication_style: 'technical',
+      languages: ['English', 'French'],
+      freeText: 'Prefers concise answers',
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain('---\n')
+    expect(content).toContain('name: Alice')
+    expect(content).toContain('role: dev')
+    expect(content).toContain('technical_level: expert')
+    expect(content).toContain('communication_style: technical')
+    expect(content).toContain('languages:')
+    expect(content).toContain('  - English')
+    expect(content).toContain('  - French')
+    expect(content).toContain('free_text: Prefers concise answers')
+    expect(content).toContain('I am a Developer. My technical level is expert. Prefers concise answers')
+  })
+
+  it('should generate a minimal profile with only required fields', () => {
+    writeProfile({
+      name: 'Bob',
+      role: 'product',
+      technical_level: 'beginner',
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain('name: Bob')
+    expect(content).toContain('role: product')
+    expect(content).toContain('technical_level: beginner')
+    expect(content).not.toContain('communication_style')
+    expect(content).not.toContain('languages')
+    expect(content).not.toContain('free_text')
+    expect(content).toContain('I am a Product Manager. My technical level is beginner.')
+  })
+
+  it('should create the config directory if it does not exist', () => {
+    const nestedDir = path.join(tmpDir, 'nested', 'dir')
+
+    // Re-mock with nested dir
+    vi.doMock('./config', () => ({ CONFIG_DIR: nestedDir }))
+    vi.resetModules()
+
+    return import('./profile').then(mod => {
+      mod.writeProfile({
+        name: 'Alice',
+        role: 'dev',
+        technical_level: 'expert',
+      })
+
+      expect(fs.existsSync(path.join(nestedDir, 'profile.md'))).toBe(true)
+    })
+  })
+
+  it('should quote name values containing colons', () => {
+    writeProfile({
+      name: 'Dr. Smith: Surgeon',
+      role: 'other',
+      technical_level: 'expert',
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain("name: 'Dr. Smith: Surgeon'")
+  })
+
+  it('should quote free_text values containing colons', () => {
+    writeProfile({
+      name: 'Alice',
+      role: 'dev',
+      technical_level: 'expert',
+      freeText: 'Note: prefers short answers',
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain("free_text: 'Note: prefers short answers'")
+  })
+
+  it('should quote values containing newlines', () => {
+    writeProfile({
+      name: 'Alice',
+      role: 'dev',
+      technical_level: 'expert',
+      freeText: 'Line one\nLine two',
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain("free_text: 'Line one\nLine two'")
+  })
+
+  it('should escape embedded single quotes by doubling them', () => {
+    writeProfile({
+      name: "O'Brien",
+      role: 'dev',
+      technical_level: 'expert',
+    })
+
+    const content = readProfileFile()
+    // O'Brien contains a single quote but no colon/newline, so it's not quoted
+    // Actually, the yamlQuote function only quotes when colons, newlines, or double-quotes are present.
+    // A single quote alone does not trigger quoting.
+    expect(content).toContain("name: O'Brien")
+  })
+
+  it('should escape values containing both colons and single quotes', () => {
+    writeProfile({
+      name: "O'Brien: Chief",
+      role: 'dev',
+      technical_level: 'expert',
+    })
+
+    const content = readProfileFile()
+    // Contains colon -> triggers quoting; single quote is doubled
+    expect(content).toContain("name: 'O''Brien: Chief'")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Round-trip: writeProfile -> readProfile
+// ---------------------------------------------------------------------------
+
+describe('round-trip writeProfile -> readProfile', () => {
+  let readProfile: typeof import('./profile').readProfile
+  let writeProfile: typeof import('./profile').writeProfile
+
+  beforeEach(async () => {
+    vi.doMock('./config', () => ({ CONFIG_DIR: tmpDir }))
+    vi.resetModules()
+    const mod = await import('./profile')
+    readProfile = mod.readProfile
+    writeProfile = mod.writeProfile
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should round-trip a full profile', () => {
+    const original = {
+      name: 'Alice',
+      role: 'dev' as const,
+      technical_level: 'expert' as const,
+      communication_style: 'technical' as const,
+      languages: ['English', 'French'],
+      freeText: 'Prefers concise answers',
+    }
+
+    writeProfile(original)
+    const result = readProfile()
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe(original.name)
+    expect(result!.role).toBe(original.role)
+    expect(result!.technical_level).toBe(original.technical_level)
+    expect(result!.communication_style).toBe(original.communication_style)
+    expect(result!.languages).toEqual(original.languages)
+    expect(result!.freeText).toBe(original.freeText)
+  })
+
+  it('should round-trip a minimal profile', () => {
+    const original = {
+      name: 'Bob',
+      role: 'qa' as const,
+      technical_level: 'beginner' as const,
+    }
+
+    writeProfile(original)
+    const result = readProfile()
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe(original.name)
+    expect(result!.role).toBe(original.role)
+    expect(result!.technical_level).toBe(original.technical_level)
+    expect(result!.communication_style).toBeUndefined()
+    expect(result!.languages).toBeUndefined()
+    expect(result!.freeText).toBeUndefined()
+  })
+
+  it('should round-trip a name containing colons', () => {
+    const original = {
+      name: 'Dr. Smith: Surgeon',
+      role: 'other' as const,
+      technical_level: 'expert' as const,
+    }
+
+    writeProfile(original)
+    const result = readProfile()
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe('Dr. Smith: Surgeon')
+  })
+
+  it('should round-trip free_text containing colons', () => {
+    const original = {
+      name: 'Alice',
+      role: 'dev' as const,
+      technical_level: 'expert' as const,
+      freeText: 'Important: always use TypeScript',
+    }
+
+    writeProfile(original)
+    const result = readProfile()
+
+    expect(result).not.toBeNull()
+    expect(result!.freeText).toBe('Important: always use TypeScript')
+  })
+
+  it('should round-trip a name with single quotes and colons', () => {
+    const original = {
+      name: "O'Brien: Chief",
+      role: 'dev' as const,
+      technical_level: 'expert' as const,
+    }
+
+    writeProfile(original)
+    const result = readProfile()
+
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe("O'Brien: Chief")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildMarkdownBody (tested indirectly via writeProfile output)
+// ---------------------------------------------------------------------------
+
+describe('buildMarkdownBody via writeProfile', () => {
+  let writeProfile: typeof import('./profile').writeProfile
+
+  beforeEach(async () => {
+    vi.doMock('./config', () => ({ CONFIG_DIR: tmpDir }))
+    vi.resetModules()
+    const mod = await import('./profile')
+    writeProfile = mod.writeProfile
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should generate English body by default', () => {
+    writeProfile({
+      name: 'Alice',
+      role: 'dev',
+      technical_level: 'expert',
+      languages: ['English'],
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain('I am a Developer. My technical level is expert.')
+  })
+
+  it('should generate French body when first language is French', () => {
+    writeProfile({
+      name: 'Alice',
+      role: 'dev',
+      technical_level: 'expert',
+      languages: ['Français'],
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain('Je suis Développeur. Mon niveau technique est expert.')
+  })
+
+  it('should generate French body when first language is "fr"', () => {
+    writeProfile({
+      name: 'Alice',
+      role: 'dev',
+      technical_level: 'beginner',
+      languages: ['fr'],
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain('Je suis Développeur. Mon niveau technique est débutant.')
+  })
+
+  it('should generate French body when first language is "french" (case-insensitive)', () => {
+    writeProfile({
+      name: 'Alice',
+      role: 'qa',
+      technical_level: 'intermediate',
+      languages: ['French'],
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain('Je suis Ingénieur QA. Mon niveau technique est intermédiaire.')
+  })
+
+  it('should generate English body when no languages are specified', () => {
+    writeProfile({
+      name: 'Alice',
+      role: 'product',
+      technical_level: 'intermediate',
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain('I am a Product Manager. My technical level is intermediate.')
+  })
+
+  it('should append freeText to the body', () => {
+    writeProfile({
+      name: 'Alice',
+      role: 'dev',
+      technical_level: 'expert',
+      freeText: 'Loves testing.',
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain('I am a Developer. My technical level is expert. Loves testing.')
+  })
+
+  it('should use correct labels for all roles in English', () => {
+    const roles: Array<{ role: 'product' | 'dev' | 'design' | 'qa' | 'ops' | 'manager' | 'other'; label: string }> = [
+      { role: 'product', label: 'Product Manager' },
+      { role: 'dev', label: 'Developer' },
+      { role: 'design', label: 'Designer' },
+      { role: 'qa', label: 'QA Engineer' },
+      { role: 'ops', label: 'Ops Engineer' },
+      { role: 'manager', label: 'Engineering Manager' },
+      { role: 'other', label: 'Team Member' },
+    ]
+
+    for (const { role, label } of roles) {
+      writeProfile({
+        name: 'Test',
+        role,
+        technical_level: 'intermediate',
+      })
+
+      const content = readProfileFile()
+      expect(content).toContain(`I am a ${label}.`)
+    }
+  })
+
+  it('should use correct labels for all levels in English', () => {
+    const levels: Array<{ level: 'beginner' | 'intermediate' | 'expert'; label: string }> = [
+      { level: 'beginner', label: 'beginner' },
+      { level: 'intermediate', label: 'intermediate' },
+      { level: 'expert', label: 'expert' },
+    ]
+
+    for (const { level, label } of levels) {
+      writeProfile({
+        name: 'Test',
+        role: 'dev',
+        technical_level: level,
+      })
+
+      const content = readProfileFile()
+      expect(content).toContain(`My technical level is ${label}.`)
+    }
+  })
+
+  it('should fall back to "other" role label for unknown roles', () => {
+    writeProfile({
+      name: 'Test',
+      role: 'unknown_role' as 'other',
+      technical_level: 'intermediate',
+    })
+
+    const content = readProfileFile()
+    expect(content).toContain('I am a Team Member.')
+  })
+})

--- a/desktop/src/main/config/profile.ts
+++ b/desktop/src/main/config/profile.ts
@@ -1,0 +1,164 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import type { UserProfile } from '../../types'
+import { CONFIG_DIR } from './config'
+
+const PROFILE_PATH = path.join(CONFIG_DIR, 'profile.md')
+
+export function readProfile(): UserProfile | null {
+  try {
+    if (!fs.existsSync(PROFILE_PATH)) return null
+    const content = fs.readFileSync(PROFILE_PATH, 'utf8')
+    return parseFrontmatter(content)
+  } catch {
+    return null
+  }
+}
+
+export function writeProfile(profile: UserProfile): void {
+  if (!fs.existsSync(CONFIG_DIR)) {
+    fs.mkdirSync(CONFIG_DIR, { recursive: true })
+  }
+
+  const yaml = buildYamlFrontmatter(profile)
+  const body = buildMarkdownBody(profile)
+  const content = `---\n${yaml}---\n\n${body}\n`
+
+  fs.writeFileSync(PROFILE_PATH, content, 'utf8')
+}
+
+function parseFrontmatter(content: string): UserProfile | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) return null
+
+  const lines = match[1].split('\n')
+  const data: Record<string, string | string[]> = {}
+  let currentKey: string | null = null
+
+  for (const line of lines) {
+    // Array item (continuation of previous key)
+    if (line.match(/^\s+-\s+/) && currentKey) {
+      const value = line.replace(/^\s+-\s+/, '').trim()
+      if (!Array.isArray(data[currentKey])) {
+        data[currentKey] = []
+      }
+      ;(data[currentKey] as string[]).push(value)
+      continue
+    }
+
+    const colonIndex = line.indexOf(':')
+    if (colonIndex === -1) continue
+
+    const key = line.substring(0, colonIndex).trim()
+    let value = line.substring(colonIndex + 1).trim()
+
+    // Strip surrounding single or double quotes (YAML quoting)
+    if ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith('"') && value.endsWith('"'))) {
+      value = value.slice(1, -1)
+      // Unescape doubled single quotes
+      if (value.includes("''")) {
+        value = value.replace(/''/g, "'")
+      }
+    }
+
+    if (value === '') {
+      // Next lines may be array items
+      currentKey = key
+      data[key] = []
+    } else {
+      currentKey = key
+      data[key] = value
+    }
+  }
+
+  const name = typeof data.name === 'string' ? data.name : ''
+  const role = typeof data.role === 'string' ? data.role : ''
+  const technicalLevel = typeof data.technical_level === 'string' ? data.technical_level : ''
+
+  if (!name || !role || !technicalLevel) return null
+
+  const profile: UserProfile = {
+    name,
+    role: role as UserProfile['role'],
+    technical_level: technicalLevel as UserProfile['technical_level'],
+  }
+
+  if (typeof data.communication_style === 'string' && data.communication_style) {
+    profile.communication_style = data.communication_style as UserProfile['communication_style']
+  }
+
+  if (Array.isArray(data.languages) && data.languages.length > 0) {
+    profile.languages = data.languages
+  }
+
+  if (typeof data.free_text === 'string' && data.free_text) {
+    profile.freeText = data.free_text
+  }
+
+  return profile
+}
+
+/** Quotes a YAML scalar value if it contains characters that could break parsing (colons, newlines). */
+function yamlQuote(value: string): string {
+  if (value.includes('\n') || value.includes(':') || value.includes('"')) {
+    // Use single quotes; escape embedded single quotes by doubling them
+    return `'${value.replace(/'/g, "''")}'`
+  }
+  return value
+}
+
+function buildYamlFrontmatter(profile: UserProfile): string {
+  const lines: string[] = []
+  lines.push(`name: ${yamlQuote(profile.name)}`)
+  lines.push(`role: ${profile.role}`)
+  lines.push(`technical_level: ${profile.technical_level}`)
+
+  if (profile.communication_style) {
+    lines.push(`communication_style: ${profile.communication_style}`)
+  }
+
+  if (profile.languages && profile.languages.length > 0) {
+    lines.push('languages:')
+    for (const lang of profile.languages) {
+      lines.push(`  - ${yamlQuote(lang)}`)
+    }
+  }
+
+  if (profile.freeText) {
+    lines.push(`free_text: ${yamlQuote(profile.freeText)}`)
+  }
+
+  return lines.join('\n') + '\n'
+}
+
+function buildMarkdownBody(profile: UserProfile): string {
+  const lang = profile.languages?.[0]?.toLowerCase()
+  const isFrench = lang === 'français' || lang === 'french' || lang === 'fr'
+
+  const roleLabels: Record<string, { en: string; fr: string }> = {
+    product: { en: 'Product Manager', fr: 'Product Manager' },
+    dev: { en: 'Developer', fr: 'Développeur' },
+    design: { en: 'Designer', fr: 'Designer' },
+    qa: { en: 'QA Engineer', fr: 'Ingénieur QA' },
+    ops: { en: 'Ops Engineer', fr: 'Ingénieur Ops' },
+    manager: { en: 'Engineering Manager', fr: 'Engineering Manager' },
+    other: { en: 'Team Member', fr: 'Membre de l\'équipe' },
+  }
+
+  const levelLabels: Record<string, { en: string; fr: string }> = {
+    beginner: { en: 'beginner', fr: 'débutant' },
+    intermediate: { en: 'intermediate', fr: 'intermédiaire' },
+    expert: { en: 'expert', fr: 'expert' },
+  }
+
+  const roleLabel = roleLabels[profile.role] || roleLabels.other
+  const levelLabel = levelLabels[profile.technical_level] || levelLabels.intermediate
+
+  const freeTextSuffix = profile.freeText ? ` ${profile.freeText}` : ''
+
+  if (isFrench) {
+    return `Je suis ${roleLabel.fr}. Mon niveau technique est ${levelLabel.fr}.${freeTextSuffix}`
+  }
+
+  return `I am a ${roleLabel.en}. My technical level is ${levelLabel.en}.${freeTextSuffix}`
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -20,6 +20,7 @@ import { hideQuickLaunch, resizeQuickLaunch, destroyQuickLaunch } from './window
 import { reRegisterSpotlightShortcut } from './spotlight-shortcut'
 import { Scheduler } from './scheduler/scheduler'
 import { setupSchedulerHandlers } from './ipc/scheduler-handlers'
+import { setupProfileHandlers } from './ipc/profile-handlers'
 
 let mainWindow: BrowserWindow | null = null
 let isQuitting = false
@@ -183,6 +184,7 @@ function setupHandlers() {
   setupSkillsHandlers()
   setupScriptHandlers(() => mainWindow)
   registerActivityHistoryHandlers()
+  setupProfileHandlers()
   // Notification callback - only show when window is not focused
   const notificationCallback = (title: string, body: string) => {
     if (Notification.isSupported() && mainWindow && !mainWindow.isFocused()) {

--- a/desktop/src/main/ipc/profile-handlers.ts
+++ b/desktop/src/main/ipc/profile-handlers.ts
@@ -1,0 +1,12 @@
+import { ipcMain } from 'electron'
+import { readProfile, writeProfile } from '../config/profile'
+import type { UserProfile } from '../../types'
+
+export function setupProfileHandlers(): void {
+  ipcMain.handle('profile:get', async () => readProfile())
+
+  ipcMain.handle('profile:save', async (_event, data: UserProfile) => {
+    if (!data?.name || !data?.role || !data?.technical_level) return
+    await writeProfile(data)
+  })
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
-import type { TerminalMetadata, RepositoryConfig, Schedule } from '../types'
+import type { TerminalMetadata, RepositoryConfig, Schedule, UserProfile } from '../types'
 
 export type TerminalState = 'idle' | 'working' | 'waiting' | 'completed' | 'error'
 
@@ -354,6 +354,12 @@ const schedulerApi = {
   },
 }
 
+// Profile API
+const profileApi = {
+  get: (): Promise<UserProfile | null> => ipcRenderer.invoke('profile:get'),
+  save: (data: UserProfile) => ipcRenderer.invoke('profile:save', data),
+}
+
 // Expose APIs to renderer
 contextBridge.exposeInMainWorld('electronAPI', {
   config: configApi,
@@ -369,6 +375,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   tray: trayApi,
   quickLaunch: quickLaunchApi,
   scheduler: schedulerApi,
+  profile: profileApi,
 })
 
 // Type definitions for the renderer
@@ -388,6 +395,7 @@ declare global {
       tray: typeof trayApi
       quickLaunch: typeof quickLaunchApi
       scheduler: typeof schedulerApi
+      profile: typeof profileApi
     }
   }
 

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -16,6 +16,7 @@ import { SkillsPage } from './pages/Skills'
 import { HistoryPage } from './pages/History'
 import { ScheduledPage } from './pages/Scheduled'
 import { ErrorBoundary } from './components/ErrorBoundary'
+import { ProfileOnboardingWizard } from './components/ProfileOnboardingWizard'
 import { useWindowSplitMode } from './hooks/useWindowSplitMode'
 
 function LoadingScreen() {
@@ -52,6 +53,17 @@ export function App() {
   useWindowSplitMode()
   const confirmCloseButtonRef = useRef<HTMLButtonElement>(null)
   const [showNoReposModal, setShowNoReposModal] = useState(false)
+  const [showProfileWizard, setShowProfileWizard] = useState(false)
+
+  // Check if user profile exists on mount
+  useEffect(() => {
+    if (configLoading) return
+    window.electronAPI.profile.get().then((profile) => {
+      if (!profile) {
+        setShowProfileWizard(true)
+      }
+    }).catch(() => {})
+  }, [configLoading])
 
   // Check if there are no repos configured
   const hasNoRepos = useMemo(() => {
@@ -332,6 +344,12 @@ export function App() {
           </div>
         </div>
       )}
+
+      {/* Profile Onboarding Wizard */}
+      <ProfileOnboardingWizard
+        isOpen={showProfileWizard}
+        onClose={() => setShowProfileWizard(false)}
+      />
 
       {/* No Repos Warning Modal */}
       {showNoReposModal && (

--- a/desktop/src/renderer/components/ProfileOnboardingWizard.tsx
+++ b/desktop/src/renderer/components/ProfileOnboardingWizard.tsx
@@ -1,0 +1,341 @@
+import { useState, useCallback, useEffect } from 'react'
+import { User, ChevronLeft, ChevronRight, X, Check } from 'lucide-react'
+import { ROLE_LABELS, LEVEL_LABELS, STYLE_LABELS, type UserProfile } from '../../types'
+
+interface ProfileOnboardingWizardProps {
+  isOpen: boolean
+  onClose: () => void
+  editMode?: boolean
+  initialData?: UserProfile
+}
+
+const ROLE_OPTIONS = (Object.entries(ROLE_LABELS) as [UserProfile['role'], string][]).map(
+  ([value, label]) => ({ value, label })
+)
+
+const TECH_LEVEL_OPTIONS: { value: UserProfile['technical_level']; label: string; description: string }[] = [
+  { value: 'beginner', label: LEVEL_LABELS.beginner, description: 'New to development or technical concepts' },
+  { value: 'intermediate', label: LEVEL_LABELS.intermediate, description: 'Comfortable with code and tooling' },
+  { value: 'expert', label: LEVEL_LABELS.expert, description: 'Deep technical knowledge and experience' },
+]
+
+const COMMUNICATION_STYLE_OPTIONS: { value: NonNullable<UserProfile['communication_style']>; label: string; description: string }[] = [
+  { value: 'simple', label: STYLE_LABELS.simple, description: 'Concise answers, minimal jargon' },
+  { value: 'technical', label: STYLE_LABELS.technical, description: 'Code-focused, precise terminology' },
+  { value: 'detailed', label: STYLE_LABELS.detailed, description: 'Thorough explanations with context' },
+]
+
+const LANGUAGE_OPTIONS = ['English', 'Français']
+
+const TOTAL_STEPS = 6
+
+export function ProfileOnboardingWizard({ isOpen, onClose, editMode = false, initialData }: ProfileOnboardingWizardProps) {
+  const [step, setStep] = useState(1)
+  const [name, setName] = useState('')
+  const [role, setRole] = useState<UserProfile['role'] | ''>('')
+  const [technicalLevel, setTechnicalLevel] = useState<UserProfile['technical_level'] | ''>('')
+  const [communicationStyle, setCommunicationStyle] = useState<UserProfile['communication_style'] | ''>('')
+  const [languages, setLanguages] = useState<string[]>([])
+  const [freeText, setFreeText] = useState('')
+
+  // Pre-fill in edit mode
+  useEffect(() => {
+    if (initialData) {
+      setName(initialData.name || '')
+      setRole(initialData.role || '')
+      setTechnicalLevel(initialData.technical_level || '')
+      setCommunicationStyle(initialData.communication_style || '')
+      setLanguages(initialData.languages || [])
+      setFreeText(initialData.freeText || '')
+    }
+  }, [initialData])
+
+  const canAdvance = () => {
+    switch (step) {
+      case 1: return name.trim().length > 0
+      case 2: return role !== ''
+      case 3: return technicalLevel !== ''
+      default: return true
+    }
+  }
+
+  const handleNext = () => {
+    if (step < TOTAL_STEPS) setStep(step + 1)
+  }
+
+  const handleBack = () => {
+    if (step > 1) setStep(step - 1)
+  }
+
+  const handleFinish = useCallback(async () => {
+    if (!name.trim() || !role || !technicalLevel) return
+
+    const profile: UserProfile = {
+      name: name.trim(),
+      role: role as UserProfile['role'],
+      technical_level: technicalLevel as UserProfile['technical_level'],
+    }
+
+    if (communicationStyle) {
+      profile.communication_style = communicationStyle as UserProfile['communication_style']
+    }
+
+    if (languages.length > 0) {
+      profile.languages = languages
+    }
+
+    if (freeText.trim()) {
+      profile.freeText = freeText.trim()
+    }
+
+    await window.electronAPI.profile.save(profile)
+    onClose()
+  }, [name, role, technicalLevel, communicationStyle, languages, freeText, onClose])
+
+  const toggleLanguage = useCallback((lang: string) => {
+    setLanguages(prev =>
+      prev.includes(lang) ? prev.filter(l => l !== lang) : [...prev, lang]
+    )
+  }, [])
+
+  // Handle Escape key
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 animate-modal-backdrop"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-secondary border border-white/10 rounded-xl w-full max-w-md mx-4 backdrop-blur-2xl animate-modal-content"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-4">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-accent/10 rounded-lg">
+              <User className="w-4 h-4 text-accent" />
+            </div>
+            <h3 className="text-base font-semibold">
+              {editMode ? 'Edit Profile' : 'Welcome to Magic Slash'}
+            </h3>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 text-text-secondary hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Step indicator */}
+        <div className="flex items-center gap-1.5 px-5 pb-4">
+          {Array.from({ length: TOTAL_STEPS }, (_, i) => (
+            <div
+              key={i}
+              className={`h-1 flex-1 rounded-full transition-colors ${
+                i + 1 <= step ? 'bg-accent' : 'bg-white/10'
+              }`}
+            />
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="px-5 pb-5 min-h-[200px]">
+          {step === 1 && (
+            <div className="space-y-4">
+              <div>
+                <div className="text-sm font-medium mb-1">What's your first name?</div>
+                <div className="text-xs text-text-secondary/50 mb-3">Claude will use this to personalize responses</div>
+              </div>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Your first name"
+                autoFocus
+                className="w-full px-3 py-2 bg-bg border border-white/10 rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+                onKeyDown={(e) => { if (e.key === 'Enter' && canAdvance()) handleNext() }}
+              />
+            </div>
+          )}
+
+          {step === 2 && (
+            <div className="space-y-4">
+              <div>
+                <div className="text-sm font-medium mb-1">What's your role?</div>
+                <div className="text-xs text-text-secondary/50 mb-3">Helps Claude adapt the level of detail</div>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                {ROLE_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setRole(opt.value)}
+                    className={`px-3 py-2 text-sm rounded-lg border transition-all ${
+                      role === opt.value
+                        ? 'bg-accent/10 border-accent/30 text-accent'
+                        : 'bg-bg border-white/10 text-text-secondary hover:bg-white/5 hover:text-white'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {step === 3 && (
+            <div className="space-y-4">
+              <div>
+                <div className="text-sm font-medium mb-1">Technical level</div>
+                <div className="text-xs text-text-secondary/50 mb-3">Claude adjusts vocabulary and explanations accordingly</div>
+              </div>
+              <div className="space-y-2">
+                {TECH_LEVEL_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setTechnicalLevel(opt.value)}
+                    className={`w-full px-3 py-2.5 text-left rounded-lg border transition-all ${
+                      technicalLevel === opt.value
+                        ? 'bg-accent/10 border-accent/30'
+                        : 'bg-bg border-white/10 hover:bg-white/5'
+                    }`}
+                  >
+                    <div className={`text-sm font-medium ${technicalLevel === opt.value ? 'text-accent' : 'text-white'}`}>
+                      {opt.label}
+                    </div>
+                    <div className="text-xs text-text-secondary/50 mt-0.5">{opt.description}</div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {step === 4 && (
+            <div className="space-y-4">
+              <div>
+                <div className="text-sm font-medium mb-1">Communication style</div>
+                <div className="text-xs text-text-secondary/50 mb-3">Optional - how should Claude communicate?</div>
+              </div>
+              <div className="space-y-2">
+                {COMMUNICATION_STYLE_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setCommunicationStyle(prev => prev === opt.value ? '' : opt.value)}
+                    className={`w-full px-3 py-2.5 text-left rounded-lg border transition-all ${
+                      communicationStyle === opt.value
+                        ? 'bg-accent/10 border-accent/30'
+                        : 'bg-bg border-white/10 hover:bg-white/5'
+                    }`}
+                  >
+                    <div className={`text-sm font-medium ${communicationStyle === opt.value ? 'text-accent' : 'text-white'}`}>
+                      {opt.label}
+                    </div>
+                    <div className="text-xs text-text-secondary/50 mt-0.5">{opt.description}</div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {step === 5 && (
+            <div className="space-y-4">
+              <div>
+                <div className="text-sm font-medium mb-1">Preferred languages</div>
+                <div className="text-xs text-text-secondary/50 mb-3">Optional - Claude will communicate in these languages</div>
+              </div>
+              <div className="flex gap-2">
+                {LANGUAGE_OPTIONS.map((lang) => (
+                  <button
+                    key={lang}
+                    onClick={() => toggleLanguage(lang)}
+                    className={`flex items-center gap-2 px-4 py-2.5 rounded-lg border transition-all ${
+                      languages.includes(lang)
+                        ? 'bg-accent/10 border-accent/30 text-accent'
+                        : 'bg-bg border-white/10 text-text-secondary hover:bg-white/5 hover:text-white'
+                    }`}
+                  >
+                    {languages.includes(lang) && <Check className="w-3.5 h-3.5" />}
+                    <span className="text-sm">{lang}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {step === 6 && (
+            <div className="space-y-4">
+              <div>
+                <div className="text-sm font-medium mb-1">Anything else?</div>
+                <div className="text-xs text-text-secondary/50 mb-3">Optional - anything else Claude should know about you</div>
+              </div>
+              <textarea
+                value={freeText}
+                onChange={(e) => setFreeText(e.target.value)}
+                placeholder="e.g., I prefer short answers, I work on mobile apps..."
+                rows={4}
+                className="w-full px-3 py-2 bg-bg border border-white/10 rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30 resize-none"
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-5 pb-5">
+          <div>
+            {step > 1 && (
+              <button
+                onClick={handleBack}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+              >
+                <ChevronLeft className="w-3.5 h-3.5" />
+                Back
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {!editMode && (
+              <button
+                onClick={onClose}
+                className="px-3 py-1.5 text-xs font-medium text-text-secondary/50 hover:text-text-secondary transition-colors"
+              >
+                Skip
+              </button>
+            )}
+            {step < TOTAL_STEPS ? (
+              <button
+                onClick={handleNext}
+                disabled={!canAdvance()}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-accent border border-accent/20 rounded-lg hover:bg-accent/10 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                Next
+                <ChevronRight className="w-3.5 h-3.5" />
+              </button>
+            ) : (
+              <button
+                onClick={handleFinish}
+                disabled={!name.trim() || !role || !technicalLevel}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <Check className="w-3.5 h-3.5" />
+                Finish
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/desktop/src/renderer/pages/Config/ProfileSection.tsx
+++ b/desktop/src/renderer/pages/Config/ProfileSection.tsx
@@ -1,0 +1,107 @@
+import { useState, useEffect, useCallback } from 'react'
+import { User, Pencil, Plus } from 'lucide-react'
+import { ProfileOnboardingWizard } from '../../components/ProfileOnboardingWizard'
+import { ROLE_LABELS, LEVEL_LABELS, STYLE_LABELS, type UserProfile } from '../../../types'
+
+export function ProfileSection() {
+  const [profile, setProfile] = useState<UserProfile | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [showWizard, setShowWizard] = useState(false)
+
+  const loadProfile = useCallback(async () => {
+    try {
+      const data = await window.electronAPI.profile.get()
+      setProfile(data)
+    } catch {
+      setProfile(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadProfile()
+  }, [loadProfile])
+
+  const handleWizardClose = useCallback(() => {
+    setShowWizard(false)
+    loadProfile()
+  }, [loadProfile])
+
+  if (loading) return null
+
+  return (
+    <>
+      <div>
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2 text-sm text-text-secondary">
+            <User className="w-4 h-4" />
+            <span>Profile</span>
+          </div>
+          {profile && (
+            <button
+              onClick={() => setShowWizard(true)}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-text-secondary bg-white/[0.06] border border-white/[0.15] rounded-lg hover:bg-white/[0.12] hover:text-white transition-all"
+            >
+              <Pencil className="w-3 h-3" />
+              <span>Edit profile</span>
+            </button>
+          )}
+        </div>
+
+        {profile ? (
+          <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
+            <div className="flex items-center gap-3 mb-3">
+              <div className="w-9 h-9 rounded-full bg-accent/10 flex items-center justify-center">
+                <span className="text-sm font-semibold text-accent">
+                  {profile.name.charAt(0).toUpperCase()}
+                </span>
+              </div>
+              <div>
+                <div className="text-sm font-medium">{profile.name}</div>
+                <div className="text-xs text-text-secondary/50 mt-0.5">
+                  {LEVEL_LABELS[profile.technical_level] || profile.technical_level}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-1.5">
+              <span className="px-2 py-0.5 bg-accent/10 text-accent text-xs font-medium rounded">
+                {ROLE_LABELS[profile.role] || profile.role}
+              </span>
+              {profile.communication_style && (
+                <span className="px-2 py-0.5 bg-white/5 text-text-secondary text-xs font-medium rounded">
+                  {STYLE_LABELS[profile.communication_style] || profile.communication_style}
+                </span>
+              )}
+              {profile.languages?.map((lang) => (
+                <span key={lang} className="px-2 py-0.5 bg-white/5 text-text-secondary text-xs font-medium rounded">
+                  {lang}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowWizard(true)}
+            className="w-full py-6 text-center border border-dashed border-border/50 rounded-xl hover:border-text-secondary/50 hover:bg-white/5 transition-colors"
+          >
+            <User className="w-6 h-6 text-text-secondary/30 mx-auto mb-2" />
+            <div className="text-sm text-text-secondary/50 mb-1">No profile configured</div>
+            <div className="flex items-center gap-1 justify-center text-xs text-accent/70">
+              <Plus className="w-3 h-3" />
+              Create profile
+            </div>
+          </button>
+        )}
+      </div>
+
+      <ProfileOnboardingWizard
+        isOpen={showWizard}
+        onClose={handleWizardClose}
+        editMode={profile !== null}
+        initialData={profile || undefined}
+      />
+    </>
+  )
+}

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, CalendarClock } from 'lucide-react'
+import { ProfileSection } from './ProfileSection'
 import { RepoPage } from './RepoPage'
 import { useStore } from '../../store'
 import { useConfig } from '../../hooks/useConfig'
@@ -227,6 +228,9 @@ function WelcomePage() {
           Manage your repositories and configure Magic Slash
         </p>
       </div>
+
+      {/* Profile Section */}
+      <ProfileSection />
 
       {/* Repositories Section */}
       <div>

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -195,3 +195,35 @@ export interface BranchCommit {
   relativeDate: string
   isPushed: boolean
 }
+
+export interface UserProfile {
+  name: string
+  role: 'product' | 'dev' | 'design' | 'qa' | 'ops' | 'manager' | 'other'
+  technical_level: 'beginner' | 'intermediate' | 'expert'
+  communication_style?: 'simple' | 'technical' | 'detailed'
+  languages?: string[]
+  freeText?: string
+}
+
+// Shared display labels for profile fields (used by wizard + profile section)
+export const ROLE_LABELS: Record<UserProfile['role'], string> = {
+  product: 'Product',
+  dev: 'Dev',
+  design: 'Design',
+  qa: 'QA',
+  ops: 'Ops',
+  manager: 'Manager',
+  other: 'Other',
+}
+
+export const LEVEL_LABELS: Record<UserProfile['technical_level'], string> = {
+  beginner: 'Beginner',
+  intermediate: 'Intermediate',
+  expert: 'Expert',
+}
+
+export const STYLE_LABELS: Record<NonNullable<UserProfile['communication_style']>, string> = {
+  simple: 'Simple',
+  technical: 'Technical',
+  detailed: 'Detailed',
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-slash",
-  "version": "0.42.3",
+  "version": "0.43.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-slash",
-      "version": "0.42.3",
+      "version": "0.43.3",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",


### PR DESCRIPTION
## Description

Add a user profile system with an onboarding wizard in the Desktop app. On first launch, a 6-step wizard collects the user's name, role, technical level, communication style, language preferences, and free text. The profile is saved at `~/.config/magic-slash/profile.md` and read by all `/magic:*` skills to adapt their communication style, vocabulary, and detail level based on who the user is.

## Related Issue

Closes #65

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- New `UserProfile` interface and shared label constants (`ROLE_LABELS`, `LEVEL_LABELS`, `STYLE_LABELS`) in `types.ts`
- Backend profile module (`desktop/src/main/config/profile.ts`): read/write `profile.md` with YAML frontmatter parsing/serialization, proper quoting for special characters
- IPC handlers (`profile:get`, `profile:save`) in `desktop/src/main/ipc/profile-handlers.ts`
- Preload bridge extension with `profileApi` (get, save) and Window type augmentation
- 6-step onboarding wizard component (`ProfileOnboardingWizard.tsx`): name, role, technical level, communication style, languages, free text — with Back/Next/Skip/Finish navigation and edit mode support
- Profile section in Settings page (`ProfileSection.tsx`): displays current profile with avatar, badges, and Edit button; empty state with Create button
- Skill injection instruction in `CLAUDE.md` (7-point guide for all `/magic:*` skills)
- User profile documentation section in `README.md`
- 37 unit tests covering parsing, serialization, round-trips, YAML edge cases, and body generation

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [x] Tested affected slash commands

### Test Steps

1. Run `npm run desktop` — the profile onboarding wizard should appear on first launch (if `~/.config/magic-slash/profile.md` does not exist)
2. Fill in all 6 steps (name, role, technical level, communication style, languages, free text) and click **Finish** — verify `~/.config/magic-slash/profile.md` is created with correct YAML frontmatter and markdown body
3. Close and relaunch the app — the wizard should **not** reappear
4. Go to **Settings** — the Profile section should display at the top with your name, role badge, level, and language tags
5. Click **Edit profile** — the wizard reopens pre-filled with your current data; modify a field and save — verify the file is updated
6. Delete `~/.config/magic-slash/profile.md` and relaunch — the wizard should appear again
7. Click **Skip** in the wizard — it closes, and reappears on next launch (no file saved)
8. Run `npm test` — all 176 tests pass including the 37 new profile tests

## Screenshots

N/A — Desktop app UI changes (wizard modal and settings section)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

- No new npm dependencies added
- Permission migration was determined unnecessary: the existing glob `Read($HOME/.config/magic-slash/*)` in `install.sh` already covers `profile.md`
- The YAML frontmatter parser is intentionally minimal (handles the format written by the app); values containing colons, newlines, or quotes are properly escaped