### PR TITLE
[#116] Require concrete manual test scenarios in the PR "How to test" section

### DIFF
--- a/skills/magic-pr/SKILL.md
+++ b/skills/magic-pr/SKILL.md
@@ -303,7 +303,8 @@ Then selectively read the **key files** (business logic, API routes, components)
 
 1. From the `--stat` output, identify key files vs secondary files (tests, config, types, lock files)
 2. Read key modified files individually using `Read` to understand the changes in context
-3. Use this understanding to write a meaningful summary and concrete testing instructions in Step 6
+3. While reading, note the user-visible surfaces touched (routes/pages, UI components, API endpoints, CLI commands) and the test environment needed (env vars, seed data, a service to run) — this is the raw material for the manual test scenarios in Step 6
+4. Use this understanding to write a meaningful summary and concrete testing instructions in Step 6
 
 Only use `git diff origin/$DEV_BRANCH..HEAD` for small changes (< 10 files, < 200 lines total). For anything larger, the selective approach above produces better PR descriptions while consuming far less context.
 
@@ -315,7 +316,7 @@ Check if a PR template exists in the project:
 cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || cat .github/pull_request_template.md 2>/dev/null || cat docs/pull_request_template.md 2>/dev/null || echo ""
 ```
 
-If a template exists, you must **strictly follow it** and fill in its sections. For any section related to testing (e.g., "Testing", "How to test", "Test Steps", "Comment tester", "Vérification"), you must **analyze the diff from Step 4.1** to fill it with concrete, specific testing steps based on the actual code changes. Do NOT use generic placeholders.
+If a template exists, you must **strictly follow it** and fill in its sections. For any section related to testing (e.g., "Testing", "How to test", "Test Steps", "Comment tester", "Vérification"), you must **analyze the diff from Step 4.1** to fill it with concrete, specific testing steps based on the actual code changes. Do NOT use generic placeholders. The same rules as the default template apply: write numbered manual scenarios from the user's point of view (each pairing an action with its observable expected result), never "run the automated tests" as the sole content, and — if the PR has no manually testable surface (docs-only, CI, pure refactor) — state that plainly instead of inventing a scenario.
 
 ## Step 5.1: Check for conflicts with base branch
 
@@ -406,6 +407,9 @@ After the user confirms, verify the PR body before passing it to the MCP tool. I
 2. **No unfilled template placeholders**: the body must not contain instruction text inside square brackets (e.g., `[Concise summary of changes]`, `[List of commits]`). Every `[instruction]` from the template must have been replaced with actual content.
 3. **Required section headers present**: the body must contain at least `## Summary` and `## Changes` as distinct lines (or their FR equivalents `## Résumé` and `## Changements` if `languages.pullRequest` is `"fr"`).
 4. **Non-empty sections**: each section heading must be followed by at least one non-blank line of actual content before the next heading or end of body.
+5. **Testing section is a real manual scenario**: locate the testing section under EITHER the default headers (`## How to test` / `## Comment tester`) OR any testing-related project-template heading (e.g. `## Testing`, `### Test Steps`, `## Vérification`, `## QA`) — whichever is present. The section PASSES if it meets EITHER of these conditions:
+   - **Manual scenario**: contains at least one numbered step (a line starting with `1.`) and does NOT consist solely of a test command (e.g. only "run npm test" / "lancer npm test"). A single automated-test line is acceptable only as an optional last line after the manual steps.
+   - **No-surface declaration**: explicitly states there is no manual test surface (docs-only/CI/pure refactor), e.g. "No manual test surface — docs-only change; verify rendering / links". In this case a numbered step is NOT required.
 
 **If any check fails:**
 - Log which check(s) failed

--- a/skills/magic-pr/references/messages.md
+++ b/skills/magic-pr/references/messages.md
@@ -321,11 +321,12 @@ Créer cette PR ? (O/n/edit)
 
 ## How to test
 
-[Based on the diff from Step 4.1, write concrete step-by-step testing instructions:
-- Identify the features/fixes changed in the diff
-- For each change, describe how to verify it works
-- Include expected results
-Do NOT use generic placeholders - every step must be specific to the actual changes]
+[Write concrete MANUAL test scenarios from the user's point of view, grounded in the actual diff from Step 4.1 (the user-visible surfaces and test environment identified there):
+- If setup is needed, start with a single prerequisites line (env vars, seed data, a service to run).
+- Then list 2-5 numbered actions. Each step pairs a concrete action (open a URL/page, click a UI element, run a CLI command, call an endpoint) with its observable expected result — action → expected result.
+- Do NOT write "run the automated tests" (npm test, etc.) as the only instruction. A single automated-test line is allowed ONLY as an optional last line AFTER the manual steps.
+- If the PR has no manually testable surface (docs-only, CI, pure refactor), do NOT invent a scenario: state it plainly instead, e.g. "No manual test surface — docs-only change; verify rendering / links".
+Every step must be specific to the actual changes — no generic placeholders.]
 ```
 
 ## MSG_PR_TEMPLATE_FR
@@ -343,11 +344,12 @@ Do NOT use generic placeholders - every step must be specific to the actual chan
 
 ## Comment tester
 
-[À partir du diff récupéré au Step 4.1, rédiger des instructions de test concrètes étape par étape :
-- Identifier les fonctionnalités/corrections modifiées dans le diff
-- Pour chaque changement, décrire comment vérifier qu'il fonctionne
-- Inclure les résultats attendus
-Ne PAS utiliser de placeholders génériques - chaque étape doit être spécifique aux changements réels]
+[Rédiger des scénarios de test MANUELS concrets du point de vue de l'utilisateur, ancrés dans le diff réel du Step 4.1 (les surfaces visibles par l'utilisateur et l'environnement de test identifiés à cette étape) :
+- Si une préparation est nécessaire, commencer par une seule ligne de prérequis (variables d'environnement, données de départ, un service à lancer).
+- Puis lister 2 à 5 actions numérotées. Chaque étape associe une action concrète (ouvrir une URL/page, cliquer sur un élément d'UI, lancer une commande CLI, appeler un endpoint) à son résultat attendu observable — action → résultat attendu.
+- Ne PAS écrire « lancer les tests automatisés » (npm test, etc.) comme seule instruction. Une unique ligne de tests automatisés n'est autorisée QU'EN dernière ligne optionnelle, APRÈS les étapes manuelles.
+- Si la PR n'a aucune surface testable manuellement (docs uniquement, CI, refactoring pur), ne PAS inventer de scénario : le dire clairement à la place, ex. « Aucune surface de test manuel — changement docs uniquement ; vérifier le rendu / les liens ».
+Chaque étape doit être spécifique aux changements réels — pas de placeholders génériques.]
 ```
 
 ## MSG_JIRA_COMMENT


### PR DESCRIPTION
## Description

Make the "How to test" / "Comment tester" section of PRs generated by `/magic:pr` produce concrete manual test scenarios written from the user's point of view (prerequisites → numbered actions → observable expected result), grounded in the actual diff — instead of shallow "run the automated tests".

## Related Issue

Closes #116

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Rewrote the `## How to test` / `## Comment tester` blocks in `MSG_PR_TEMPLATE_EN` / `MSG_PR_TEMPLATE_FR` (strict EN/FR parity): manual scenarios, forbid "run the automated tests" as the sole instruction, explicit fallback for PRs with no testable surface.
- Strengthened SKILL.md Step 4.1 to extract user-visible surfaces (routes/pages, UI components, API endpoints, CLI commands) + test environment as raw material for scenarios.
- Aligned SKILL.md Step 5 so project PR templates get the same rules.
- Added SKILL.md Step 6.2.1 check #5 validating the testing section (numbered steps, not test-command-only) across default and project-template headers.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

### Test Steps

1. On a branch with a UI change (new component/route), run `/magic:pr` — the generated testing section shows 2-5 numbered steps pairing a concrete action (open a page, click an element) with an observable expected result, not just "run npm test".
2. On a docs-only branch (e.g. a `.md` edit), run `/magic:pr` — the section shows the explicit fallback ("No manual test surface — docs-only change…") instead of an invented scenario.
3. Repeat step 1 with `languages.pullRequest: "fr"` — the "Comment tester" section applies identical rules (EN/FR parity).
4. Since this repo ships `.github/PULL_REQUEST_TEMPLATE.md`, confirm its `### Test Steps` section (not only the default template) is filled with numbered manual scenarios and that Step 6.2.1 check #5 validates them.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

Pure prompt-engineering change to the `magic-pr` skill files. No config option added. Confidence review scored 9/10; end-to-end `/magic:pr` runs across UI / backend / docs-only branches remain as manual verification (see Test Steps).