### PR TITLE
feat(desktop): show live context usage and cost in agent sidebar

### DIFF
--- a/desktop/src/main/hooks/claude-hooks-config.ts
+++ b/desktop/src/main/hooks/claude-hooks-config.ts
@@ -4,6 +4,37 @@ import * as os from 'os'
 
 const CLAUDE_SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json')
 const MAGIC_SLASH_HOOK_MARKER = 'magic-slash-desktop'
+
+// StatusLine integration: a wrapper script captures Claude Code's statusline JSON
+// (cost, context usage, model) and POSTs it to the local status server, then relays
+// the user's original statusline so nothing is lost.
+const MAGIC_SLASH_CONFIG_DIR = path.join(os.homedir(), '.config', 'magic-slash')
+const STATUSLINE_SCRIPT_PATH = path.join(MAGIC_SLASH_CONFIG_DIR, 'statusline.sh')
+const STATUSLINE_BACKUP_PATH = path.join(MAGIC_SLASH_CONFIG_DIR, 'statusline-original.json')
+const STATUSLINE_MARKER = 'magic-slash/statusline.sh'
+
+const STATUSLINE_SCRIPT = `#!/usr/bin/env bash
+# Managed by Magic Slash Desktop — captures Claude Code usage for the app sidebar.
+input=$(cat)
+if [ -n "$MAGIC_SLASH_TERMINAL_ID" ] && [ -n "$MAGIC_SLASH_PORT" ]; then
+  printf '%s' "$input" | curl -s -X POST --data-binary @- \\
+    "http://127.0.0.1:$MAGIC_SLASH_PORT/usage?id=$MAGIC_SLASH_TERMINAL_ID" >/dev/null 2>&1 || true
+fi
+# Relay the user's original statusline if one was configured
+if [ -n "$MAGIC_SLASH_INNER_STATUSLINE" ]; then
+  printf '%s' "$input" | eval "$MAGIC_SLASH_INNER_STATUSLINE"
+fi
+`
+
+interface StatusLineConfig {
+  type?: string
+  command?: string
+  [key: string]: unknown
+}
+
+function isMagicSlashStatusLine(sl: StatusLineConfig | undefined): boolean {
+  return typeof sl?.command === 'string' && sl.command.includes(STATUSLINE_MARKER)
+}
 const MAGIC_SLASH_PERMISSIONS = [
   // Desktop communication
   'Bash(*http://127.0.0.1:*)',
@@ -71,6 +102,7 @@ interface ClaudeSettings {
     allow?: string[]
     deny?: string[]
   }
+  statusLine?: StatusLineConfig
   [key: string]: unknown
 }
 
@@ -189,6 +221,109 @@ export function configureClaudeHooks(): void {
   }
 }
 
+/**
+ * Configure Claude Code's statusLine to point at our capture wrapper, preserving any
+ * pre-existing user statusLine (chained via MAGIC_SLASH_INNER_STATUSLINE).
+ * Returns the user's original statusLine command to chain (empty string if none).
+ */
+export function configureStatusLine(): string {
+  try {
+    // Ensure config dir and write the wrapper script (executable)
+    if (!fs.existsSync(MAGIC_SLASH_CONFIG_DIR)) {
+      fs.mkdirSync(MAGIC_SLASH_CONFIG_DIR, { recursive: true })
+    }
+    fs.writeFileSync(STATUSLINE_SCRIPT_PATH, STATUSLINE_SCRIPT, { mode: 0o755 })
+    // Re-assert mode in case the file already existed with different perms
+    fs.chmodSync(STATUSLINE_SCRIPT_PATH, 0o755)
+
+    const claudeDir = path.dirname(CLAUDE_SETTINGS_PATH)
+    if (!fs.existsSync(claudeDir)) {
+      fs.mkdirSync(claudeDir, { recursive: true })
+    }
+
+    let settings: ClaudeSettings = {}
+    if (fs.existsSync(CLAUDE_SETTINGS_PATH)) {
+      try {
+        settings = JSON.parse(fs.readFileSync(CLAUDE_SETTINGS_PATH, 'utf-8'))
+      } catch {
+        // Leave settings empty; configureClaudeHooks handles backup of invalid files
+      }
+    }
+
+    const existing = settings.statusLine
+    let inner = ''
+
+    if (existing && !isMagicSlashStatusLine(existing)) {
+      // First time we take over: back up the user's original statusLine and chain it
+      inner = typeof existing.command === 'string' ? existing.command : ''
+      try {
+        fs.writeFileSync(STATUSLINE_BACKUP_PATH, JSON.stringify(existing))
+      } catch (e) {
+        console.error('Failed to back up original statusLine:', e)
+      }
+    } else if (existing && isMagicSlashStatusLine(existing)) {
+      // Already ours: recover the original command from the backup to keep chaining
+      inner = readBackupStatusLineCommand()
+    } else {
+      // No statusLine configured: record "none" so uninstall removes ours cleanly
+      try {
+        fs.writeFileSync(STATUSLINE_BACKUP_PATH, 'null')
+      } catch {
+        // non-fatal
+      }
+    }
+
+    settings.statusLine = {
+      type: 'command',
+      command: `bash ${STATUSLINE_SCRIPT_PATH}`,
+    }
+
+    fs.writeFileSync(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2))
+    console.log('Claude Code statusLine configured successfully')
+    return inner
+  } catch (error) {
+    console.error('Failed to configure Claude Code statusLine:', error)
+    return ''
+  }
+}
+
+function readBackupStatusLineCommand(): string {
+  try {
+    if (!fs.existsSync(STATUSLINE_BACKUP_PATH)) return ''
+    const raw = fs.readFileSync(STATUSLINE_BACKUP_PATH, 'utf-8')
+    const parsed = JSON.parse(raw) as StatusLineConfig | null
+    return typeof parsed?.command === 'string' ? parsed.command : ''
+  } catch {
+    return ''
+  }
+}
+
+function restoreStatusLine(settings: ClaudeSettings): void {
+  if (!isMagicSlashStatusLine(settings.statusLine)) {
+    return
+  }
+  let restored: StatusLineConfig | null = null
+  try {
+    if (fs.existsSync(STATUSLINE_BACKUP_PATH)) {
+      restored = JSON.parse(fs.readFileSync(STATUSLINE_BACKUP_PATH, 'utf-8'))
+    }
+  } catch {
+    restored = null
+  }
+  if (restored && typeof restored === 'object') {
+    settings.statusLine = restored
+  } else {
+    delete settings.statusLine
+  }
+  try {
+    if (fs.existsSync(STATUSLINE_BACKUP_PATH)) {
+      fs.unlinkSync(STATUSLINE_BACKUP_PATH)
+    }
+  } catch {
+    // non-fatal
+  }
+}
+
 export function removeClaudeHooks(): void {
   try {
     if (!fs.existsSync(CLAUDE_SETTINGS_PATH)) {
@@ -198,24 +333,25 @@ export function removeClaudeHooks(): void {
     const content = fs.readFileSync(CLAUDE_SETTINGS_PATH, 'utf-8')
     const settings: ClaudeSettings = JSON.parse(content)
 
-    if (!settings.hooks) {
-      return
-    }
+    // Restore the user's original statusLine (or remove ours if they had none)
+    restoreStatusLine(settings)
 
     // Remove Magic Slash hooks from all events
-    for (const event of Object.keys(settings.hooks)) {
-      if (Array.isArray(settings.hooks[event])) {
-        settings.hooks[event] = settings.hooks[event]!.filter(hook => !isMagicSlashHook(hook))
-        // Remove empty arrays
-        if (settings.hooks[event]!.length === 0) {
-          delete settings.hooks[event]
+    if (settings.hooks) {
+      for (const event of Object.keys(settings.hooks)) {
+        if (Array.isArray(settings.hooks[event])) {
+          settings.hooks[event] = settings.hooks[event]!.filter(hook => !isMagicSlashHook(hook))
+          // Remove empty arrays
+          if (settings.hooks[event]!.length === 0) {
+            delete settings.hooks[event]
+          }
         }
       }
-    }
 
-    // Remove empty hooks object
-    if (Object.keys(settings.hooks).length === 0) {
-      delete settings.hooks
+      // Remove empty hooks object
+      if (Object.keys(settings.hooks).length === 0) {
+        delete settings.hooks
+      }
     }
 
     // Remove Magic Slash permissions

--- a/desktop/src/main/hooks/claude-hooks-config.ts
+++ b/desktop/src/main/hooks/claude-hooks-config.ts
@@ -13,18 +13,32 @@ const STATUSLINE_SCRIPT_PATH = path.join(MAGIC_SLASH_CONFIG_DIR, 'statusline.sh'
 const STATUSLINE_BACKUP_PATH = path.join(MAGIC_SLASH_CONFIG_DIR, 'statusline-original.json')
 const STATUSLINE_MARKER = 'magic-slash/statusline.sh'
 
-const STATUSLINE_SCRIPT = `#!/usr/bin/env bash
+// Wrap a string as a safe single-quoted POSIX shell literal.
+function shSingleQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+// Build the statusLine wrapper. The user's original command is baked in as the
+// fallback so a plain `claude` session started OUTSIDE the desktop app (where
+// MAGIC_SLASH_INNER_STATUSLINE is not injected) still renders the user's own
+// statusline. Inside the app the env var takes precedence.
+function buildStatusLineScript(innerCommand: string): string {
+  const baked = shSingleQuote(innerCommand)
+  return `#!/usr/bin/env bash
 # Managed by Magic Slash Desktop — captures Claude Code usage for the app sidebar.
 input=$(cat)
 if [ -n "$MAGIC_SLASH_TERMINAL_ID" ] && [ -n "$MAGIC_SLASH_PORT" ]; then
   printf '%s' "$input" | curl -s -X POST --data-binary @- \\
     "http://127.0.0.1:$MAGIC_SLASH_PORT/usage?id=$MAGIC_SLASH_TERMINAL_ID" >/dev/null 2>&1 || true
 fi
-# Relay the user's original statusline if one was configured
-if [ -n "$MAGIC_SLASH_INNER_STATUSLINE" ]; then
-  printf '%s' "$input" | eval "$MAGIC_SLASH_INNER_STATUSLINE"
+# Relay the user's original statusline. The env var (set by the desktop app) wins;
+# otherwise fall back to the command baked in at configuration time.
+INNER=\${MAGIC_SLASH_INNER_STATUSLINE:-${baked}}
+if [ -n "$INNER" ]; then
+  printf '%s' "$input" | eval "$INNER"
 fi
 `
+}
 
 interface StatusLineConfig {
   type?: string
@@ -228,13 +242,10 @@ export function configureClaudeHooks(): void {
  */
 export function configureStatusLine(): string {
   try {
-    // Ensure config dir and write the wrapper script (executable)
+    // Ensure config dir exists
     if (!fs.existsSync(MAGIC_SLASH_CONFIG_DIR)) {
       fs.mkdirSync(MAGIC_SLASH_CONFIG_DIR, { recursive: true })
     }
-    fs.writeFileSync(STATUSLINE_SCRIPT_PATH, STATUSLINE_SCRIPT, { mode: 0o755 })
-    // Re-assert mode in case the file already existed with different perms
-    fs.chmodSync(STATUSLINE_SCRIPT_PATH, 0o755)
 
     const claudeDir = path.dirname(CLAUDE_SETTINGS_PATH)
     if (!fs.existsSync(claudeDir)) {
@@ -254,12 +265,14 @@ export function configureStatusLine(): string {
     let inner = ''
 
     if (existing && !isMagicSlashStatusLine(existing)) {
-      // First time we take over: back up the user's original statusLine and chain it
+      // First time we take over: back up the user's original statusLine and chain it.
+      // The backup MUST succeed before we overwrite — otherwise a later uninstall
+      // could not restore the original and would silently drop the user's config.
       inner = typeof existing.command === 'string' ? existing.command : ''
       try {
         fs.writeFileSync(STATUSLINE_BACKUP_PATH, JSON.stringify(existing))
       } catch (e) {
-        console.error('Failed to back up original statusLine:', e)
+        throw new Error('Failed to back up original statusLine; aborting to avoid data loss', { cause: e })
       }
     } else if (existing && isMagicSlashStatusLine(existing)) {
       // Already ours: recover the original command from the backup to keep chaining
@@ -272,6 +285,12 @@ export function configureStatusLine(): string {
         // non-fatal
       }
     }
+
+    // Write the wrapper script (executable) with the original command baked in as
+    // the fallback, so it works even outside the desktop app.
+    fs.writeFileSync(STATUSLINE_SCRIPT_PATH, buildStatusLineScript(inner), { mode: 0o755 })
+    // Re-assert mode in case the file already existed with different perms
+    fs.chmodSync(STATUSLINE_SCRIPT_PATH, 0o755)
 
     settings.statusLine = {
       type: 'command',

--- a/desktop/src/main/hooks/status-server.test.ts
+++ b/desktop/src/main/hooks/status-server.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { parseStatusLinePayload } from './status-server'
+
+describe('parseStatusLinePayload', () => {
+  const fullPayload = JSON.stringify({
+    model: { id: 'claude-opus-4-8', display_name: 'Opus 4.8' },
+    context_window: {
+      total_input_tokens: 140000,
+      total_output_tokens: 5000,
+      context_window_size: 200000,
+      used_percentage: 68,
+    },
+    cost: {
+      total_cost_usd: 0.4237,
+      total_duration_ms: 754321,
+      total_lines_added: 120,
+      total_lines_removed: 45,
+    },
+  })
+
+  it('extracts cost, model, duration and lines', () => {
+    const usage = parseStatusLinePayload(fullPayload)
+    expect(usage.costUsd).toBe(0.4237)
+    expect(usage.model).toBe('Opus 4.8')
+    expect(usage.durationMs).toBe(754321)
+    expect(usage.linesAdded).toBe(120)
+    expect(usage.linesRemoved).toBe(45)
+  })
+
+  it('uses the exact total_input_tokens (not derived from the rounded percentage)', () => {
+    const usage = parseStatusLinePayload(fullPayload)
+    expect(usage.contextPercent).toBe(68)
+    expect(usage.contextWindowSize).toBe(200000)
+    // Exact count, not 68% of 200000 (= 136000)
+    expect(usage.contextTokens).toBe(140000)
+  })
+
+  it('falls back to percentage x window size when exact tokens are absent', () => {
+    const payload = JSON.stringify({
+      context_window: { used_percentage: 50, context_window_size: 1_000_000 },
+    })
+    const usage = parseStatusLinePayload(payload)
+    expect(usage.contextPercent).toBe(50)
+    expect(usage.contextTokens).toBe(500_000)
+  })
+
+  it('returns undefined fields for a minimal/empty payload', () => {
+    const usage = parseStatusLinePayload('{}')
+    expect(usage.costUsd).toBeUndefined()
+    expect(usage.contextPercent).toBeUndefined()
+    expect(usage.contextTokens).toBeUndefined()
+    expect(usage.model).toBeUndefined()
+  })
+
+  it('ignores fields with the wrong type', () => {
+    const payload = JSON.stringify({
+      model: { display_name: 42 },
+      cost: { total_cost_usd: 'nope' },
+      context_window: { used_percentage: null },
+    })
+    const usage = parseStatusLinePayload(payload)
+    expect(usage.model).toBeUndefined()
+    expect(usage.costUsd).toBeUndefined()
+    expect(usage.contextPercent).toBeUndefined()
+  })
+})

--- a/desktop/src/main/hooks/status-server.ts
+++ b/desktop/src/main/hooks/status-server.ts
@@ -1,11 +1,13 @@
 import * as http from 'http'
 import { URL } from 'url'
+import type { TerminalUsage } from '../../types'
 
 type StateCallback = (terminalId: string, state: string) => void
 type MetadataCallback = (terminalId: string, metadata: Record<string, string | string[] | Record<string, { prUrl?: string }>>) => void
 type CommandStartCallback = (terminalId: string, command: string) => void
 type CommandEndCallback = (terminalId: string, exitCode: number) => void
 type RepositoriesCallback = (terminalId: string, repositories: string[]) => void
+type UsageCallback = (terminalId: string, usage: TerminalUsage) => void
 
 let server: http.Server | null = null
 let serverPort: number = 0
@@ -14,6 +16,7 @@ let metadataCallback: MetadataCallback | null = null
 let commandStartCallback: CommandStartCallback | null = null
 let commandEndCallback: CommandEndCallback | null = null
 let repositoriesCallback: RepositoriesCallback | null = null
+let usageCallback: UsageCallback | null = null
 
 export function getServerPort(): number {
   return serverPort
@@ -39,6 +42,62 @@ export function setRepositoriesCallback(callback: RepositoriesCallback) {
   repositoriesCallback = callback
 }
 
+export function setUsageCallback(callback: UsageCallback) {
+  usageCallback = callback
+}
+
+// Read the full request body (used by the POST /usage route)
+function readRequestBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let size = 0
+    const MAX_BODY = 256 * 1024 // guard against runaway payloads
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length
+      if (size > MAX_BODY) {
+        reject(new Error('Body too large'))
+        req.destroy()
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')))
+    req.on('error', reject)
+  })
+}
+
+// Parse the Claude Code statusLine JSON payload into a TerminalUsage object.
+// Field names come from the statusLine stdin schema (context_window.*, cost.*, model.*).
+// Exported for unit testing.
+export function parseStatusLinePayload(body: string): TerminalUsage {
+  const data = JSON.parse(body)
+  const ctx = data?.context_window ?? {}
+  const cost = data?.cost ?? {}
+
+  const contextWindowSize = typeof ctx.context_window_size === 'number' ? ctx.context_window_size : undefined
+  const contextPercent = typeof ctx.used_percentage === 'number' ? ctx.used_percentage : undefined
+  // Prefer the exact token count from the statusline. Deriving from used_percentage loses
+  // precision (a rounded percentage on a 1M-token window jumps in 10k-token steps), so we only
+  // fall back to the percentage estimate when the exact count is unavailable.
+  let contextTokens: number | undefined
+  if (typeof ctx.total_input_tokens === 'number') {
+    contextTokens = ctx.total_input_tokens
+  } else if (contextPercent !== undefined && contextWindowSize !== undefined) {
+    contextTokens = Math.round((contextPercent / 100) * contextWindowSize)
+  }
+
+  return {
+    costUsd: typeof cost.total_cost_usd === 'number' ? cost.total_cost_usd : undefined,
+    contextPercent,
+    contextTokens,
+    contextWindowSize,
+    model: typeof data?.model?.display_name === 'string' ? data.model.display_name : undefined,
+    durationMs: typeof cost.total_duration_ms === 'number' ? cost.total_duration_ms : undefined,
+    linesAdded: typeof cost.total_lines_added === 'number' ? cost.total_lines_added : undefined,
+    linesRemoved: typeof cost.total_lines_removed === 'number' ? cost.total_lines_removed : undefined,
+  }
+}
+
 export function startStatusServer(): Promise<number> {
   return new Promise((resolve, reject) => {
     server = http.createServer((req, res) => {
@@ -53,7 +112,37 @@ export function startStatusServer(): Promise<number> {
       try {
         const url = new URL(req.url, `http://localhost:${serverPort}`)
 
-        if (url.pathname === '/status') {
+        if (url.pathname === '/usage') {
+          // Statusline usage report — carries cost/context/model as a raw JSON body (POST).
+          const terminalId = url.searchParams.get('id')
+
+          // Ignore sidebar terminals (VS Code extension)
+          if (terminalId?.startsWith('sidebar-')) {
+            res.writeHead(200)
+            res.end('OK')
+            return
+          }
+
+          readRequestBody(req)
+            .then((body) => {
+              if (terminalId && body && usageCallback) {
+                try {
+                  const usage = parseStatusLinePayload(body)
+                  usage.updatedAt = Date.now()
+                  usageCallback(terminalId, usage)
+                } catch (e) {
+                  console.error('[Usage] Failed to parse statusline payload:', e)
+                }
+              }
+              res.writeHead(200)
+              res.end('OK')
+            })
+            .catch(() => {
+              res.writeHead(200)
+              res.end('OK')
+            })
+          return
+        } else if (url.pathname === '/status') {
           const terminalId = url.searchParams.get('id')
           const state = url.searchParams.get('state')
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -2,10 +2,11 @@ import { app, BrowserWindow, Notification, ipcMain, dialog, Menu, shell, globalS
 import { join } from 'path'
 import { setupConfigHandlers } from './ipc/config-handlers'
 import { setupTerminalHandlers, cleanupTerminals, restoreAgents } from './ipc/terminal-handlers'
-import { startStatusServer, stopStatusServer, setStateCallback, setMetadataCallback, setCommandStartCallback, setCommandEndCallback, setRepositoriesCallback } from './hooks/status-server'
+import { startStatusServer, stopStatusServer, setStateCallback, setMetadataCallback, setCommandStartCallback, setCommandEndCallback, setRepositoriesCallback, setUsageCallback } from './hooks/status-server'
 import { installShellIntegration } from './hooks/shell-integration'
-import { configureClaudeHooks } from './hooks/claude-hooks-config'
-import { setStatusServerPort, updateTerminalStateFromHook, updateTerminalMetadataFromHook, updateTerminalRepositoriesFromHook } from './pty/terminal-manager'
+import { configureClaudeHooks, configureStatusLine } from './hooks/claude-hooks-config'
+import { setStatusServerPort, setInnerStatusLine, updateTerminalStateFromHook, updateTerminalMetadataFromHook, updateTerminalUsageFromHook, updateTerminalRepositoriesFromHook } from './pty/terminal-manager'
+import type { TerminalUsage } from '../types'
 import { setupAutoUpdater, setUpdaterMainWindow, checkForUpdatesOnStartup, isUpdating } from './updater'
 import { updateSkills } from './skills-updater'
 import { setupSkillsHandlers } from './ipc/skills-handlers'
@@ -435,6 +436,9 @@ async function initializeHooksAndSessions() {
     // Configure Claude Code hooks (deferred file I/O)
     configureClaudeHooks()
 
+    // Configure the statusLine capture wrapper, preserving any user statusLine
+    setInnerStatusLine(configureStatusLine())
+
     // Set up callbacks for status updates
     setStateCallback((terminalId: string, state: string) => {
       updateTerminalStateFromHook(terminalId, state)
@@ -462,6 +466,18 @@ async function initializeHooksAndSessions() {
       // Update tray (metadata changes may affect display)
       if (aggregator) {
         aggregator.update()
+      }
+    })
+
+    // Usage stats from the statusLine wrapper — in-memory update + single metadata IPC.
+    // Not persisted to disk (see updateTerminalUsageFromHook) since statusLine is high-frequency.
+    setUsageCallback((terminalId: string, usage: TerminalUsage) => {
+      updateTerminalUsageFromHook(terminalId, usage)
+      if (mainWindow) {
+        mainWindow.webContents.send('terminal:metadata', {
+          id: terminalId,
+          metadata: { usage }
+        })
       }
     })
 

--- a/desktop/src/main/pty/terminal-manager.ts
+++ b/desktop/src/main/pty/terminal-manager.ts
@@ -7,7 +7,7 @@ import { readConfig } from '../config/config'
 import { updateAgentMetadata, updateAgentRepositories, createDefaultMetadata, mergeMetadata } from '../config/agents'
 import { expandPath } from '../config/validation'
 import { getCommonPaths } from '../utils/paths'
-import type { TerminalMetadata, TerminalState, LaunchMode } from '../../types'
+import type { TerminalMetadata, TerminalState, LaunchMode, TerminalUsage } from '../../types'
 export type { TerminalMetadata, TerminalState }
 
 const DEFAULT_PTY_ROWS = 40
@@ -73,6 +73,14 @@ let statusServerPort: number = 0
 
 export function setStatusServerPort(port: number) {
   statusServerPort = port
+}
+
+// User's pre-existing statusLine command, preserved and chained by our wrapper script.
+// Empty string means the user had no statusLine (wrapper stays silent in-terminal).
+let innerStatusLine: string = ''
+
+export function setInnerStatusLine(command: string) {
+  innerStatusLine = command || ''
 }
 
 // Update terminal state from hook callback
@@ -450,6 +458,8 @@ export function launchClaude(
         // Magic Slash hook integration
         MAGIC_SLASH_TERMINAL_ID: id,
         ...(statusServerPort > 0 ? { MAGIC_SLASH_PORT: statusServerPort.toString() } : {}),
+        // Chained statusLine: the wrapper relays the user's original statusLine if any
+        ...(innerStatusLine ? { MAGIC_SLASH_INNER_STATUSLINE: innerStatusLine } : {}),
       }
     })
 
@@ -614,6 +624,16 @@ export function updateTerminalMetadataFromHook(terminalId: string, metadata: Par
   if (terminal.onMetadataChange) {
     terminal.onMetadataChange(terminal.metadata)
   }
+}
+
+// Update terminal usage stats from the statusLine wrapper.
+// In-memory only: statusLine fires very frequently and usage is ephemeral session data,
+// so we deliberately skip disk persistence (updateAgentMetadata) and the onMetadataChange
+// callback. The IPC send to the renderer is handled by the caller (setUsageCallback in index.ts).
+export function updateTerminalUsageFromHook(terminalId: string, usage: TerminalUsage) {
+  const terminal = terminals.get(terminalId)
+  if (!terminal) return
+  terminal.metadata = { ...terminal.metadata, usage }
 }
 
 // Update terminal repositories from hook callback

--- a/desktop/src/renderer/components/AgentInfoSidebar.tsx
+++ b/desktop/src/renderer/components/AgentInfoSidebar.tsx
@@ -3,6 +3,7 @@ import { X, Bot, Edit2, Layers, CalendarClock } from 'lucide-react'
 import { useStore } from '../store'
 import { useTerminals } from '../hooks/useTerminals'
 import { TicketHeader } from './agent-info-sidebar/TicketHeader'
+import { UsageCard } from './agent-info-sidebar/UsageCard'
 import { RepositoryCard } from './agent-info-sidebar/RepositoryCard'
 import { RepositorySelector } from './agent-info-sidebar/RepositorySelector'
 import type { RepoGitData } from './agent-info-sidebar/types'
@@ -447,6 +448,9 @@ export function AgentInfoSidebar() {
                 </div>
               </div>
             )}
+
+            {/* Usage Card (context, cost, model) */}
+            {metadata?.usage && <UsageCard usage={metadata.usage} />}
 
             {/* Ticket Header Card */}
             <TicketHeader

--- a/desktop/src/renderer/components/agent-info-sidebar/UsageCard.tsx
+++ b/desktop/src/renderer/components/agent-info-sidebar/UsageCard.tsx
@@ -1,0 +1,120 @@
+import { Gauge, DollarSign, Cpu, Clock } from 'lucide-react'
+import type { TerminalUsage } from '../../../types'
+
+interface UsageCardProps {
+  usage: TerminalUsage
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return `${n}`
+}
+
+function formatCost(usd: number): string {
+  // Show more precision for tiny amounts so it doesn't read as "$0.00"
+  if (usd > 0 && usd < 0.01) return `$${usd.toFixed(4)}`
+  return `$${usd.toFixed(2)}`
+}
+
+function formatDuration(ms: number): string {
+  const totalSec = Math.round(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m ${s}s`
+  return `${s}s`
+}
+
+// Traffic-light color for context fill: green → yellow → red as it fills up.
+function contextColors(pct: number): { bar: string; text: string } {
+  if (pct >= 85) return { bar: 'bg-red', text: 'text-red' }
+  if (pct >= 65) return { bar: 'bg-yellow', text: 'text-yellow' }
+  return { bar: 'bg-green', text: 'text-green' }
+}
+
+export function UsageCard({ usage }: UsageCardProps) {
+  const {
+    costUsd,
+    contextPercent,
+    contextTokens,
+    contextWindowSize,
+    model,
+    durationMs,
+    linesAdded,
+    linesRemoved,
+  } = usage
+
+  const hasContext = typeof contextPercent === 'number'
+  const pct = Math.min(100, Math.max(0, contextPercent ?? 0))
+  const colors = contextColors(pct)
+
+  return (
+    <div className="bg-white/[0.06] rounded-xl p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-text-secondary/50 uppercase tracking-wider">Session</span>
+        {model && (
+          <span className="flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-purple/15 text-purple text-[11px] font-medium">
+            <Cpu className="w-3 h-3" />
+            {model}
+          </span>
+        )}
+      </div>
+
+      {/* Context usage */}
+      {hasContext && (
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs">
+            <span className="flex items-center gap-1.5 text-text-secondary">
+              <Gauge className="w-3.5 h-3.5" />
+              Context
+            </span>
+            <span className={`font-mono font-medium ${colors.text}`}>{Math.round(pct)}%</span>
+          </div>
+          <div className="h-1.5 w-full rounded-full bg-white/[0.08] overflow-hidden">
+            <div
+              className={`h-full rounded-full ${colors.bar} transition-all duration-500`}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          {typeof contextTokens === 'number' && typeof contextWindowSize === 'number' && (
+            <div className="text-[11px] text-text-secondary/70 font-mono">
+              {formatTokens(contextTokens)} / {formatTokens(contextWindowSize)} tokens
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Cost + duration + lines */}
+      <div className="flex items-center justify-between text-xs">
+        {typeof costUsd === 'number' && (
+          <span className="flex items-center gap-1.5 text-text-secondary">
+            <DollarSign className="w-3.5 h-3.5" />
+            <span className="font-mono font-medium text-white">{formatCost(costUsd)}</span>
+          </span>
+        )}
+        {typeof durationMs === 'number' && (
+          <span className="flex items-center gap-1.5 text-text-secondary">
+            <Clock className="w-3.5 h-3.5" />
+            <span className="font-mono">{formatDuration(durationMs)}</span>
+          </span>
+        )}
+      </div>
+
+      {(typeof linesAdded === 'number' || typeof linesRemoved === 'number') && (
+        (linesAdded ?? 0) + (linesRemoved ?? 0) > 0 && (
+          <div className="flex items-center gap-2 text-[11px] font-mono">
+            {typeof linesAdded === 'number' && linesAdded > 0 && (
+              <span className="text-green">+{linesAdded}</span>
+            )}
+            {typeof linesRemoved === 'number' && linesRemoved > 0 && (
+              <span className="text-red">-{linesRemoved}</span>
+            )}
+            <span className="text-text-secondary/50">lines</span>
+          </div>
+        )
+      )}
+    </div>
+  )
+}

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -10,6 +10,18 @@ export interface RepositoryMetadata {
   prClosed?: boolean
 }
 
+export interface TerminalUsage {
+  costUsd?: number           // cost.total_cost_usd
+  contextPercent?: number    // context_window.used_percentage (0-100)
+  contextTokens?: number     // tokens currently occupying the context window
+  contextWindowSize?: number // context_window.context_window_size
+  model?: string             // model.display_name
+  durationMs?: number        // cost.total_duration_ms
+  linesAdded?: number        // cost.total_lines_added
+  linesRemoved?: number      // cost.total_lines_removed
+  updatedAt?: number         // timestamp of last statusline report
+}
+
 export interface TerminalMetadata {
   title?: string
   branchName?: string
@@ -20,6 +32,7 @@ export interface TerminalMetadata {
   fullStackTaskId?: string
   relatedWorktrees?: string[]
   repositoryMetadata?: Record<string, RepositoryMetadata>
+  usage?: TerminalUsage
 }
 
 export interface TerminalInfo {


### PR DESCRIPTION
## Description

Adds a live usage card at the top of the right-hand Agent Info sidebar in the desktop app. It shows the current Claude Code session's context-window usage (percentage + exact tokens), cumulative conversation cost, active model, session duration, and lines changed.

Data is captured via Claude Code's `statusLine`: a generated wrapper script (`~/.config/magic-slash/statusline.sh`) POSTs the statusline JSON to the existing local status server, then relays any pre-existing user statusLine so nothing is lost. Values flow through the existing metadata IPC channel to the sidebar, in-memory only (not persisted, since the statusline fires frequently).

## Related Issue

N/A — no linked ticket.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `claude-hooks-config.ts`: `configureStatusLine()` writes the capture wrapper, backs up and chains the user's existing statusLine, and restores it on uninstall.
- `status-server.ts`: new `POST /usage` route + `parseStatusLinePayload()` — prefers the exact `total_input_tokens` over the rounded percentage for precision.
- `terminal-manager.ts`: injects the `MAGIC_SLASH_INNER_STATUSLINE` env var + `updateTerminalUsageFromHook()` (in-memory, no disk writes).
- `index.ts`: wires `configureStatusLine()` and `setUsageCallback`.
- `types.ts`: new `TerminalUsage` type on `TerminalMetadata`.
- `UsageCard.tsx` + `AgentInfoSidebar.tsx`: new sidebar card rendering context/cost/model/duration/lines.
- `status-server.test.ts`: unit tests for the payload parser.

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

### Test Steps

1. Run `npm run desktop` and open the Agents page.
2. Launch an agent and send it a couple of messages → a "Session" card appears at the top of the right sidebar showing context %, exact token count, cost, and model.
3. Keep chatting → the context bar and token count update at fine (~1k) granularity (not 10k steps), the cost climbs, and the bar color shifts green → yellow → red as the context fills.
4. If you have a custom statusLine in `~/.claude/settings.json`, confirm it still renders both inside the app terminal and in a plain `claude` session (chaining preserved).
5. Run `npm test` → the `parseStatusLinePayload` suite passes.

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

Usage is captured via statusLine because it is the only source that exposes point-in-time context occupancy — hooks don't carry cost/token data and the transcript JSONL format is explicitly unstable. Plugins cannot define a main-session statusLine, so there is no conflict; only a user's own statusLine is affected, and it is chained/preserved.