### PR TITLE
[#100] feat(desktop): PR review watcher with magic-resolve/magic-done actions

### DIFF
--- a/desktop/src/main/github.test.ts
+++ b/desktop/src/main/github.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock child_process BEFORE importing the module under test so getGitHubToken()
+// doesn't attempt to spawn `gh` during the test run.
+vi.mock('child_process', () => ({
+  execFileSync: () => '',
+}))
+
+import { parsePRUrl, aggregatePRStatus } from './github'
+
+describe('parsePRUrl', () => {
+  it('parses a standard PR URL', () => {
+    expect(parsePRUrl('https://github.com/xrequillart/magic-slash/pull/42')).toEqual({
+      owner: 'xrequillart',
+      repo: 'magic-slash',
+      number: 42,
+    })
+  })
+
+  it('tolerates a trailing slash', () => {
+    expect(parsePRUrl('https://github.com/xrequillart/magic-slash/pull/42/')).toEqual({
+      owner: 'xrequillart',
+      repo: 'magic-slash',
+      number: 42,
+    })
+  })
+
+  it('tolerates http', () => {
+    expect(parsePRUrl('http://github.com/a/b/pull/1')).toEqual({ owner: 'a', repo: 'b', number: 1 })
+  })
+
+  it('tolerates a query string', () => {
+    expect(parsePRUrl('https://github.com/a/b/pull/1?diff=split')).toEqual({ owner: 'a', repo: 'b', number: 1 })
+  })
+
+  it('returns null for non-PR URLs', () => {
+    expect(parsePRUrl('https://github.com/xrequillart/magic-slash/issues/42')).toBeNull()
+    expect(parsePRUrl('https://example.com/xrequillart/magic-slash/pull/42')).toBeNull()
+    expect(parsePRUrl('not a url')).toBeNull()
+    expect(parsePRUrl('')).toBeNull()
+  })
+
+  it('returns null for zero or invalid PR numbers', () => {
+    expect(parsePRUrl('https://github.com/a/b/pull/0')).toBeNull()
+    expect(parsePRUrl('https://github.com/a/b/pull/abc')).toBeNull()
+  })
+})
+
+describe('aggregatePRStatus', () => {
+  const pr = { state: 'open', merged: false, updated_at: '2025-01-01T10:00:00Z' }
+
+  it('returns approved when the latest review is APPROVED', () => {
+    const result = aggregatePRStatus(
+      pr,
+      [{ user: { login: 'alice' }, state: 'APPROVED' }],
+      [],
+    )
+    expect(result.status).toBe('approved')
+    expect(result.reviewers).toEqual(['alice'])
+    expect(result.commentCount).toBe(0)
+  })
+
+  it('lets changes_requested win over approved from a different reviewer', () => {
+    const result = aggregatePRStatus(
+      pr,
+      [
+        { user: { login: 'alice' }, state: 'APPROVED' },
+        { user: { login: 'bob' }, state: 'CHANGES_REQUESTED' },
+      ],
+      [],
+    )
+    expect(result.status).toBe('changes-requested')
+    expect(result.reviewers).toEqual(expect.arrayContaining(['alice', 'bob']))
+  })
+
+  it('uses the latest review from the same reviewer', () => {
+    const result = aggregatePRStatus(
+      pr,
+      [
+        { user: { login: 'alice' }, state: 'CHANGES_REQUESTED' },
+        { user: { login: 'alice' }, state: 'APPROVED' },
+      ],
+      [],
+    )
+    expect(result.status).toBe('approved')
+  })
+
+  it('returns commented when only inline comments exist', () => {
+    const result = aggregatePRStatus(
+      pr,
+      [],
+      [{ user: { login: 'carol' } }, { user: { login: 'carol' } }],
+    )
+    expect(result.status).toBe('commented')
+    expect(result.commentCount).toBe(2)
+  })
+
+  it('returns pending when there are no reviews and no comments', () => {
+    const result = aggregatePRStatus(pr, [], [])
+    expect(result.status).toBe('pending')
+    expect(result.reviewers).toEqual([])
+  })
+
+  it('propagates merged and closed flags', () => {
+    const mergedPR = { state: 'closed', merged: true, updated_at: '2025-01-01T10:00:00Z' }
+    const result = aggregatePRStatus(mergedPR, [{ user: { login: 'alice' }, state: 'APPROVED' }], [])
+    expect(result.merged).toBe(true)
+    expect(result.closed).toBe(true)
+  })
+})

--- a/desktop/src/main/github.ts
+++ b/desktop/src/main/github.ts
@@ -14,3 +14,194 @@ export function githubHeaders(extra?: Record<string, string>): Record<string, st
   if (token) headers.Authorization = `Bearer ${token}`
   return headers
 }
+
+export interface ParsedPRUrl {
+  owner: string
+  repo: string
+  number: number
+}
+
+/** Parses a GitHub PR URL. Returns null if the URL is not a valid PR URL. */
+export function parsePRUrl(url: string): ParsedPRUrl | null {
+  const match = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?(?:[?#].*)?$/)
+  if (!match) return null
+  const [, owner, repo, numberStr] = match
+  const number = parseInt(numberStr, 10)
+  if (number <= 0) return null
+  return { owner, repo, number }
+}
+
+interface GitHubReview {
+  user?: { login?: string } | null
+  state?: string
+  submitted_at?: string
+}
+
+interface GitHubReviewComment {
+  user?: { login?: string } | null
+}
+
+interface GitHubPullRequest {
+  state?: string
+  merged?: boolean
+  head?: { sha?: string }
+  updated_at?: string
+}
+
+export interface PRFetchResult<T> {
+  data: T
+  rateLimitRemaining: number
+}
+
+function parseRateLimitRemaining(res: Response): number {
+  const header = res.headers.get('X-RateLimit-Remaining')
+  const parsed = header ? parseInt(header, 10) : NaN
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY
+}
+
+async function ghGet<T>(url: string): Promise<PRFetchResult<T>> {
+  const res = await fetch(url, {
+    headers: githubHeaders({ Accept: 'application/vnd.github+json' }),
+  })
+  if (!res.ok) {
+    throw new Error(`GitHub API ${res.status} for ${url}`)
+  }
+  const data = (await res.json()) as T
+  return { data, rateLimitRemaining: parseRateLimitRemaining(res) }
+}
+
+export async function fetchPullRequest(
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<PRFetchResult<GitHubPullRequest>> {
+  return ghGet<GitHubPullRequest>(`https://api.github.com/repos/${owner}/${repo}/pulls/${number}`)
+}
+
+export async function fetchPRReviews(
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<PRFetchResult<GitHubReview[]>> {
+  return ghGet<GitHubReview[]>(`https://api.github.com/repos/${owner}/${repo}/pulls/${number}/reviews`)
+}
+
+export async function fetchPRReviewComments(
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<PRFetchResult<GitHubReviewComment[]>> {
+  return ghGet<GitHubReviewComment[]>(`https://api.github.com/repos/${owner}/${repo}/pulls/${number}/comments`)
+}
+
+export type AggregatedReviewStatus = 'approved' | 'changes-requested' | 'commented' | 'pending'
+
+export interface AggregatedPRStatus {
+  status: AggregatedReviewStatus
+  commentCount: number
+  reviewers: string[]
+  merged: boolean
+  closed: boolean
+  updatedAt: number
+}
+
+/**
+ * Reduces a PR + its reviews + review comments into a single status snapshot.
+ * Rule: keep the latest review per reviewer; changes_requested > approved > commented > pending.
+ */
+export function aggregatePRStatus(
+  pr: GitHubPullRequest,
+  reviews: GitHubReview[],
+  comments: GitHubReviewComment[],
+): AggregatedPRStatus {
+  const latestByReviewer = new Map<string, GitHubReview>()
+  for (const review of reviews) {
+    const login = review.user?.login
+    if (!login) continue
+    // reviews come chronological; overwriting preserves the last one
+    latestByReviewer.set(login, review)
+  }
+
+  const latestStates = Array.from(latestByReviewer.values()).map(r => (r.state || '').toUpperCase())
+
+  let status: AggregatedReviewStatus
+  if (latestStates.includes('CHANGES_REQUESTED')) {
+    status = 'changes-requested'
+  } else if (latestStates.includes('APPROVED')) {
+    status = 'approved'
+  } else if (latestStates.includes('COMMENTED') || comments.length > 0) {
+    status = 'commented'
+  } else {
+    status = 'pending'
+  }
+
+  const reviewers = Array.from(latestByReviewer.entries())
+    .filter(([, r]) => (r.state || '').toUpperCase() !== 'PENDING')
+    .map(([login]) => login)
+
+  const updatedAtMs = pr.updated_at ? new Date(pr.updated_at).getTime() : 0
+
+  return {
+    status,
+    commentCount: comments.length,
+    reviewers,
+    merged: pr.merged === true,
+    closed: pr.state === 'closed',
+    updatedAt: Number.isFinite(updatedAtMs) ? updatedAtMs : 0,
+  }
+}
+
+export interface PRStatusSnapshot extends AggregatedPRStatus {
+  rateLimitRemaining: number
+}
+
+interface PRCacheEntry {
+  lastSeenUpdatedAt: number
+  snapshot: PRStatusSnapshot
+}
+
+const prCache = new Map<string, PRCacheEntry>()
+
+/** Returns the cache entry for a PR URL (visible for testing/diagnostics). */
+export function getCachedPRStatus(url: string): PRCacheEntry | undefined {
+  return prCache.get(url)
+}
+
+/** Clears all cache entries (visible for testing). */
+export function clearPRCache(): void {
+  prCache.clear()
+}
+
+/**
+ * Orchestrates the 3 fetches and aggregates. Returns null if the URL is invalid.
+ * Uses an in-memory cache keyed by URL: if pr.updated_at matches the last snapshot,
+ * returns the cached aggregation (still refreshes rateLimitRemaining).
+ */
+export async function fetchPRStatus(url: string): Promise<PRStatusSnapshot | null> {
+  const parsed = parsePRUrl(url)
+  if (!parsed) return null
+
+  const { owner, repo, number } = parsed
+  const [prRes, reviewsRes, commentsRes] = await Promise.all([
+    fetchPullRequest(owner, repo, number),
+    fetchPRReviews(owner, repo, number),
+    fetchPRReviewComments(owner, repo, number),
+  ])
+
+  const rateLimitRemaining = Math.min(
+    prRes.rateLimitRemaining,
+    reviewsRes.rateLimitRemaining,
+    commentsRes.rateLimitRemaining,
+  )
+
+  const prUpdatedAtMs = prRes.data.updated_at ? new Date(prRes.data.updated_at).getTime() : 0
+  const cached = prCache.get(url)
+  if (cached && cached.lastSeenUpdatedAt === prUpdatedAtMs && prUpdatedAtMs > 0) {
+    return { ...cached.snapshot, rateLimitRemaining }
+  }
+
+  const aggregated = aggregatePRStatus(prRes.data, reviewsRes.data, commentsRes.data)
+  const snapshot: PRStatusSnapshot = { ...aggregated, rateLimitRemaining }
+  prCache.set(url, { lastSeenUpdatedAt: aggregated.updatedAt, snapshot })
+  return snapshot
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -21,6 +21,8 @@ import { reRegisterSpotlightShortcut } from './spotlight-shortcut'
 import { Scheduler } from './scheduler/scheduler'
 import { setupSchedulerHandlers } from './ipc/scheduler-handlers'
 import { setupProfileHandlers } from './ipc/profile-handlers'
+import { PRReviewWatcher } from './pr-review-watcher/watcher'
+import { setupPRReviewHandlers } from './ipc/pr-review-handlers'
 
 let mainWindow: BrowserWindow | null = null
 let isQuitting = false
@@ -28,6 +30,7 @@ let forceQuit = false
 let trayManager: TrayManager | null = null
 let aggregator: AgentStateAggregator | null = null
 let scheduler: Scheduler | null = null
+let prReviewWatcher: PRReviewWatcher | null = null
 
 function createMenu() {
   const isMac = process.platform === 'darwin'
@@ -213,6 +216,13 @@ function setupHandlers() {
     notificationCallback,
   )
   setupSchedulerHandlers(scheduler)
+
+  // Initialize PR review watcher and its IPC handlers
+  prReviewWatcher = new PRReviewWatcher(
+    () => mainWindow,
+    notificationCallback,
+  )
+  setupPRReviewHandlers(prReviewWatcher)
 
   // Window control handlers
   ipcMain.handle('window:minimize', () => {
@@ -510,6 +520,18 @@ async function initializeHooksAndSessions() {
       })
     }
 
+    // Start PR review watcher (default ON unless explicitly disabled)
+    if (prReviewWatcher) {
+      const cfg = readConfig()
+      if (cfg.prReviews?.enabled !== false) {
+        prReviewWatcher.start()
+      }
+
+      // On wake/unlock, kick an immediate tick (suspend is a no-op: the interval pauses naturally).
+      powerMonitor.on('resume', () => prReviewWatcher?.onResume())
+      powerMonitor.on('unlock-screen', () => prReviewWatcher?.onResume())
+    }
+
     // Trigger initial tray state update after agents are restored
     setTimeout(() => {
       if (aggregator) aggregator.update()
@@ -543,6 +565,12 @@ app.on('before-quit', async (event) => {
   if (scheduler) {
     scheduler.stop()
     scheduler = null
+  }
+
+  // Stop PR review watcher
+  if (prReviewWatcher) {
+    prReviewWatcher.stop()
+    prReviewWatcher = null
   }
 
   // Cleanup global shortcuts

--- a/desktop/src/main/ipc/pr-review-handlers.ts
+++ b/desktop/src/main/ipc/pr-review-handlers.ts
@@ -1,0 +1,57 @@
+import { ipcMain, clipboard } from 'electron'
+import { readConfig, writeConfig } from '../config/config'
+import { writeToTerminal, getTerminal } from '../pty/terminal-manager'
+import type { PRReviewWatcher } from '../pr-review-watcher/watcher'
+
+const MIN_POLL_INTERVAL_MS = 30_000
+const MAX_POLL_INTERVAL_MS = 600_000
+
+export function setupPRReviewHandlers(watcher: PRReviewWatcher) {
+  ipcMain.handle('prWatcher:setEnabled', async (_event, enabled: boolean) => {
+    const config = readConfig()
+    config.prReviews = { ...(config.prReviews || {}), enabled }
+    writeConfig(config)
+    watcher.setEnabled(enabled)
+    return config
+  })
+
+  ipcMain.handle('prWatcher:getStatus', async () => {
+    return watcher.getStatus()
+  })
+
+  ipcMain.handle('prWatcher:setInterval', async (_event, ms: number) => {
+    if (!Number.isFinite(ms) || ms < MIN_POLL_INTERVAL_MS || ms > MAX_POLL_INTERVAL_MS) {
+      throw new Error(`Invalid poll interval: ${ms} (must be ${MIN_POLL_INTERVAL_MS}..${MAX_POLL_INTERVAL_MS})`)
+    }
+    const config = readConfig()
+    config.prReviews = { ...(config.prReviews || {}), pollIntervalMs: ms }
+    writeConfig(config)
+    watcher.setInterval(ms)
+    return config
+  })
+
+  ipcMain.handle('prWatcher:setAutoLaunchSkills', async (_event, enabled: boolean) => {
+    const config = readConfig()
+    config.prReviews = { ...(config.prReviews || {}), autoLaunchSkills: enabled }
+    writeConfig(config)
+    return config
+  })
+
+  // Sends a slash command to an agent terminal. If autoLaunchSkills is disabled,
+  // the command is copied to clipboard instead so the user can paste it manually.
+  ipcMain.handle('prWatcher:sendCommand', async (_event, { terminalId, command }: { terminalId: string; command: string }) => {
+    if (!command.trim()) {
+      throw new Error('prWatcher:sendCommand requires a non-empty command')
+    }
+    if (!getTerminal(terminalId)) {
+      throw new Error(`Terminal ${terminalId} not found`)
+    }
+    const autoLaunch = readConfig().prReviews?.autoLaunchSkills === true
+    if (!autoLaunch) {
+      clipboard.writeText(command)
+      return { launched: false, copied: true }
+    }
+    writeToTerminal(terminalId, command + '\n')
+    return { launched: true, copied: false }
+  })
+}

--- a/desktop/src/main/pr-review-watcher/watcher.ts
+++ b/desktop/src/main/pr-review-watcher/watcher.ts
@@ -1,0 +1,180 @@
+import { BrowserWindow } from 'electron'
+import { readConfig } from '../config/config'
+import { getAllTerminals, updateTerminalMetadataFromHook } from '../pty/terminal-manager'
+import { addHistoryEntry } from '../config/activity-history'
+import { fetchPRStatus, type AggregatedReviewStatus } from '../github'
+import type { RepositoryMetadata } from '../../types'
+
+const DEFAULT_POLL_INTERVAL_MS = 60_000
+const MIN_POLL_INTERVAL_MS = 30_000
+const MAX_POLL_INTERVAL_MS = 600_000
+const RATE_LIMIT_SAFETY_FLOOR = 500
+const NOTIFICATION_COOLDOWN_MS = 5 * 60 * 1000
+
+interface LastKnown {
+  status: AggregatedReviewStatus
+  updatedAt: number
+}
+
+export class PRReviewWatcher {
+  private intervalId: ReturnType<typeof setInterval> | null = null
+  private pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS
+  private lastTickAt: number | null = null
+  private watchingCount: number = 0
+  private lastNotifiedAt = new Map<string, number>()
+  private lastKnownStatus = new Map<string, LastKnown>()
+  private getMainWindow: () => BrowserWindow | null
+  private showNotification: (title: string, body: string) => void
+
+  constructor(
+    getMainWindow: () => BrowserWindow | null,
+    showNotification: (title: string, body: string) => void,
+  ) {
+    this.getMainWindow = getMainWindow
+    this.showNotification = showNotification
+
+    const cfg = readConfig().prReviews
+    if (cfg?.pollIntervalMs && cfg.pollIntervalMs >= MIN_POLL_INTERVAL_MS && cfg.pollIntervalMs <= MAX_POLL_INTERVAL_MS) {
+      this.pollIntervalMs = cfg.pollIntervalMs
+    }
+  }
+
+  start(): void {
+    if (this.intervalId) return
+    this.intervalId = setInterval(() => { void this.tick() }, this.pollIntervalMs)
+    void this.tick()
+  }
+
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId)
+      this.intervalId = null
+    }
+  }
+
+  setEnabled(enabled: boolean): void {
+    if (enabled) this.start()
+    else this.stop()
+  }
+
+  setInterval(ms: number): void {
+    this.pollIntervalMs = ms
+    if (this.intervalId) {
+      this.stop()
+      this.start()
+    }
+  }
+
+  getStatus() {
+    const config = readConfig()
+    return {
+      enabled: config.prReviews?.enabled !== false,
+      pollIntervalMs: this.pollIntervalMs,
+      watchingCount: this.watchingCount,
+      lastTickAt: this.lastTickAt,
+    }
+  }
+
+  onResume(): void {
+    void this.tick()
+  }
+
+  async tick(): Promise<void> {
+    this.lastTickAt = Date.now()
+
+    const config = readConfig()
+    if (config.prReviews?.enabled === false) return
+
+    const terminals = getAllTerminals()
+    type Target = { terminalId: string; repoPath: string; prUrl: string; existing: RepositoryMetadata }
+    const targets: Target[] = []
+
+    for (const terminal of terminals) {
+      const repoMap = terminal.metadata?.repositoryMetadata || {}
+      for (const [repoPath, repoMeta] of Object.entries(repoMap)) {
+        const prUrl = repoMeta?.prUrl
+        if (!prUrl) continue
+        // Stop polling closed-but-unmerged PRs
+        if (repoMeta.prClosed === true && repoMeta.prMerged !== true) continue
+        targets.push({ terminalId: terminal.id, repoPath, prUrl, existing: repoMeta })
+      }
+    }
+
+    this.watchingCount = targets.length
+
+    for (const target of targets) {
+      try {
+        const snapshot = await fetchPRStatus(target.prUrl)
+        if (!snapshot) continue
+
+        if (snapshot.rateLimitRemaining < RATE_LIMIT_SAFETY_FLOOR) {
+          console.warn(`[PRReviewWatcher] Rate limit low (${snapshot.rateLimitRemaining}), skipping remaining PRs this tick`)
+          return
+        }
+
+        const previous = this.lastKnownStatus.get(target.prUrl)
+        if (previous && previous.updatedAt === snapshot.updatedAt) continue
+
+        const mergedRepoMeta: RepositoryMetadata = {
+          ...target.existing,
+          prReviewStatus: snapshot.status,
+          prReviewCommentCount: snapshot.commentCount,
+          prReviewers: snapshot.reviewers,
+          prReviewUpdatedAt: snapshot.updatedAt,
+          prMerged: snapshot.merged,
+          prClosed: snapshot.closed,
+        }
+
+        updateTerminalMetadataFromHook(target.terminalId, {
+          repositoryMetadata: { [target.repoPath]: mergedRepoMeta },
+        })
+
+        // History entry on transition
+        const prevStatus = previous?.status
+        if (prevStatus !== snapshot.status) {
+          if (snapshot.status === 'approved' || snapshot.status === 'changes-requested') {
+            const terminal = terminals.find(t => t.id === target.terminalId)
+            addHistoryEntry({
+              agentId: target.terminalId,
+              agentName: terminal?.metadata?.title || terminal?.name || target.terminalId,
+              action: snapshot.status === 'approved' ? 'review_approved' : 'review_changes_requested',
+              ticketId: terminal?.metadata?.ticketId,
+              description: terminal?.metadata?.description,
+              repositories: terminal?.repositories || [],
+            })
+          }
+        }
+
+        // Notify only if window is not focused, on a real transition, respecting cooldown
+        const mainWindow = this.getMainWindow()
+        const windowFocused = mainWindow?.isFocused() ?? false
+        const now = Date.now()
+        const lastNotified = this.lastNotifiedAt.get(target.prUrl) || 0
+        if (!windowFocused && now - lastNotified > NOTIFICATION_COOLDOWN_MS && prevStatus !== snapshot.status) {
+          this.lastNotifiedAt.set(target.prUrl, now)
+          this.showNotification(
+            'PR review update',
+            `${target.prUrl}: ${snapshot.status}`,
+          )
+        }
+
+        this.lastKnownStatus.set(target.prUrl, { status: snapshot.status, updatedAt: snapshot.updatedAt })
+
+        if (mainWindow) {
+          mainWindow.webContents.send('prWatcher:updated', {
+            terminalId: target.terminalId,
+            repoPath: target.repoPath,
+            prUrl: target.prUrl,
+            status: snapshot.status,
+            commentCount: snapshot.commentCount,
+            reviewers: snapshot.reviewers,
+            merged: snapshot.merged,
+            closed: snapshot.closed,
+          })
+        }
+      } catch (err) {
+        console.error(`[PRReviewWatcher] Failed to refresh ${target.prUrl}:`, err)
+      }
+    }
+  }
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -354,6 +354,36 @@ const schedulerApi = {
   },
 }
 
+// PR Review Watcher API
+const prWatcherApi = {
+  setEnabled: (enabled: boolean) =>
+    ipcRenderer.invoke('prWatcher:setEnabled', enabled),
+  getStatus: (): Promise<{ enabled: boolean; pollIntervalMs: number; watchingCount: number; lastTickAt: number | null }> =>
+    ipcRenderer.invoke('prWatcher:getStatus'),
+  setInterval: (ms: number) =>
+    ipcRenderer.invoke('prWatcher:setInterval', ms),
+  setAutoLaunchSkills: (enabled: boolean) =>
+    ipcRenderer.invoke('prWatcher:setAutoLaunchSkills', enabled),
+  sendCommand: (terminalId: string, command: string): Promise<{ launched: boolean; copied: boolean }> =>
+    ipcRenderer.invoke('prWatcher:sendCommand', { terminalId, command }),
+  onUpdated: (callback: (data: PRWatcherUpdate) => void) => {
+    const listener = (_event: IpcRendererEvent, data: PRWatcherUpdate) => callback(data)
+    ipcRenderer.on('prWatcher:updated', listener)
+    return () => ipcRenderer.removeListener('prWatcher:updated', listener)
+  },
+}
+
+interface PRWatcherUpdate {
+  terminalId: string
+  repoPath: string
+  prUrl: string
+  status: string
+  commentCount: number
+  reviewers: string[]
+  merged: boolean
+  closed: boolean
+}
+
 // Profile API
 const profileApi = {
   get: (): Promise<UserProfile | null> => ipcRenderer.invoke('profile:get'),
@@ -375,6 +405,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   tray: trayApi,
   quickLaunch: quickLaunchApi,
   scheduler: schedulerApi,
+  prWatcher: prWatcherApi,
   profile: profileApi,
 })
 
@@ -395,6 +426,7 @@ declare global {
       tray: typeof trayApi
       quickLaunch: typeof quickLaunchApi
       scheduler: typeof schedulerApi
+      prWatcher: typeof prWatcherApi
       profile: typeof profileApi
     }
   }

--- a/desktop/src/renderer/components/AgentInfoSidebar.tsx
+++ b/desktop/src/renderer/components/AgentInfoSidebar.tsx
@@ -504,6 +504,7 @@ export function AgentInfoSidebar() {
                     gitData={repoGitData[repoPath]}
                     baseBranch={metadata?.baseBranch}
                     prUrl={getRepoPrUrl(repoPath)}
+                    repoMetadata={metadata?.repositoryMetadata?.[repoPath]}
                     copiedCommitHash={copiedCommitHash}
                     copiedBranch={copiedBranch}
                     onCopyCommitHash={copyCommitHash}

--- a/desktop/src/renderer/components/agent-info-sidebar/RepositoryCard.tsx
+++ b/desktop/src/renderer/components/agent-info-sidebar/RepositoryCard.tsx
@@ -1,8 +1,10 @@
-import { GitBranch, Copy, Check, ExternalLink, ArrowRight } from 'lucide-react'
+import { GitBranch, Copy, Check, ExternalLink, ArrowRight, CheckCircle2, AlertCircle, MessageSquare, Clock, Wrench, CheckCircle } from 'lucide-react'
 import { GitHubIcon, VSCodeIcon } from './icons'
 import { ScriptsDropdown } from './ScriptsDropdown'
 import { formatRelativeDate } from './utils'
+import { showToast } from '../Toast'
 import type { RepoGitData } from './types'
+import type { RepositoryMetadata } from '../../../types'
 
 interface RepositoryCardProps {
   repoPath: string
@@ -12,10 +14,44 @@ interface RepositoryCardProps {
   gitData: RepoGitData | undefined
   baseBranch: string | undefined
   prUrl: string | undefined
+  repoMetadata?: RepositoryMetadata
   copiedCommitHash: string | null
   copiedBranch: string | null
   onCopyCommitHash: (hash: string) => void
   onCopyBranchName: (branch: string) => void
+}
+
+const REVIEW_STATUS_LABELS: Record<NonNullable<RepositoryMetadata['prReviewStatus']>, string> = {
+  approved: 'Approved',
+  'changes-requested': 'Changes requested',
+  commented: 'Commented',
+  pending: 'Pending',
+}
+
+function ReviewStatusIcon({ status }: { status: NonNullable<RepositoryMetadata['prReviewStatus']> }) {
+  switch (status) {
+    case 'approved':
+      return <CheckCircle2 className="w-3.5 h-3.5 text-green-500" />
+    case 'changes-requested':
+      return <AlertCircle className="w-3.5 h-3.5 text-red-500" />
+    case 'commented':
+      return <MessageSquare className="w-3.5 h-3.5 text-blue-500" />
+    case 'pending':
+      return <Clock className="w-3.5 h-3.5 text-text-secondary" />
+  }
+}
+
+async function runSlashCommand(terminalId: string, command: string) {
+  try {
+    const result = await window.electronAPI.prWatcher.sendCommand(terminalId, command)
+    if (result.launched) {
+      showToast(`Sent ${command} to the agent`, 'success')
+    } else if (result.copied) {
+      showToast(`Auto-launch disabled — ${command} copied to clipboard`, 'warning')
+    }
+  } catch (err) {
+    showToast(err instanceof Error ? err.message : 'Failed to launch command', 'error')
+  }
 }
 
 export function RepositoryCard({
@@ -26,6 +62,7 @@ export function RepositoryCard({
   gitData,
   baseBranch,
   prUrl,
+  repoMetadata,
   copiedCommitHash,
   copiedBranch,
   onCopyCommitHash,
@@ -229,6 +266,52 @@ export function RepositoryCard({
           </div>
           <ExternalLink className="w-3 h-3 text-accent/50 group-hover:text-accent transition-colors" />
         </button>
+      )}
+
+      {/* PR review status block */}
+      {prUrl && repoMetadata?.prReviewStatus && (
+        <div className="mt-2 bg-white/[0.06] rounded-md p-2 space-y-1.5">
+          <div className="flex items-center gap-1.5 text-xs">
+            <ReviewStatusIcon status={repoMetadata.prReviewStatus} />
+            <span className="text-white/80 font-medium">
+              {REVIEW_STATUS_LABELS[repoMetadata.prReviewStatus]}
+            </span>
+            {repoMetadata.prMerged && (
+              <span className="ml-1 px-1.5 py-0.5 rounded bg-green-500/10 text-green-500 text-[10px] font-semibold uppercase tracking-wide">
+                merged
+              </span>
+            )}
+            {repoMetadata.prReviewCommentCount !== undefined && repoMetadata.prReviewCommentCount > 0 && (
+              <span className="ml-auto flex items-center gap-1 text-text-secondary/70">
+                <MessageSquare className="w-3 h-3" />
+                {repoMetadata.prReviewCommentCount}
+              </span>
+            )}
+          </div>
+          {repoMetadata.prReviewers && repoMetadata.prReviewers.length > 0 && (
+            <div className="text-[10px] text-text-secondary/60 truncate" title={repoMetadata.prReviewers.join(', ')}>
+              by {repoMetadata.prReviewers.join(', ')}
+            </div>
+          )}
+          {(repoMetadata.prReviewStatus === 'changes-requested' || repoMetadata.prReviewStatus === 'commented') && (
+            <button
+              onClick={() => runSlashCommand(agentId, '/magic:resolve')}
+              className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 rounded-md text-red-500 text-xs font-medium transition-colors"
+            >
+              <Wrench className="w-3 h-3" />
+              Launch magic-resolve
+            </button>
+          )}
+          {repoMetadata.prMerged === true && (
+            <button
+              onClick={() => runSlashCommand(agentId, '/magic:done')}
+              className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 bg-green-500/10 hover:bg-green-500/20 border border-green-500/20 rounded-md text-green-500 text-xs font-medium transition-colors"
+            >
+              <CheckCircle className="w-3 h-3" />
+              Launch magic-done
+            </button>
+          )}
+        </div>
       )}
     </div>
   )

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, CalendarClock } from 'lucide-react'
+import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, CalendarClock, GitPullRequest } from 'lucide-react'
 import { ProfileSection } from './ProfileSection'
 import { RepoPage } from './RepoPage'
 import { useStore } from '../../store'
@@ -42,6 +42,9 @@ function WelcomePage() {
   const [showBypassWarning, setShowBypassWarning] = useState(false)
   const [schedulerEnabled, setSchedulerEnabled] = useState(config?.schedulerEnabled ?? true)
   const [schedulerDefaultTime, setSchedulerDefaultTime] = useState(config?.schedulerDefaultTime ?? '09:00')
+  const [prWatcherEnabled, setPrWatcherEnabled] = useState(config?.prReviews?.enabled ?? true)
+  const [prWatcherInterval, setPrWatcherInterval] = useState(config?.prReviews?.pollIntervalMs ?? 60_000)
+  const [prWatcherAutoLaunch, setPrWatcherAutoLaunch] = useState(config?.prReviews?.autoLaunchSkills ?? false)
 
   const configSpotlightEnabled = config?.spotlight?.enabled
   const configSpotlightShortcut = config?.spotlight?.shortcut
@@ -64,6 +67,15 @@ function WelcomePage() {
   useEffect(() => {
     if (configSchedulerDefaultTime !== undefined) setSchedulerDefaultTime(configSchedulerDefaultTime)
   }, [configSchedulerDefaultTime])
+
+  const configPrWatcherEnabled = config?.prReviews?.enabled
+  const configPrWatcherInterval = config?.prReviews?.pollIntervalMs
+  const configPrWatcherAutoLaunch = config?.prReviews?.autoLaunchSkills
+  useEffect(() => {
+    if (configPrWatcherEnabled !== undefined) setPrWatcherEnabled(configPrWatcherEnabled)
+    if (configPrWatcherInterval !== undefined) setPrWatcherInterval(configPrWatcherInterval)
+    if (configPrWatcherAutoLaunch !== undefined) setPrWatcherAutoLaunch(configPrWatcherAutoLaunch)
+  }, [configPrWatcherEnabled, configPrWatcherInterval, configPrWatcherAutoLaunch])
 
   const handleSpotlightToggle = async () => {
     const newEnabled = !spotlightEnabled
@@ -443,6 +455,87 @@ function WelcomePage() {
             <div className="text-xs text-text-secondary/50">
               Schedules are preserved but no agents will run automatically.
             </div>
+          )}
+        </div>
+      </div>
+
+      {/* PR Review Watcher Section */}
+      <div>
+        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
+          <GitPullRequest className="w-4 h-4" />
+          <span>PR Review Watcher</span>
+        </div>
+        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium">Watch PR reviews</div>
+              <div className="text-xs text-text-secondary/50 mt-0.5">Poll GitHub to track review status on agents' pull requests</div>
+            </div>
+            <button
+              onClick={() => {
+                const newValue = !prWatcherEnabled
+                setPrWatcherEnabled(newValue)
+                window.electronAPI.prWatcher.setEnabled(newValue)
+              }}
+              className={`relative w-10 h-[22px] rounded-full transition-colors duration-200 flex-shrink-0 ${
+                prWatcherEnabled ? 'bg-accent' : 'bg-white/20'
+              }`}
+            >
+              <div className={`absolute top-[3px] left-[3px] w-4 h-4 rounded-full bg-white transition-transform duration-200 ${
+                prWatcherEnabled ? 'translate-x-[18px]' : 'translate-x-0'
+              }`} />
+            </button>
+          </div>
+          {prWatcherEnabled && (
+            <>
+              <div className="border-t border-white/5 pt-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="text-sm font-medium">Polling interval</div>
+                    <div className="text-xs text-text-secondary/50 mt-0.5">How often the GitHub API is polled</div>
+                  </div>
+                  <div className="relative">
+                    <select
+                      value={prWatcherInterval}
+                      onChange={(e) => {
+                        const newInterval = parseInt(e.target.value, 10)
+                        setPrWatcherInterval(newInterval)
+                        window.electronAPI.prWatcher.setInterval(newInterval)
+                      }}
+                      className="w-52 px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors appearance-none cursor-pointer"
+                    >
+                      <option value={30_000}>30 seconds</option>
+                      <option value={60_000}>1 minute</option>
+                      <option value={120_000}>2 minutes</option>
+                      <option value={300_000}>5 minutes</option>
+                    </select>
+                    <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary/50 pointer-events-none" />
+                  </div>
+                </div>
+              </div>
+              <div className="border-t border-white/5 pt-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="text-sm font-medium">Auto-launch skills</div>
+                    <div className="text-xs text-text-secondary/50 mt-0.5">Send /magic:resolve or /magic:done directly to the agent's terminal. Disabled by default for safety.</div>
+                  </div>
+                  <button
+                    onClick={() => {
+                      const newValue = !prWatcherAutoLaunch
+                      setPrWatcherAutoLaunch(newValue)
+                      window.electronAPI.prWatcher.setAutoLaunchSkills(newValue)
+                    }}
+                    className={`relative w-10 h-[22px] rounded-full transition-colors duration-200 flex-shrink-0 ${
+                      prWatcherAutoLaunch ? 'bg-accent' : 'bg-white/20'
+                    }`}
+                  >
+                    <div className={`absolute top-[3px] left-[3px] w-4 h-4 rounded-full bg-white transition-transform duration-200 ${
+                      prWatcherAutoLaunch ? 'translate-x-[18px]' : 'translate-x-0'
+                    }`} />
+                  </button>
+                </div>
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/desktop/src/renderer/pages/History/index.tsx
+++ b/desktop/src/renderer/pages/History/index.tsx
@@ -16,6 +16,8 @@ const ACTION_CONFIG: Record<HistoryAction, { label: string; color: string }> = {
   committed: { label: 'Committed', color: 'bg-yellow' },
   pr_created: { label: 'PR created', color: 'bg-blue' },
   review: { label: 'In review', color: 'bg-purple' },
+  review_approved: { label: 'Review approved', color: 'bg-green' },
+  review_changes_requested: { label: 'Changes requested', color: 'bg-red' },
   merged: { label: 'Merged', color: 'bg-green' },
   done: { label: 'Done', color: 'bg-teal' },
   agent_closed: { label: 'Agent closed', color: 'bg-text-secondary' },

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -2,6 +2,12 @@ export type TerminalState = 'idle' | 'working' | 'waiting' | 'completed' | 'erro
 
 export interface RepositoryMetadata {
   prUrl?: string
+  prReviewStatus?: 'approved' | 'changes-requested' | 'commented' | 'pending'
+  prReviewCommentCount?: number
+  prReviewers?: string[]
+  prReviewUpdatedAt?: number
+  prMerged?: boolean
+  prClosed?: boolean
 }
 
 export interface TerminalMetadata {
@@ -120,6 +126,11 @@ export interface Config {
   launchMode?: LaunchMode
   schedulerEnabled?: boolean
   schedulerDefaultTime?: string
+  prReviews?: {
+    enabled?: boolean
+    pollIntervalMs?: number
+    autoLaunchSkills?: boolean
+  }
 }
 
 export interface PRTemplate {
@@ -148,6 +159,8 @@ export type HistoryAction =
   | 'review'
   | 'merged'
   | 'done'
+  | 'review_approved'
+  | 'review_changes_requested'
   | 'waiting'
   | 'completed'
   | 'agent_created'


### PR DESCRIPTION
## Description

Adds a background service to the desktop app that monitors PR review status via the GitHub API. When a PR owned by an agent is reviewed, the sidebar shows the review state (approved / changes requested / commented / pending) with Lucide icons, a comment count and reviewer list, plus contextual buttons to launch `/magic:resolve` or `/magic:done` on the agent's terminal.

Closes the loop between `/magic:pr` and acting on review feedback — no more manually checking GitHub.

## Related Issue

Closes #100

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **Types & config** (`desktop/src/types.ts`): extended `RepositoryMetadata` with `prReviewStatus`, `prReviewCommentCount`, `prReviewers`, `prReviewUpdatedAt`, `prMerged`, `prClosed`; added `review_approved` / `review_changes_requested` to `HistoryAction`; added `Config.prReviews` block.
- **GitHub helpers** (`desktop/src/main/github.ts`): new `parsePRUrl`, `fetchPullRequest`, `fetchPRReviews`, `fetchPRReviewComments`, `aggregatePRStatus`, `fetchPRStatus` — native `fetch` + existing `githubHeaders()`, with in-memory cache keyed on PR `updated_at` and rate-limit awareness via `X-RateLimit-Remaining`.
- **PRReviewWatcher service** (`desktop/src/main/pr-review-watcher/watcher.ts`): mirrors the `Scheduler` pattern — `start/stop/tick/onResume` lifecycle, 60s default interval, 5-min notification cooldown, history dedup via `prReviewUpdatedAt`, skips closed-unmerged PRs and pauses when rate-limit remaining < 500.
- **IPC handlers** (`desktop/src/main/ipc/pr-review-handlers.ts`): `prWatcher:setEnabled`, `getStatus`, `setInterval`, `setAutoLaunchSkills`, `sendCommand`. `sendCommand` honours `autoLaunchSkills` (off by default: copies the slash command to clipboard instead of writing to the PTY).
- **Main process wiring** (`desktop/src/main/index.ts`): instantiates `PRReviewWatcher`, starts it per config, wires `powerMonitor` resume/unlock, stops on `before-quit`.
- **Preload bridge** (`desktop/src/preload/index.ts`): exposes `window.electronAPI.prWatcher.{setEnabled, getStatus, setInterval, setAutoLaunchSkills, sendCommand, onUpdated}`.
- **Sidebar UI** (`RepositoryCard.tsx`, `AgentInfoSidebar.tsx`): new review block under the PR button — color-coded Lucide icons (`CheckCircle2` / `AlertCircle` / `MessageSquare` / `Clock`), comment count, reviewer list, "Launch magic-resolve" button when status is `changes-requested` or `commented`, "Launch magic-done" button whenever `merged === true`.
- **Settings page** (`Config/index.tsx`): new "PR Review Watcher" section with enable toggle, polling-interval selector (30s / 1min / 2min / 5min), and auto-launch toggle (off by default).
- **Activity history** (`History/index.tsx`): added `review_approved` / `review_changes_requested` actions to `ACTION_CONFIG`.
- **Tests** (`desktop/src/main/github.test.ts`): 11 cases covering `parsePRUrl` edge cases and all `aggregatePRStatus` scenarios (approved, changes-requested wins over approved, latest review per reviewer, commented, pending, merged/closed propagation).

## Testing

- [x] Ran linters (`npm run lint:js`) — only pre-existing warnings in `RepoPage.tsx`
- [x] Ran tests (`npm test`) — 205/205 passing (including 11 new cases)
- [x] Type-check (`npx tsc --noEmit` from `desktop/`) — clean
- [ ] Tested locally with Claude Code

### Test Steps

1. Pull this branch, run `npm install` at the root and `cd desktop && npm install`, then `npm run desktop` from the repo root.
2. Start an agent that has an open PR (via `/magic:pr`). Within ~60s, the agent's sidebar card should show a new "Review" block under the "View Pull Request" button with a status icon (initially "Pending" / Clock).
3. On GitHub, approve the PR or request changes. Wait up to the polling interval — the badge should update; if the desktop window is unfocused, a system notification appears (cooldown 5 min per PR).
4. When the status is `changes-requested` or `commented`, a red "Launch magic-resolve" button appears. With `Auto-launch skills` OFF (default), clicking it copies `/magic:resolve` to the clipboard and shows a toast; with it ON, the command is written to the agent's terminal.
5. Merge the PR — a green "Launch magic-done" button appears; same auto-launch behavior.
6. In Settings → "PR Review Watcher": toggle the watcher off/on, change the polling interval (30s / 1min / 2min / 5min), toggle auto-launch.

## Screenshots

_Not attached — UI-only screenshots should be added during review._

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests for the new helpers
- [x] All linters pass locally

## Additional Notes

- No new npm dependencies — native `fetch` + existing `gh` CLI token retrieval.
- `autoLaunchSkills` defaults to OFF to prevent surprise writes to the agent's PTY; fallback is clipboard copy + toast.
- In-memory notification cooldown resets on app restart (acceptable limitation — documented in the watcher).
- Closed-but-not-merged PRs are dropped from polling to save quota.
- The "Launch magic-done" button is gated on `merged === true` alone (not `approved && merged`) to stay robust if the review status is stale post-merge.
