### PR TITLE
[#124] Cloud PR 2 — Auth & organization (optional local-first login + invitation onboarding)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "magic-slash-desktop",
-  "version": "0.46.0",
+  "version": "0.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-slash-desktop",
-      "version": "0.46.0",
+      "version": "0.51.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@supabase/supabase-js": "~2.78.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
@@ -1998,6 +1999,85 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.78.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.78.0.tgz",
+      "integrity": "sha512-cXDtu1U0LeZj/xfnFoV7yCze37TcbNo8FCxy1FpqhMbB9u9QxxDSW6pA5gm/07Ei7m260Lof4CZx67Cu6DPeig==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.78.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.78.0.tgz",
+      "integrity": "sha512-t1jOvArBsOINyqaRee1xJ3gryXLvkBzqnKfi6q3YRzzhJbGS6eXz0pXR5fqmJeB01fLC+1njpf3YhMszdPEF7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.78.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.78.0.tgz",
+      "integrity": "sha512-AwhpYlSvJ+PSnPmIK8sHj7NGDyDENYfQGKrMtpVIEzQA2ApUjgpUGxzXWN4Z0wEtLQsvv7g4y9HVad9Hzo1TNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.78.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.78.0.tgz",
+      "integrity": "sha512-rCs1zmLe7of7hj4s7G9z8rTqzWuNVtmwDr3FiCRCJFawEoa+RQO1xpZGbdeuVvVmKDyVN6b542Okci+117y/LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.78.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.78.0.tgz",
+      "integrity": "sha512-n17P0JbjHOlxqJpkaGFOn97i3EusEKPEbWOpuk1r4t00Wg06B8Z4GUiq0O0n1vUpjiMgJUkLIMuBVp+bEgunzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "2.6.15",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.78.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.78.0.tgz",
+      "integrity": "sha512-xYMRNBFmKp2m1gMuwcp/gr/HlfZKqjye1Ib8kJe29XJNsgwsfO/f8skxnWiscFKTlkOKLuBexNgl5L8dzGt6vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.78.0",
+        "@supabase/functions-js": "2.78.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "2.78.0",
+        "@supabase/realtime-js": "2.78.0",
+        "@supabase/storage-js": "2.78.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -2168,11 +2248,16 @@
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/plist": {
       "version": "3.0.5",
@@ -2235,6 +2320,15 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -9151,6 +9245,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -9188,6 +9288,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -9220,7 +9326,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -9975,6 +10080,22 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10060,6 +10181,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@supabase/supabase-js": "~2.78.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",

--- a/desktop/src/main/cloud/auth.ts
+++ b/desktop/src/main/cloud/auth.ts
@@ -1,0 +1,137 @@
+import type { Session, SupabaseClient } from '@supabase/supabase-js'
+import type { AuthStatus } from '../../types'
+import { getSupabaseClient, isCloudEnabled } from './supabase-client'
+import { saveSession, loadSession, clearSession, type StoredSession } from './session-store'
+
+const DISABLED: AuthStatus = { enabled: false, loggedIn: false }
+
+function toStored(session: Session): StoredSession {
+  return {
+    access_token: session.access_token,
+    refresh_token: session.refresh_token,
+    expires_at: session.expires_at,
+    user: session.user ? { id: session.user.id, email: session.user.email } : undefined,
+  }
+}
+
+function toStatus(stored: StoredSession): AuthStatus {
+  return {
+    enabled: true,
+    loggedIn: true,
+    user: stored.user ? { id: stored.user.id, email: stored.user.email } : undefined,
+  }
+}
+
+/**
+ * Returns a Supabase client with the persisted session applied, or null when
+ * cloud is disabled or there is no session. Never throws. Restoring the session
+ * lets the SDK refresh the access token transparently for org queries.
+ */
+export async function getAuthedClient(): Promise<SupabaseClient | null> {
+  const client = getSupabaseClient()
+  if (!client) return null
+
+  const stored = loadSession()
+  if (!stored) return null
+
+  try {
+    const { data, error } = await client.auth.setSession({
+      access_token: stored.access_token,
+      refresh_token: stored.refresh_token,
+    })
+    if (error) {
+      // The refresh token was rejected (expired/revoked). Drop the stale session
+      // so getStatus() stops reporting a signed-in state the app can't act on.
+      console.warn('[cloud] stored session rejected, clearing:', error.message)
+      clearSession()
+      return null
+    }
+    if (!data.session) return null
+    // The token may have been refreshed — persist the latest.
+    saveSession(toStored(data.session))
+    return client
+  } catch (error) {
+    // Transient failure (e.g. offline): keep the session so the user stays
+    // logged in and can retry once connectivity is back.
+    console.error('[cloud] Failed to restore session:', error)
+    return null
+  }
+}
+
+/** Current auth status derived from the persisted session. Never throws. */
+export async function getStatus(): Promise<AuthStatus> {
+  if (!isCloudEnabled()) return DISABLED
+  const stored = loadSession()
+  if (!stored) return { enabled: true, loggedIn: false }
+  return toStatus(stored)
+}
+
+export async function signIn(email: string, password: string): Promise<AuthStatus> {
+  const client = getSupabaseClient()
+  if (!client) throw new Error('Cloud features are not available')
+
+  const { data, error } = await client.auth.signInWithPassword({ email, password })
+  if (error) throw new Error(error.message)
+  if (!data.session) throw new Error('Sign-in did not return a session')
+
+  const stored = toStored(data.session)
+  saveSession(stored)
+  return toStatus(stored)
+}
+
+interface SignUpOptions {
+  orgName?: string
+  invitationToken?: string
+}
+
+/**
+ * Sign up with email/password. Two branches:
+ *  - normal sign-up: creates a personal org via the create_organization RPC.
+ *  - invitation sign-up (invitationToken present): does NOT create a personal
+ *    org — the invitee joins the inviting org via acceptInvitation afterwards.
+ *
+ * When email confirmation is enabled in Supabase, sign-up returns no session; in
+ * that case we surface loggedIn:false so the UI can prompt the user to confirm.
+ */
+export async function signUp(email: string, password: string, options: SignUpOptions = {}): Promise<AuthStatus> {
+  const client = getSupabaseClient()
+  if (!client) throw new Error('Cloud features are not available')
+
+  const { data, error } = await client.auth.signUp({ email, password })
+  if (error) throw new Error(error.message)
+
+  // No session → email confirmation required. Nothing to persist yet.
+  if (!data.session) {
+    return { enabled: true, loggedIn: false }
+  }
+
+  const stored = toStored(data.session)
+  saveSession(stored)
+
+  // Normal sign-up creates a personal org. Invitation sign-up skips this: the
+  // invitee joins the existing org through accept_invitation.
+  if (!options.invitationToken) {
+    const orgName = options.orgName?.trim() || `${email.split('@')[0]}'s org`
+    const { error: rpcError } = await client.rpc('create_organization', { org_name: orgName })
+    if (rpcError) {
+      // Surface the failure but keep the session — the user is still signed in.
+      console.error('[cloud] create_organization failed:', rpcError)
+      throw new Error(`Account created but org setup failed: ${rpcError.message}`)
+    }
+  }
+
+  return toStatus(stored)
+}
+
+export async function signOut(): Promise<AuthStatus> {
+  const client = getSupabaseClient()
+  if (client) {
+    try {
+      await client.auth.signOut()
+    } catch (error) {
+      console.error('[cloud] signOut error (ignored):', error)
+    }
+  }
+  clearSession()
+  return isCloudEnabled() ? { enabled: true, loggedIn: false } : DISABLED
+}

--- a/desktop/src/main/cloud/org.ts
+++ b/desktop/src/main/cloud/org.ts
@@ -1,0 +1,216 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Config, Invitation, InvitationStatus, Member, MembershipRole, Org, OrgSharedConfig } from '../../types'
+import { getAuthedClient } from './auth'
+import { loadSession } from './session-store'
+import { readConfig, mergeOrgSharedConfig, setCurrentOrgId } from '../config/config'
+
+interface OrgRow {
+  id: string
+  name: string
+  created_by: string | null
+}
+
+interface MembershipRow {
+  org_id: string
+  role: MembershipRole
+  organizations: OrgRow | OrgRow[] | null
+}
+
+function firstOrg(rel: OrgRow | OrgRow[] | null): OrgRow | null {
+  if (!rel) return null
+  return Array.isArray(rel) ? (rel[0] ?? null) : rel
+}
+
+/**
+ * The org this install is currently associated with. Prefers the locally
+ * remembered currentOrgId, otherwise the first membership. Returns null when
+ * cloud is disabled, the user is logged out, or has no membership.
+ */
+export async function getCurrentOrg(): Promise<Org | null> {
+  const client = await getAuthedClient()
+  if (!client) return null
+
+  const stored = loadSession()
+  const uid = stored?.user?.id
+  if (!uid) return null
+
+  const { data, error } = await client
+    .from('memberships')
+    .select('org_id, role, organizations(id, name, created_by)')
+    .eq('user_id', uid)
+
+  if (error || !data || data.length === 0) return null
+
+  const rows = data as unknown as MembershipRow[]
+  const preferredId = readConfig().currentOrgId
+  const chosen = rows.find(r => r.org_id === preferredId) ?? rows[0]
+  const org = firstOrg(chosen.organizations)
+  if (!org) return null
+
+  return {
+    id: org.id,
+    name: org.name,
+    createdBy: org.created_by ?? undefined,
+    role: chosen.role,
+  }
+}
+
+/**
+ * Members of the given org (defaults to the current org). Emails are not
+ * exposed by RLS on auth.users, so only the caller's own email is filled in;
+ * others come back without an email (userId + role only).
+ */
+export async function listMembers(orgId?: string): Promise<Member[]> {
+  const client = await getAuthedClient()
+  if (!client) return []
+
+  const targetOrgId = orgId ?? (await getCurrentOrg())?.id
+  if (!targetOrgId) return []
+
+  const { data, error } = await client
+    .from('memberships')
+    .select('user_id, role, created_at')
+    .eq('org_id', targetOrgId)
+
+  if (error || !data) return []
+
+  const stored = loadSession()
+  const selfId = stored?.user?.id
+  const selfEmail = stored?.user?.email
+
+  return data.map((row) => ({
+    userId: row.user_id as string,
+    role: row.role as MembershipRole,
+    createdAt: row.created_at as string | undefined,
+    email: row.user_id === selfId ? selfEmail : undefined,
+  }))
+}
+
+/** Create an invitation (admin only — RLS enforces the admin gate). */
+export async function createInvitation(email: string, role: MembershipRole = 'user', orgId?: string): Promise<Invitation> {
+  const client = await getAuthedClient()
+  if (!client) throw new Error('Cloud features are not available')
+
+  const targetOrgId = orgId ?? (await getCurrentOrg())?.id
+  if (!targetOrgId) throw new Error('No organization to invite into')
+
+  const stored = loadSession()
+  const { data, error } = await client
+    .from('invitations')
+    .insert({ org_id: targetOrgId, email: email.trim(), role, invited_by: stored?.user?.id })
+    .select('id, email, role, status, token, expires_at, created_at')
+    .single()
+
+  if (error) throw new Error(error.message)
+
+  return {
+    id: data.id,
+    email: data.email,
+    role: data.role,
+    status: data.status,
+    token: data.token,
+    expiresAt: data.expires_at,
+    createdAt: data.created_at,
+  }
+}
+
+/**
+ * Effective status for display: a still-`pending` invitation whose `expires_at`
+ * has passed is reported as `expired`. accept_invitation deliberately does not
+ * flip the stored status (that write would roll back with its RAISE), so expiry
+ * is derived here at read time. Other statuses pass through unchanged.
+ */
+function effectiveStatus(status: InvitationStatus, expiresAt?: string | null): InvitationStatus {
+  if (status === 'pending' && expiresAt && Date.parse(expiresAt) < Date.now()) {
+    return 'expired'
+  }
+  return status
+}
+
+/** List invitations for the org (admin only — RLS gates SELECT to admins). */
+export async function listInvitations(orgId?: string): Promise<Invitation[]> {
+  const client = await getAuthedClient()
+  if (!client) return []
+
+  const targetOrgId = orgId ?? (await getCurrentOrg())?.id
+  if (!targetOrgId) return []
+
+  const { data, error } = await client
+    .from('invitations')
+    .select('id, email, role, status, token, expires_at, created_at')
+    .eq('org_id', targetOrgId)
+    .order('created_at', { ascending: false })
+
+  if (error || !data) return []
+
+  return data.map((row) => ({
+    id: row.id,
+    email: row.email,
+    role: row.role,
+    status: effectiveStatus(row.status as InvitationStatus, row.expires_at as string | null),
+    token: row.token,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+  }))
+}
+
+export interface AcceptInvitationResult {
+  orgId: string
+  config: Config
+}
+
+/** Read the org's shared config and merge it into the local config (best-effort). */
+async function mergeSharedConfigWith(client: SupabaseClient, orgId: string): Promise<Config> {
+  try {
+    const { data: shared, error } = await client.rpc('get_org_shared_config', { p_org_id: orgId })
+    if (!error && shared) {
+      return mergeOrgSharedConfig(shared as OrgSharedConfig, orgId)
+    }
+  } catch (mergeError) {
+    // Inheriting shared config is best-effort — never fail over it.
+    console.error('[cloud] Failed to merge org shared config:', mergeError)
+  }
+  return readConfig()
+}
+
+/**
+ * Re-apply the org's shared config to the local config. mergeOrgSharedConfig only
+ * reaches repositories that already exist, so onboarding calls this AFTER adding
+ * the invitee's repos, ensuring newly-created repos also inherit the org's
+ * languages, commit/PR format, and keywords. Degrades gracefully to the current
+ * config when cloud is unavailable or there is no org.
+ */
+export async function applySharedConfig(orgId?: string): Promise<Config> {
+  const client = await getAuthedClient()
+  if (!client) return readConfig()
+
+  const targetOrgId = orgId ?? (await getCurrentOrg())?.id
+  if (!targetOrgId) return readConfig()
+
+  return mergeSharedConfigWith(client, targetOrgId)
+}
+
+/**
+ * Accept an invitation: the RPC atomically creates the membership and marks the
+ * invite accepted (returns the org_id). ONLY THEN do we read the org's shared
+ * config — the membership must exist first or RLS/get_org_shared_config would
+ * reject the read. The shared fields are merged into the local config, preserving
+ * local repo paths and integration toggles. Note this initial merge only reaches
+ * repositories that already exist; repos added later during onboarding re-apply
+ * it via applySharedConfig (see the invitation wizard).
+ */
+export async function acceptInvitation(token: string): Promise<AcceptInvitationResult> {
+  const client = await getAuthedClient()
+  if (!client) throw new Error('Cloud features are not available')
+
+  const { data: orgId, error } = await client.rpc('accept_invitation', { invitation_token: token })
+  if (error) throw new Error(error.message)
+  if (!orgId) throw new Error('accept_invitation returned no org')
+
+  setCurrentOrgId(orgId as string)
+
+  // Membership now exists → safe to read the org's shared config.
+  const config = await mergeSharedConfigWith(client, orgId as string)
+
+  return { orgId: orgId as string, config }
+}

--- a/desktop/src/main/cloud/session-store.ts
+++ b/desktop/src/main/cloud/session-store.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { safeStorage } from 'electron'
+import { CONFIG_DIR } from '../config/config'
+
+// Persisted Supabase session, encrypted at rest with the OS keychain via
+// Electron safeStorage (zero extra native deps). Only the fields we need to
+// restore a session are stored.
+export interface StoredSession {
+  access_token: string
+  refresh_token: string
+  expires_at?: number
+  user?: {
+    id: string
+    email?: string
+  }
+}
+
+const SESSION_FILE = path.join(CONFIG_DIR, 'cloud-session.enc')
+
+/**
+ * Persist a session to disk, encrypted with safeStorage. No-ops silently if
+ * encryption is unavailable — cloud auth is optional and must never crash.
+ */
+export function saveSession(session: StoredSession): void {
+  try {
+    if (!safeStorage.isEncryptionAvailable()) return
+    if (!fs.existsSync(CONFIG_DIR)) {
+      fs.mkdirSync(CONFIG_DIR, { recursive: true })
+    }
+    const encrypted = safeStorage.encryptString(JSON.stringify(session))
+    fs.writeFileSync(SESSION_FILE, encrypted)
+  } catch (error) {
+    console.error('[cloud] Failed to save session:', error)
+  }
+}
+
+/**
+ * Load and decrypt the persisted session. MUST NEVER throw — returns null on
+ * any error (missing file, encryption unavailable, corrupted data) so boot is
+ * never blocked by the cloud layer.
+ */
+export function loadSession(): StoredSession | null {
+  try {
+    if (!fs.existsSync(SESSION_FILE)) return null
+    if (!safeStorage.isEncryptionAvailable()) return null
+    const encrypted = fs.readFileSync(SESSION_FILE)
+    const decrypted = safeStorage.decryptString(encrypted)
+    const parsed = JSON.parse(decrypted) as StoredSession
+    if (!parsed?.access_token || !parsed?.refresh_token) return null
+    return parsed
+  } catch (error) {
+    console.error('[cloud] Failed to load session:', error)
+    return null
+  }
+}
+
+/** Remove the persisted session (on sign-out). Never throws. */
+export function clearSession(): void {
+  try {
+    if (fs.existsSync(SESSION_FILE)) {
+      fs.unlinkSync(SESSION_FILE)
+    }
+  } catch (error) {
+    console.error('[cloud] Failed to clear session:', error)
+  }
+}

--- a/desktop/src/main/cloud/supabase-client.ts
+++ b/desktop/src/main/cloud/supabase-client.ts
@@ -1,0 +1,36 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+// The Supabase URL + anon key are injected at build time by vite.config.ts
+// (define block on the main-process build). They are public/safe to ship — RLS
+// on the database is what actually enforces access. When they are absent the
+// cloud features are simply hidden and the app boots + works entirely offline.
+const SUPABASE_URL = process.env.MAGIC_SLASH_SUPABASE_URL || ''
+const SUPABASE_ANON_KEY = process.env.MAGIC_SLASH_SUPABASE_ANON_KEY || ''
+
+let cachedClient: SupabaseClient | null = null
+
+/** True when Supabase env is configured, i.e. cloud features are available. */
+export function isCloudEnabled(): boolean {
+  return SUPABASE_URL.length > 0 && SUPABASE_ANON_KEY.length > 0
+}
+
+/**
+ * Lazy Supabase client factory. Returns null when env is missing so callers can
+ * treat cloud as "unavailable" without any special-casing. The client never
+ * persists the session itself — we manage that explicitly via session-store so
+ * we can encrypt it in the OS keychain (safeStorage). Token refresh is handled
+ * in-memory once a session is loaded.
+ */
+export function getSupabaseClient(): SupabaseClient | null {
+  if (!isCloudEnabled()) return null
+  if (cachedClient) return cachedClient
+
+  cachedClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: true,
+      detectSessionInUrl: false,
+    },
+  })
+  return cachedClient
+}

--- a/desktop/src/main/config/config-merge.test.ts
+++ b/desktop/src/main/config/config-merge.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Config, OrgSharedConfig } from '../../types'
+
+// In-memory config file so readConfig/writeConfig have no real FS side effects.
+let store = ''
+
+vi.mock('fs', () => ({
+  existsSync: () => true,
+  readFileSync: () => store,
+  writeFileSync: (_path: string, data: string) => {
+    store = data
+  },
+  mkdirSync: () => undefined,
+}))
+
+// Neutralise schema validation and defaults so readConfig returns our config as-is.
+vi.mock('./schema-validator', () => ({
+  validateConfig: () => ({ valid: true, errors: [] }),
+  hasCriticalErrors: () => false,
+}))
+
+vi.mock('./defaults', () => ({
+  DEFAULT_REPOSITORY_FIELDS: {},
+  DEFAULT_SPOTLIGHT: {},
+  isValidSpotlightConfig: () => true,
+}))
+
+vi.mock('./validation', () => ({
+  expandPath: (p: string) => p,
+}))
+
+import { mergeOrgSharedConfig } from './config'
+
+/** Seed the in-memory config file. */
+function seed(config: Config): void {
+  store = JSON.stringify(config)
+}
+
+function baseConfig(): Config {
+  return {
+    version: '1.0.0',
+    repositories: {},
+    splitEnabled: false,
+    splitActive: false,
+    integrations: { github: true, atlassian: true },
+    spotlight: {},
+  } as unknown as Config
+}
+
+describe('mergeOrgSharedConfig', () => {
+  beforeEach(() => {
+    store = ''
+  })
+
+  it('fills unset language fields but never overrides existing local ones', () => {
+    const config = baseConfig()
+    config.repositories = {
+      web: { path: '/local/web', keywords: ['web'], languages: { commit: 'fr' } },
+    }
+    seed(config)
+
+    const shared: OrgSharedConfig = { languages: { commit: 'en', pullRequest: 'en' } }
+    const result = mergeOrgSharedConfig(shared)
+
+    // Existing local value wins; missing one is inherited.
+    expect(result.repositories.web.languages).toEqual({ commit: 'fr', pullRequest: 'en' })
+  })
+
+  it('fills unset commit and pullRequest fields, preserving those already set', () => {
+    const config = baseConfig()
+    config.repositories = {
+      api: { path: '/local/api', keywords: ['api'], commit: { format: 'gitmoji' } },
+    }
+    seed(config)
+
+    const shared: OrgSharedConfig = {
+      commit: { format: 'angular', style: 'single-line', coAuthor: false },
+      pullRequest: { autoLinkTickets: true },
+    }
+    const result = mergeOrgSharedConfig(shared)
+
+    expect(result.repositories.api.commit).toEqual({
+      format: 'gitmoji', // local wins
+      style: 'single-line', // inherited
+      coAuthor: false, // inherited (false is a real value, not "unset")
+    })
+    expect(result.repositories.api.pullRequest).toEqual({ autoLinkTickets: true })
+  })
+
+  it('applies shared keywords only to repos with defaulted keywords', () => {
+    const config = baseConfig()
+    config.repositories = {
+      empty: { path: '/local/empty', keywords: [] },
+      defaulted: { path: '/local/defaulted', keywords: ['defaulted'] }, // == repo name
+      customized: { path: '/local/customized', keywords: ['payments', 'billing'] },
+    }
+    seed(config)
+
+    const shared: OrgSharedConfig = {
+      repoKeywords: {
+        empty: ['shared', 'kw'],
+        defaulted: ['shared', 'kw'],
+        customized: ['should', 'not', 'apply'],
+      },
+    }
+    const result = mergeOrgSharedConfig(shared)
+
+    expect(result.repositories.empty.keywords).toEqual(['shared', 'kw'])
+    expect(result.repositories.defaulted.keywords).toEqual(['shared', 'kw'])
+    expect(result.repositories.customized.keywords).toEqual(['payments', 'billing']) // untouched
+  })
+
+  it('never touches local repo paths', () => {
+    const config = baseConfig()
+    config.repositories = {
+      web: { path: '/very/local/path', keywords: [] },
+    }
+    seed(config)
+
+    const result = mergeOrgSharedConfig({ languages: { commit: 'en' }, repoKeywords: { web: ['x'] } })
+
+    expect(result.repositories.web.path).toBe('/very/local/path')
+  })
+
+  it('records the org id when provided', () => {
+    seed(baseConfig())
+    const result = mergeOrgSharedConfig({}, 'org-123')
+    expect(result.currentOrgId).toBe('org-123')
+  })
+
+  it('does not set an org id when none is provided', () => {
+    seed(baseConfig())
+    const result = mergeOrgSharedConfig({})
+    expect(result.currentOrgId).toBeUndefined()
+  })
+
+  it('ignores empty and malformed shared config without throwing', () => {
+    const config = baseConfig()
+    config.repositories = {
+      web: { path: '/local/web', keywords: ['web'], languages: { commit: 'fr' } },
+    }
+    seed(config)
+
+    expect(() => mergeOrgSharedConfig({})).not.toThrow()
+    // Malformed input (wrong shapes) is defensively ignored.
+    const result = mergeOrgSharedConfig({
+      languages: 'nope' as unknown as OrgSharedConfig['languages'],
+      repoKeywords: { web: 'nope' as unknown as string[] },
+    })
+    expect(result.repositories.web.languages).toEqual({ commit: 'fr' })
+    expect(result.repositories.web.keywords).toEqual(['web'])
+  })
+})

--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
-import type { Config, RepositoryConfig, LaunchMode } from '../../types'
+import type { Config, RepositoryConfig, LaunchMode, OrgSharedConfig } from '../../types'
 import { validateConfig, hasCriticalErrors } from './schema-validator'
 import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig } from './defaults'
 import { expandPath } from './validation'
@@ -387,6 +387,95 @@ export function updateSplitActive(active: boolean): Config {
 export function updateLaunchMode(mode: LaunchMode): Config {
   const config = readConfig()
   config.launchMode = mode
+  writeConfig(config)
+  return config
+}
+
+/**
+ * Toggle an integration flag. github is always true (const true in the schema);
+ * only atlassian is user-settable. DISPLAY/detection only — no token is stored.
+ */
+export function setIntegration(name: 'atlassian', enabled: boolean): Config {
+  const config = readConfig()
+  config.integrations = config.integrations || { github: true }
+  if (name === 'atlassian') {
+    config.integrations.atlassian = enabled
+  }
+  writeConfig(config)
+  return config
+}
+
+/** Persist which cloud org this install is associated with. */
+export function setCurrentOrgId(orgId: string | undefined): Config {
+  const config = readConfig()
+  if (orgId) {
+    config.currentOrgId = orgId
+  } else {
+    delete config.currentOrgId
+  }
+  writeConfig(config)
+  return config
+}
+
+/** Copy accepted source values onto target, but only where target has none yet. */
+function fillUnset(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  accept: (value: unknown) => boolean,
+): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (accept(value) && target[key] === undefined) {
+      target[key] = value
+    }
+  }
+}
+
+/**
+ * Merge an org's shared config (inherited on invitation onboarding) into the
+ * local config, applied as DEFAULTS over every existing repository: existing
+ * local values always win, so local repo paths and integration toggles are
+ * preserved. Only the shared fields are touched — languages, commit/PR format,
+ * and repo keywords. Missing/malformed input is ignored (never throws on data).
+ */
+export function mergeOrgSharedConfig(shared: OrgSharedConfig, orgId?: string): Config {
+  const config = readConfig()
+  config.repositories = config.repositories || {}
+
+  for (const repo of Object.values(config.repositories)) {
+    // Languages: fill only keys the repo hasn't already set.
+    if (shared.languages && typeof shared.languages === 'object') {
+      repo.languages = repo.languages || {}
+      fillUnset(repo.languages, shared.languages, (v) => typeof v === 'string')
+    }
+
+    // Commit settings: fill only unset fields.
+    if (shared.commit && typeof shared.commit === 'object') {
+      repo.commit = repo.commit || {}
+      fillUnset(repo.commit, shared.commit, (v) => v !== undefined)
+    }
+
+    // Pull request settings: fill only unset fields.
+    if (shared.pullRequest && typeof shared.pullRequest === 'object') {
+      repo.pullRequest = repo.pullRequest || {}
+      fillUnset(repo.pullRequest, shared.pullRequest, (v) => v !== undefined)
+    }
+  }
+
+  // Repo keywords keyed by repo name: apply to a matching local repo only when
+  // it has no meaningful keywords yet (empty or defaulted to its own name).
+  if (shared.repoKeywords && typeof shared.repoKeywords === 'object') {
+    for (const [name, keywords] of Object.entries(shared.repoKeywords)) {
+      const repo = config.repositories[name]
+      if (!repo || !Array.isArray(keywords)) continue
+      const isDefaulted = repo.keywords.length === 0 || (repo.keywords.length === 1 && repo.keywords[0] === name)
+      if (isDefaulted && keywords.length > 0) {
+        repo.keywords = keywords
+      }
+    }
+  }
+
+  if (orgId) config.currentOrgId = orgId
+
   writeConfig(config)
   return config
 }

--- a/desktop/src/main/github-auth.test.ts
+++ b/desktop/src/main/github-auth.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Controllable mock of child_process so getGitHubAuthStatus() never spawns `gh`.
+// Each test sets execFileSync's behaviour to simulate a `gh auth status` outcome.
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+}))
+
+import { execFileSync } from 'child_process'
+import { getGitHubAuthStatus } from './github'
+
+const mockExec = execFileSync as unknown as ReturnType<typeof vi.fn>
+
+/** Build the error `gh` throws on non-zero exit, carrying output on stderr. */
+function ghError(stderr = '', stdout = ''): Error {
+  return Object.assign(new Error('gh exited non-zero'), { stderr, stdout })
+}
+
+describe('getGitHubAuthStatus', () => {
+  beforeEach(() => {
+    mockExec.mockReset()
+  })
+
+  it('reports logged in and parses the account from the "account <user>" format', () => {
+    mockExec.mockReturnValue(
+      '✓ Logged in to github.com account octocat (keyring)\n  - Active account: true\n',
+    )
+    expect(getGitHubAuthStatus()).toEqual({ loggedIn: true, account: 'octocat' })
+  })
+
+  it('parses the account from the "Logged in to <host> as <user>" format', () => {
+    mockExec.mockReturnValue('✓ Logged in to github.com as octocat (oauth_token)\n')
+    expect(getGitHubAuthStatus()).toEqual({ loggedIn: true, account: 'octocat' })
+  })
+
+  it('reports logged in without an account when the output has no recognizable handle', () => {
+    mockExec.mockReturnValue('✓ Logged in to github.com\n')
+    expect(getGitHubAuthStatus()).toEqual({ loggedIn: true, account: undefined })
+  })
+
+  it('reports logged out when gh exits non-zero with no account in its output', () => {
+    mockExec.mockImplementation(() => {
+      throw ghError('You are not logged into any GitHub hosts. Run gh auth login to authenticate.\n')
+    })
+    expect(getGitHubAuthStatus()).toEqual({ loggedIn: false })
+  })
+
+  it('reports logged out when gh fails even if an account name appears on stderr', () => {
+    // Invalid/expired credentials: gh exits non-zero but may still name the
+    // account. The login is unusable, so it must NOT be reported as connected.
+    mockExec.mockImplementation(() => {
+      throw ghError('X Failed to log in to github.com account octocat (keyring) - invalid token\n')
+    })
+    expect(getGitHubAuthStatus()).toEqual({ loggedIn: false })
+  })
+
+  it('never stores or returns a token', () => {
+    mockExec.mockReturnValue('✓ Logged in to github.com account octocat\n')
+    const result = getGitHubAuthStatus()
+    expect(Object.keys(result).sort()).toEqual(['account', 'loggedIn'])
+  })
+})

--- a/desktop/src/main/github.ts
+++ b/desktop/src/main/github.ts
@@ -8,6 +8,32 @@ export function getGitHubToken(): string | null {
   }
 }
 
+/** Extract the account handle from `gh auth status` output (either format). */
+function parseGhAccount(text: string): string | undefined {
+  return text.match(/account\s+(\S+)/i)?.[1] || text.match(/Logged in to \S+ as (\S+)/i)?.[1]
+}
+
+/**
+ * Detects GitHub CLI auth status for DISPLAY only — no token is ever stored.
+ * Parses `gh auth status`, which writes to stderr and includes a line like
+ * "✓ Logged in to github.com account <user> (...)". Returns { loggedIn } and,
+ * when available, the detected account handle.
+ */
+export function getGitHubAuthStatus(): { loggedIn: boolean; account?: string } {
+  try {
+    const output = execFileSync('gh', ['auth', 'status'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    return { loggedIn: true, account: parseGhAccount(output) }
+  } catch {
+    // gh exits non-zero when not logged in OR when the stored credentials are
+    // invalid/expired. Either way the login is unusable, so report disconnected
+    // even if an account handle still appears in the error output.
+    return { loggedIn: false }
+  }
+}
+
 export function githubHeaders(extra?: Record<string, string>): Record<string, string> {
   const headers: Record<string, string> = { ...extra }
   const token = getGitHubToken()

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -21,6 +21,8 @@ import { hideQuickLaunch, resizeQuickLaunch, destroyQuickLaunch } from './window
 import { reRegisterSpotlightShortcut } from './spotlight-shortcut'
 import { setupProfileHandlers } from './ipc/profile-handlers'
 import { setupUsageHandlers } from './ipc/usage-handlers'
+import { setupAuthHandlers } from './ipc/auth-handlers'
+import { setupOrgHandlers } from './ipc/org-handlers'
 import { PRReviewWatcher } from './pr-review-watcher/watcher'
 import { setupPRReviewHandlers } from './ipc/pr-review-handlers'
 
@@ -189,6 +191,10 @@ function setupHandlers() {
   registerActivityHistoryHandlers()
   setupProfileHandlers()
   setupUsageHandlers()
+  // Cloud (optional): auth + organization. Handlers degrade gracefully when the
+  // Supabase env is missing — they never block boot.
+  setupAuthHandlers(() => mainWindow)
+  setupOrgHandlers()
   // Notification callback - only show when window is not focused
   const notificationCallback = (title: string, body: string) => {
     if (Notification.isSupported() && mainWindow && !mainWindow.isFocused()) {

--- a/desktop/src/main/ipc/auth-handlers.ts
+++ b/desktop/src/main/ipc/auth-handlers.ts
@@ -1,0 +1,32 @@
+import { ipcMain, type BrowserWindow } from 'electron'
+import type { AuthStatus } from '../../types'
+import { signIn, signUp, signOut, getStatus } from '../cloud/auth'
+
+interface LoginArgs { email: string; password: string }
+interface SignUpArgs { email: string; password: string; orgName?: string; invitationToken?: string }
+
+export function setupAuthHandlers(getMainWindow: () => BrowserWindow | null): void {
+  const emit = (status: AuthStatus) => {
+    getMainWindow()?.webContents.send('auth:statusChanged', status)
+  }
+
+  ipcMain.handle('auth:status', async (): Promise<AuthStatus> => getStatus())
+
+  ipcMain.handle('auth:login', async (_event, { email, password }: LoginArgs): Promise<AuthStatus> => {
+    const status = await signIn(email, password)
+    emit(status)
+    return status
+  })
+
+  ipcMain.handle('auth:signup', async (_event, { email, password, orgName, invitationToken }: SignUpArgs): Promise<AuthStatus> => {
+    const status = await signUp(email, password, { orgName, invitationToken })
+    emit(status)
+    return status
+  })
+
+  ipcMain.handle('auth:logout', async (): Promise<AuthStatus> => {
+    const status = await signOut()
+    emit(status)
+    return status
+  })
+}

--- a/desktop/src/main/ipc/config-handlers.ts
+++ b/desktop/src/main/ipc/config-handlers.ts
@@ -21,7 +21,9 @@ import {
   updateSplitEnabled,
   updateSplitActive,
   updateLaunchMode,
+  setIntegration,
 } from '../config/config'
+import { getGitHubAuthStatus } from '../github'
 import { reRegisterSpotlightShortcut } from '../spotlight-shortcut'
 import { repairConfig } from '../config/migrate'
 import { isValidSpotlightShortcut, isValidLaunchMode } from '../config/defaults'
@@ -291,6 +293,18 @@ export function setupConfigHandlers(getMainWindow: () => BrowserWindow | null) {
     }
     const config = updateLaunchMode(mode)
     return { config }
+  })
+
+  // Toggle an integration flag (only atlassian is user-settable). Detection/
+  // display only — no token is ever stored (see ticket #124 locked decisions).
+  ipcMain.handle('config:setIntegration', async (_event, { name, enabled }: { name: 'atlassian'; enabled: boolean }) => {
+    const config = setIntegration(name, enabled)
+    return { config }
+  })
+
+  // GitHub CLI auth status for DISPLAY only (`gh auth status`). No token stored.
+  ipcMain.handle('config:getGitHubAuthStatus', async () => {
+    return getGitHubAuthStatus()
   })
 
   // Validate path

--- a/desktop/src/main/ipc/org-handlers.ts
+++ b/desktop/src/main/ipc/org-handlers.ts
@@ -1,0 +1,25 @@
+import { ipcMain } from 'electron'
+import type { AcceptInvitationResult } from '../cloud/org'
+import type { Config, Invitation, Member, MembershipRole, Org } from '../../types'
+import { getCurrentOrg, listMembers, listInvitations, createInvitation, acceptInvitation, applySharedConfig } from '../cloud/org'
+
+interface InviteArgs { email: string; role?: MembershipRole }
+interface AcceptArgs { token: string }
+
+export function setupOrgHandlers(): void {
+  ipcMain.handle('org:current', async (): Promise<Org | null> => getCurrentOrg())
+
+  ipcMain.handle('org:members', async (): Promise<Member[]> => listMembers())
+
+  ipcMain.handle('org:invitations', async (): Promise<Invitation[]> => listInvitations())
+
+  ipcMain.handle('org:invite', async (_event, { email, role }: InviteArgs): Promise<Invitation> =>
+    createInvitation(email, role ?? 'user'),
+  )
+
+  ipcMain.handle('org:accept', async (_event, { token }: AcceptArgs): Promise<AcceptInvitationResult> =>
+    acceptInvitation(token),
+  )
+
+  ipcMain.handle('org:applyShared', async (): Promise<Config> => applySharedConfig())
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
-import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config } from '../types'
+import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole } from '../types'
 
 export type TerminalState = 'idle' | 'working' | 'waiting' | 'completed' | 'error'
 
@@ -81,6 +81,12 @@ const configApi = {
 
   hasGitHubRemote: (path: string) =>
     ipcRenderer.invoke('config:hasGitHubRemote', { path }),
+
+  getGitHubAuthStatus: (): Promise<GitHubAuthStatus> =>
+    ipcRenderer.invoke('config:getGitHubAuthStatus'),
+
+  setIntegration: (name: 'atlassian', enabled: boolean): Promise<{ config: Config }> =>
+    ipcRenderer.invoke('config:setIntegration', { name, enabled }),
 
   getGitStatus: (path: string) =>
     ipcRenderer.invoke('config:getGitStatus', { path }),
@@ -381,6 +387,33 @@ const usageApi = {
   getSpend: (): Promise<SpendSummary> => ipcRenderer.invoke('usage:getSpend'),
 }
 
+// Auth API (optional cloud auth via Supabase — never required for the app to run)
+const authApi = {
+  status: (): Promise<AuthStatus> => ipcRenderer.invoke('auth:status'),
+  login: (email: string, password: string): Promise<AuthStatus> =>
+    ipcRenderer.invoke('auth:login', { email, password }),
+  signup: (email: string, password: string, opts?: { orgName?: string; invitationToken?: string }): Promise<AuthStatus> =>
+    ipcRenderer.invoke('auth:signup', { email, password, orgName: opts?.orgName, invitationToken: opts?.invitationToken }),
+  logout: (): Promise<AuthStatus> => ipcRenderer.invoke('auth:logout'),
+  onStatusChanged: (callback: (status: AuthStatus) => void) => {
+    const listener = (_event: IpcRendererEvent, status: AuthStatus) => callback(status)
+    ipcRenderer.on('auth:statusChanged', listener)
+    return () => ipcRenderer.removeListener('auth:statusChanged', listener)
+  },
+}
+
+// Org API (organization membership + invitations)
+const orgApi = {
+  current: (): Promise<Org | null> => ipcRenderer.invoke('org:current'),
+  members: (): Promise<Member[]> => ipcRenderer.invoke('org:members'),
+  invitations: (): Promise<Invitation[]> => ipcRenderer.invoke('org:invitations'),
+  invite: (email: string, role?: MembershipRole): Promise<Invitation> =>
+    ipcRenderer.invoke('org:invite', { email, role }),
+  accept: (token: string): Promise<{ orgId: string; config: Config }> =>
+    ipcRenderer.invoke('org:accept', { token }),
+  applySharedConfig: (): Promise<Config> => ipcRenderer.invoke('org:applyShared'),
+}
+
 // Expose APIs to renderer
 contextBridge.exposeInMainWorld('electronAPI', {
   config: configApi,
@@ -398,6 +431,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   prWatcher: prWatcherApi,
   profile: profileApi,
   usage: usageApi,
+  auth: authApi,
+  org: orgApi,
 })
 
 // Type definitions for the renderer
@@ -419,6 +454,8 @@ declare global {
       prWatcher: typeof prWatcherApi
       profile: typeof profileApi
       usage: typeof usageApi
+      auth: typeof authApi
+      org: typeof orgApi
     }
   }
 

--- a/desktop/src/renderer/components/InvitationOnboardingWizard.tsx
+++ b/desktop/src/renderer/components/InvitationOnboardingWizard.tsx
@@ -1,0 +1,314 @@
+import { useState, useCallback, useEffect } from 'react'
+import { Mail, ChevronLeft, ChevronRight, X, Check, Folder, Trash2, Loader2 } from 'lucide-react'
+import { useAuth } from '../hooks/useAuth'
+import { useOrg } from '../hooks/useOrg'
+import { useConfig } from '../hooks/useConfig'
+
+interface InvitationOnboardingWizardProps {
+  isOpen: boolean
+  onClose: () => void
+  initialToken?: string
+}
+
+interface PickedRepo {
+  name: string
+  path: string
+}
+
+const TOTAL_STEPS = 3
+
+/**
+ * Invitation onboarding: accept token → sign up/in → accept invitation → ask
+ * ONLY for repo paths (everything else is inherited from the org). Skippable —
+ * the app never blocks on it. Modeled on ProfileOnboardingWizard.
+ */
+export function InvitationOnboardingWizard({ isOpen, onClose, initialToken = '' }: InvitationOnboardingWizardProps) {
+  const { login, signup } = useAuth()
+  const { accept } = useOrg()
+  const { loadConfig } = useConfig()
+
+  const [step, setStep] = useState(1)
+  const [token, setToken] = useState(initialToken)
+  const [isNewAccount, setIsNewAccount] = useState(true)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [repos, setRepos] = useState<PickedRepo[]>([])
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [orgName, setOrgName] = useState<string | null>(null)
+
+  useEffect(() => { setToken(initialToken) }, [initialToken])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); onClose() }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  // Step 1 → 2: authenticate then accept the invitation (membership + inherit config).
+  const handleAcceptInvitation = useCallback(async () => {
+    if (busy) return
+    setError(null)
+    if (!token.trim()) { setError('Invitation token is required'); return }
+    if (!email.trim() || !password) { setError('Email and password are required'); return }
+
+    setBusy(true)
+    try {
+      const status = isNewAccount
+        ? await signup(email.trim(), password, { invitationToken: token.trim() })
+        : await login(email.trim(), password)
+
+      if (!status.loggedIn) {
+        setError('Please confirm your email, then reopen this wizard to continue.')
+        return
+      }
+
+      const result = await accept(token.trim())
+      const current = await window.electronAPI.org.current()
+      setOrgName(current?.name ?? null)
+      // Reflect any inherited config merge in the UI immediately.
+      if (result?.config) loadConfig()
+      setStep(2)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to accept invitation')
+    } finally {
+      setBusy(false)
+    }
+  }, [busy, token, email, password, isNewAccount, signup, login, accept, loadConfig])
+
+  const handleAddRepo = useCallback(async () => {
+    const folderPath = await window.electronAPI.dialog.openFolder()
+    if (!folderPath) return
+    const folderName = folderPath.split(/[\\/]/).pop() || ''
+    const name = folderName.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase()
+    if (!name) { setError('Invalid folder name'); return }
+    if (repos.some(r => r.name === name)) { setError(`'${name}' already added`); return }
+    setError(null)
+    setRepos(prev => [...prev, { name, path: folderPath }])
+  }, [repos])
+
+  const handleRemoveRepo = useCallback((name: string) => {
+    setRepos(prev => prev.filter(r => r.name !== name))
+  }, [])
+
+  // Step 2 → 3: persist the picked repo paths (inheriting org keywords by name).
+  const handleFinishRepos = useCallback(async () => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      for (const repo of repos) {
+        await window.electronAPI.config.addRepository(repo.name, repo.path, [])
+      }
+      // Newly added repos must also inherit the org's shared config — the merge
+      // at accept time only reached repositories that already existed.
+      await window.electronAPI.org.applySharedConfig().catch(() => undefined)
+      loadConfig()
+      setStep(3)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to add repositories')
+    } finally {
+      setBusy(false)
+    }
+  }, [busy, repos, loadConfig])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 animate-modal-backdrop"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-secondary border border-white/10 rounded-xl w-full max-w-md mx-4 backdrop-blur-2xl animate-modal-content"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-4">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-accent/10 rounded-lg">
+              <Mail className="w-4 h-4 text-accent" />
+            </div>
+            <h3 className="text-base font-semibold">Join your team</h3>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 text-text-secondary hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Step indicator */}
+        <div className="flex items-center gap-1.5 px-5 pb-4">
+          {Array.from({ length: TOTAL_STEPS }, (_, i) => (
+            <div
+              key={i}
+              className={`h-1 flex-1 rounded-full transition-colors ${i + 1 <= step ? 'bg-accent' : 'bg-white/10'}`}
+            />
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="px-5 pb-5 min-h-[220px]">
+          {step === 1 && (
+            <div className="space-y-3">
+              <div>
+                <div className="text-sm font-medium mb-1">Accept your invitation</div>
+                <div className="text-xs text-text-secondary/50 mb-3">
+                  Paste the invitation token you received, then sign in or create your account. You&apos;ll inherit your team&apos;s configuration automatically.
+                </div>
+              </div>
+              <input
+                type="text"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                placeholder="Invitation token"
+                autoFocus
+                className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30 font-mono"
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setIsNewAccount(true)}
+                  className={`flex-1 px-3 py-1.5 text-xs rounded-lg border transition-all ${isNewAccount ? 'bg-accent/10 border-accent/30 text-accent' : 'bg-white/[0.06] border-white/[0.08] text-text-secondary hover:text-white'}`}
+                >
+                  New account
+                </button>
+                <button
+                  onClick={() => setIsNewAccount(false)}
+                  className={`flex-1 px-3 py-1.5 text-xs rounded-lg border transition-all ${!isNewAccount ? 'bg-accent/10 border-accent/30 text-accent' : 'bg-white/[0.06] border-white/[0.08] text-text-secondary hover:text-white'}`}
+                >
+                  Existing account
+                </button>
+              </div>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Email (must match the invitation)"
+                className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+              />
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Password"
+                onKeyDown={(e) => { if (e.key === 'Enter') handleAcceptInvitation() }}
+                className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+              />
+            </div>
+          )}
+
+          {step === 2 && (
+            <div className="space-y-3">
+              <div>
+                <div className="text-sm font-medium mb-1">Add your repositories</div>
+                <div className="text-xs text-text-secondary/50 mb-3">
+                  This is the only thing you set locally — everything else is inherited from your org.
+                </div>
+              </div>
+              <button
+                onClick={handleAddRepo}
+                className="w-full flex items-center justify-center gap-2 py-3 text-sm border border-dashed border-white/15 rounded-lg text-text-secondary hover:border-accent/40 hover:text-white transition-colors"
+              >
+                <Folder className="w-4 h-4" />
+                Add a repository folder
+              </button>
+              {repos.length > 0 && (
+                <div className="space-y-1.5">
+                  {repos.map((repo) => (
+                    <div key={repo.name} className="flex items-center gap-2 px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg">
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium truncate">{repo.name}</div>
+                        <div className="text-xs text-text-secondary/50 truncate">{repo.path}</div>
+                      </div>
+                      <button
+                        onClick={() => handleRemoveRepo(repo.name)}
+                        className="p-1 text-text-secondary/50 hover:text-red transition-colors"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {step === 3 && (
+            <div className="flex flex-col items-center justify-center text-center py-8 space-y-3">
+              <div className="p-3 bg-green/10 rounded-full">
+                <Check className="w-6 h-6 text-green" />
+              </div>
+              <div className="text-sm font-medium">You&apos;re all set!</div>
+              <div className="text-xs text-text-secondary/60">
+                {orgName ? <>You&apos;ve joined <span className="text-white font-medium">{orgName}</span> and inherited its configuration.</> : 'You\'ve joined your team and inherited its configuration.'}
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="mt-3 px-3 py-2 bg-red/10 border border-red/20 rounded-lg text-xs text-red">
+              {error}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-5 pb-5">
+          <div>
+            {step === 2 && (
+              <button
+                onClick={() => setStep(1)}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+              >
+                <ChevronLeft className="w-3.5 h-3.5" />
+                Back
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {step < 3 && (
+              <button
+                onClick={onClose}
+                className="px-3 py-1.5 text-xs font-medium text-text-secondary/50 hover:text-text-secondary transition-colors"
+              >
+                Skip
+              </button>
+            )}
+            {step === 1 && (
+              <button
+                onClick={handleAcceptInvitation}
+                disabled={busy}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-accent border border-accent/20 rounded-lg hover:bg-accent/10 transition-all disabled:opacity-40"
+              >
+                {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <>Accept<ChevronRight className="w-3.5 h-3.5" /></>}
+              </button>
+            )}
+            {step === 2 && (
+              <button
+                onClick={handleFinishRepos}
+                disabled={busy}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40"
+              >
+                {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <><ChevronRight className="w-3.5 h-3.5" />Continue</>}
+              </button>
+            )}
+            {step === 3 && (
+              <button
+                onClick={onClose}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all"
+              >
+                <Check className="w-3.5 h-3.5" />
+                Done
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/desktop/src/renderer/components/LoginScreen.tsx
+++ b/desktop/src/renderer/components/LoginScreen.tsx
@@ -1,0 +1,176 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Cloud, X, LogIn, UserPlus, Loader2 } from 'lucide-react'
+import { useAuth } from '../hooks/useAuth'
+
+interface LoginScreenProps {
+  isOpen: boolean
+  onClose: () => void
+  onSignedIn?: () => void
+}
+
+type Mode = 'signin' | 'signup'
+
+/**
+ * Optional email/password sign-in + sign-up (personal org). Fully SKIPPABLE —
+ * the app never blocks on auth. Sign-up creates a personal org server-side.
+ */
+export function LoginScreen({ isOpen, onClose, onSignedIn }: LoginScreenProps) {
+  const { login, signup } = useAuth()
+  const [mode, setMode] = useState<Mode>('signin')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [orgName, setOrgName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); onClose() }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  const handleSubmit = useCallback(async () => {
+    if (busy) return
+    setError(null)
+    setNotice(null)
+    if (!email.trim() || !password) {
+      setError('Email and password are required')
+      return
+    }
+    setBusy(true)
+    try {
+      const status = mode === 'signin'
+        ? await login(email.trim(), password)
+        : await signup(email.trim(), password, { orgName: orgName.trim() || undefined })
+
+      if (status.loggedIn) {
+        onSignedIn?.()
+        onClose()
+      } else {
+        // Sign-up with email confirmation enabled: no session yet.
+        setNotice('Check your inbox to confirm your email, then sign in.')
+        setMode('signin')
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Authentication failed')
+    } finally {
+      setBusy(false)
+    }
+  }, [busy, email, password, orgName, mode, login, signup, onSignedIn, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 animate-modal-backdrop"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-secondary border border-white/10 rounded-xl w-full max-w-md mx-4 backdrop-blur-2xl animate-modal-content"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-4">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-accent/10 rounded-lg">
+              <Cloud className="w-4 h-4 text-accent" />
+            </div>
+            <h3 className="text-base font-semibold">
+              {mode === 'signin' ? 'Sign in to Magic Slash' : 'Create your account'}
+            </h3>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 text-text-secondary hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 pb-5 space-y-3">
+          <p className="text-xs text-text-secondary/60">
+            Cloud sign-in is optional — Magic Slash works fully without an account. Sign in to manage your organization and invite teammates.
+          </p>
+
+          <div className="space-y-2">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Email"
+              autoFocus
+              className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+            />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Password"
+              onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
+              className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+            />
+            {mode === 'signup' && (
+              <input
+                type="text"
+                value={orgName}
+                onChange={(e) => setOrgName(e.target.value)}
+                placeholder="Organization name (optional)"
+                onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
+                className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+              />
+            )}
+          </div>
+
+          {error && (
+            <div className="px-3 py-2 bg-red/10 border border-red/20 rounded-lg text-xs text-red">
+              {error}
+            </div>
+          )}
+          {notice && (
+            <div className="px-3 py-2 bg-accent/10 border border-accent/20 rounded-lg text-xs text-accent">
+              {notice}
+            </div>
+          )}
+
+          <button
+            onClick={handleSubmit}
+            disabled={busy}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-50"
+          >
+            {busy ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : mode === 'signin' ? (
+              <LogIn className="w-4 h-4" />
+            ) : (
+              <UserPlus className="w-4 h-4" />
+            )}
+            {mode === 'signin' ? 'Sign in' : 'Sign up'}
+          </button>
+
+          <div className="text-center text-xs text-text-secondary/60">
+            {mode === 'signin' ? (
+              <>
+                No account?{' '}
+                <button onClick={() => { setMode('signup'); setError(null); setNotice(null) }} className="text-accent hover:underline">
+                  Create one
+                </button>
+              </>
+            ) : (
+              <>
+                Already have an account?{' '}
+                <button onClick={() => { setMode('signin'); setError(null); setNotice(null) }} className="text-accent hover:underline">
+                  Sign in
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/desktop/src/renderer/hooks/useAuth.ts
+++ b/desktop/src/renderer/hooks/useAuth.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { AuthStatus } from '../../types'
+
+const INITIAL: AuthStatus = { enabled: false, loggedIn: false }
+
+/**
+ * Optional cloud auth state. Subscribes to auth:statusChanged so login/logout in
+ * one place propagates everywhere. The app is fully functional when logged out —
+ * consumers should treat `enabled: false` as "cloud simply hidden".
+ */
+export function useAuth() {
+  const [status, setStatus] = useState<AuthStatus>(INITIAL)
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      const s = await window.electronAPI.auth.status()
+      setStatus(s)
+    } catch {
+      setStatus(INITIAL)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.auth.onStatusChanged(setStatus)
+    return () => { unsubscribe() }
+  }, [])
+
+  const login = useCallback(
+    (email: string, password: string) => window.electronAPI.auth.login(email, password),
+    [],
+  )
+
+  const signup = useCallback(
+    (email: string, password: string, opts?: { orgName?: string; invitationToken?: string }) =>
+      window.electronAPI.auth.signup(email, password, opts),
+    [],
+  )
+
+  const logout = useCallback(() => window.electronAPI.auth.logout(), [])
+
+  return { status, loading, refresh, login, signup, logout }
+}

--- a/desktop/src/renderer/hooks/useOrg.ts
+++ b/desktop/src/renderer/hooks/useOrg.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { Invitation, Member, MembershipRole, Org } from '../../types'
+
+/**
+ * Organization state (membership + invitations). All calls degrade gracefully:
+ * when cloud is disabled or the user is logged out, everything is empty/null and
+ * nothing throws.
+ */
+export function useOrg() {
+  const [org, setOrg] = useState<Org | null>(null)
+  const [members, setMembers] = useState<Member[]>([])
+  const [invitations, setInvitations] = useState<Invitation[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const current = await window.electronAPI.org.current()
+      setOrg(current)
+      if (current) {
+        setMembers(await window.electronAPI.org.members().catch(() => []))
+        // Invitations are admin-only; a non-admin read simply yields [].
+        setInvitations(await window.electronAPI.org.invitations().catch(() => []))
+      } else {
+        setMembers([])
+        setInvitations([])
+      }
+    } catch {
+      setOrg(null)
+      setMembers([])
+      setInvitations([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const invite = useCallback(
+    async (email: string, role: MembershipRole = 'user') => {
+      const invitation = await window.electronAPI.org.invite(email, role)
+      await refresh()
+      return invitation
+    },
+    [refresh],
+  )
+
+  const accept = useCallback(
+    async (token: string) => {
+      const result = await window.electronAPI.org.accept(token)
+      await refresh()
+      return result
+    },
+    [refresh],
+  )
+
+  return { org, members, invitations, loading, refresh, invite, accept }
+}

--- a/desktop/src/renderer/pages/Config/OrgPage.tsx
+++ b/desktop/src/renderer/pages/Config/OrgPage.tsx
@@ -1,0 +1,283 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Cloud, Users, Mail, LogOut, LogIn, UserPlus, Shield, Copy, Check, Github, Loader2, Building2 } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import { useOrg } from '../../hooks/useOrg'
+import { useStore } from '../../store'
+import { LoginScreen } from '../../components/LoginScreen'
+import { InvitationOnboardingWizard } from '../../components/InvitationOnboardingWizard'
+import { showToast } from '../../components/Toast'
+import type { GitHubAuthStatus } from '../../../types'
+
+export function OrgPage() {
+  const { status, loading: authLoading, logout } = useAuth()
+  const { org, members, invitations, loading: orgLoading, refresh, invite } = useOrg()
+  const { config, setConfig } = useStore()
+
+  const [showLogin, setShowLogin] = useState(false)
+  const [showInvitationWizard, setShowInvitationWizard] = useState(false)
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [inviting, setInviting] = useState(false)
+  const [copiedToken, setCopiedToken] = useState<string | null>(null)
+
+  // Integration status (DISPLAY only — no tokens stored).
+  const [githubStatus, setGithubStatus] = useState<GitHubAuthStatus | null>(null)
+  const atlassianEnabled = config?.integrations?.atlassian ?? true
+
+  useEffect(() => {
+    window.electronAPI.config.getGitHubAuthStatus().then(setGithubStatus).catch(() => setGithubStatus({ loggedIn: false }))
+  }, [])
+
+  const isAdmin = org?.role === 'admin'
+
+  const handleInvite = useCallback(async () => {
+    if (inviting || !inviteEmail.trim()) return
+    setInviting(true)
+    try {
+      await invite(inviteEmail.trim())
+      setInviteEmail('')
+      showToast('Invitation created', 'success')
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to create invitation', 'error')
+    } finally {
+      setInviting(false)
+    }
+  }, [inviting, inviteEmail, invite])
+
+  const handleLogout = useCallback(async () => {
+    await logout()
+    await refresh()
+  }, [logout, refresh])
+
+  const handleCopyToken = useCallback((token: string) => {
+    navigator.clipboard.writeText(token).then(() => {
+      setCopiedToken(token)
+      setTimeout(() => setCopiedToken(null), 1500)
+    }).catch(() => {})
+  }, [])
+
+  const handleAtlassianToggle = useCallback(async () => {
+    const next = !atlassianEnabled
+    const result = await window.electronAPI.config.setIntegration('atlassian', next)
+    setConfig(result.config)
+  }, [atlassianEnabled, setConfig])
+
+  // Cloud disabled entirely (no Supabase env baked in) → hide cloud features.
+  if (!authLoading && !status.enabled) {
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center gap-2 text-sm text-text-secondary">
+          <Cloud className="w-4 h-4" />
+          <span>Organization</span>
+        </div>
+        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-6 text-center">
+          <Cloud className="w-8 h-8 text-text-secondary/30 mx-auto mb-3" />
+          <div className="text-sm text-text-secondary/60">Cloud features are not configured in this build.</div>
+          <div className="text-xs text-text-secondary/40 mt-1">Magic Slash works fully offline — no account required.</div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      {/* Account */}
+      <div>
+        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
+          <Cloud className="w-4 h-4" />
+          <span>Cloud account</span>
+        </div>
+        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
+          {status.loggedIn ? (
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm font-medium">{status.user?.email ?? 'Signed in'}</div>
+                <div className="text-xs text-text-secondary/50 mt-0.5">Signed in to Magic Slash cloud</div>
+              </div>
+              <button
+                onClick={handleLogout}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+              >
+                <LogOut className="w-3.5 h-3.5" />
+                Sign out
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm font-medium">Not signed in</div>
+                <div className="text-xs text-text-secondary/50 mt-0.5">Sign in to manage your organization (optional)</div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setShowInvitationWizard(true)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+                >
+                  <UserPlus className="w-3.5 h-3.5" />
+                  Join with invitation
+                </button>
+                <button
+                  onClick={() => setShowLogin(true)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all"
+                >
+                  <LogIn className="w-3.5 h-3.5" />
+                  Sign in
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Organization (signed in) */}
+      {status.loggedIn && (
+        <>
+          <div>
+            <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
+              <Building2 className="w-4 h-4" />
+              <span>Organization</span>
+            </div>
+            <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
+              {orgLoading ? (
+                <div className="flex items-center justify-center py-4 text-text-secondary/50">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                </div>
+              ) : org ? (
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="text-sm font-medium">{org.name}</div>
+                    <div className="text-xs text-text-secondary/50 mt-0.5">Your role in this organization</div>
+                  </div>
+                  <span className={`flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium ${isAdmin ? 'bg-accent/15 text-accent' : 'bg-white/10 text-text-secondary'}`}>
+                    {isAdmin && <Shield className="w-3 h-3" />}
+                    {org.role}
+                  </span>
+                </div>
+              ) : (
+                <div className="text-sm text-text-secondary/50 text-center py-2">No organization found for this account.</div>
+              )}
+            </div>
+          </div>
+
+          {/* Members */}
+          {org && (
+            <div>
+              <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
+                <Users className="w-4 h-4" />
+                <span>Members ({members.length})</span>
+              </div>
+              <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-2">
+                {members.length === 0 ? (
+                  <div className="text-sm text-text-secondary/50 text-center py-2">No members yet.</div>
+                ) : (
+                  members.map((m) => (
+                    <div key={m.userId} className="flex items-center justify-between py-1">
+                      <span className="text-sm truncate">{m.email ?? m.userId}</span>
+                      <span className={`px-2 py-0.5 rounded text-[11px] font-medium ${m.role === 'admin' ? 'bg-accent/15 text-accent' : 'bg-white/10 text-text-secondary'}`}>
+                        {m.role}
+                      </span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Invitations (admin only) */}
+          {org && isAdmin && (
+            <div>
+              <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
+                <Mail className="w-4 h-4" />
+                <span>Invite a colleague</span>
+              </div>
+              <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="email"
+                    value={inviteEmail}
+                    onChange={(e) => setInviteEmail(e.target.value)}
+                    placeholder="colleague@example.com"
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleInvite() }}
+                    className="flex-1 px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+                  />
+                  <button
+                    onClick={handleInvite}
+                    disabled={inviting || !inviteEmail.trim()}
+                    className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40"
+                  >
+                    {inviting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Mail className="w-3.5 h-3.5" />}
+                    Invite
+                  </button>
+                </div>
+
+                {invitations.length > 0 && (
+                  <div className="border-t border-white/5 pt-4 space-y-2">
+                    {invitations.map((inv) => (
+                      <div key={inv.id} className="flex items-center gap-2 text-sm">
+                        <span className="flex-1 truncate">{inv.email}</span>
+                        <span className={`px-2 py-0.5 rounded text-[11px] font-medium ${
+                          inv.status === 'pending' ? 'bg-yellow/10 text-yellow'
+                            : inv.status === 'accepted' ? 'bg-green/10 text-green'
+                            : 'bg-white/10 text-text-secondary'
+                        }`}>
+                          {inv.status}
+                        </span>
+                        {inv.status === 'pending' && (
+                          <button
+                            onClick={() => handleCopyToken(inv.token)}
+                            className="flex items-center gap-1 px-2 py-0.5 text-[11px] text-text-secondary border border-white/10 rounded hover:bg-white/10 hover:text-white transition-all"
+                            title="Copy invitation token"
+                          >
+                            {copiedToken === inv.token ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+                            Token
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Integrations status (detection/display only — no tokens stored) */}
+      <div>
+        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
+          <Github className="w-4 h-4" />
+          <span>Integrations</span>
+        </div>
+        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium">GitHub CLI</div>
+              <div className="text-xs text-text-secondary/50 mt-0.5">
+                {githubStatus?.loggedIn
+                  ? `Detected via gh${githubStatus.account ? ` — ${githubStatus.account}` : ''}`
+                  : 'Not detected. Run `gh auth login` in your terminal.'}
+              </div>
+            </div>
+            <span className={`px-2 py-0.5 rounded text-[11px] font-medium ${githubStatus?.loggedIn ? 'bg-green/10 text-green' : 'bg-red/10 text-red'}`}>
+              {githubStatus?.loggedIn ? 'Connected' : 'Not connected'}
+            </span>
+          </div>
+          <div className="border-t border-white/5 pt-4 flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium">Atlassian (Jira)</div>
+              <div className="text-xs text-text-secondary/50 mt-0.5">Auth is handled by the Atlassian MCP server. Toggle whether Jira features are enabled.</div>
+            </div>
+            <button
+              onClick={handleAtlassianToggle}
+              className={`relative w-10 h-[22px] rounded-full transition-colors duration-200 flex-shrink-0 ${atlassianEnabled ? 'bg-accent' : 'bg-white/20'}`}
+            >
+              <div className={`absolute top-[3px] left-[3px] w-4 h-4 rounded-full bg-white transition-transform duration-200 ${atlassianEnabled ? 'translate-x-[18px]' : 'translate-x-0'}`} />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <LoginScreen isOpen={showLogin} onClose={() => setShowLogin(false)} onSignedIn={refresh} />
+      <InvitationOnboardingWizard isOpen={showInvitationWizard} onClose={() => { setShowInvitationWizard(false); refresh() }} />
+    </div>
+  )
+}

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, Fragment } from 'react'
 import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, GitPullRequest, History, Gauge, User, Coins } from 'lucide-react'
 import { ProfileSection } from './ProfileSection'
 import { RepoPage } from './RepoPage'
+import { OrgPage } from './OrgPage'
 import { LimitGauge } from '../../components/agent-info-sidebar/LimitGauge'
 import { useStore } from '../../store'
 import { useConfig } from '../../hooks/useConfig'
@@ -28,11 +29,12 @@ const LAUNCH_MODE_OPTIONS: { value: LaunchMode; label: string; description: stri
   { value: 'bypassPermissions', label: 'Bypass', description: 'No permission checks — for sandboxed environments only' },
 ]
 
-type SettingsTab = 'profile' | 'repositories' | 'launch-mode' | 'features' | 'shortcuts' | 'usage' | 'about'
+type SettingsTab = 'profile' | 'repositories' | 'organization' | 'launch-mode' | 'features' | 'shortcuts' | 'usage' | 'about'
 
 const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
   { id: 'profile', label: 'Profile' },
   { id: 'repositories', label: 'Repositories' },
+  { id: 'organization', label: 'Organization' },
   { id: 'launch-mode', label: 'Launch Mode' },
   { id: 'features', label: 'Features' },
   { id: 'shortcuts', label: 'Shortcuts' },
@@ -331,6 +333,11 @@ function WelcomePage() {
       {/* Profile tab */}
       {activeTab === 'profile' && (
         <ProfileSection />
+      )}
+
+      {/* Organization tab */}
+      {activeTab === 'organization' && (
+        <OrgPage />
       )}
 
       {/* Repositories tab */}

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -158,6 +158,75 @@ export interface Config {
     pollIntervalMs?: number
     autoLaunchSkills?: boolean
   }
+  // Cloud: the org the local install is currently associated with (set after
+  // signing up / accepting an invitation). Purely a local hint — never required.
+  currentOrgId?: string
+}
+
+// ---------------------------------------------------------------------------
+// Cloud: auth & organization (optional — the app works fully without any of it)
+// ---------------------------------------------------------------------------
+
+export type MembershipRole = 'user' | 'admin'
+
+export type InvitationStatus = 'pending' | 'accepted' | 'revoked' | 'expired'
+
+/** Signed-in cloud user identity (subset of the Supabase session). */
+export interface CloudUser {
+  id: string
+  email?: string
+}
+
+/** Result of any auth query. `enabled` is false when Supabase env is missing. */
+export interface AuthStatus {
+  enabled: boolean
+  loggedIn: boolean
+  user?: CloudUser
+}
+
+export interface Org {
+  id: string
+  name: string
+  createdBy?: string
+  role: MembershipRole
+}
+
+export interface Member {
+  userId: string
+  email?: string
+  role: MembershipRole
+  createdAt?: string
+}
+
+export interface Invitation {
+  id: string
+  email: string
+  role: MembershipRole
+  status: InvitationStatus
+  token: string
+  expiresAt?: string | null
+  createdAt?: string
+}
+
+/** Shared org config the invitee inherits (never includes local repo paths). */
+export interface OrgSharedConfig {
+  languages?: Record<string, string>
+  commit?: {
+    style?: string
+    format?: string
+    coAuthor?: boolean
+    includeTicketId?: boolean
+  }
+  pullRequest?: {
+    autoLinkTickets?: boolean
+  }
+  repoKeywords?: Record<string, string[]>
+}
+
+/** GitHub CLI auth status — DISPLAY ONLY. No token is ever stored. */
+export interface GitHubAuthStatus {
+  loggedIn: boolean
+  account?: string
 }
 
 export interface PRTemplate {

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -14,6 +14,14 @@ export default defineConfig({
           args.startup()
         },
         vite: {
+          // Bundle the Supabase URL + anon key into the MAIN process build.
+          // The anon key is public/safe to ship (RLS enforces access). When these
+          // env vars are absent at build time they resolve to undefined and the
+          // cloud client stays disabled — the app still boots and works offline.
+          define: {
+            'process.env.MAGIC_SLASH_SUPABASE_URL': JSON.stringify(process.env.MAGIC_SLASH_SUPABASE_URL || ''),
+            'process.env.MAGIC_SLASH_SUPABASE_ANON_KEY': JSON.stringify(process.env.MAGIC_SLASH_SUPABASE_ANON_KEY || ''),
+          },
           build: {
             outDir: 'dist/main',
             minify: 'esbuild',

--- a/install/config-schema.json
+++ b/install/config-schema.json
@@ -79,6 +79,10 @@
       "type": "string",
       "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
       "description": "Default time for new scheduled agents (HH:mm format)"
+    },
+    "currentOrgId": {
+      "type": "string",
+      "description": "Cloud org this install is associated with (optional local hint)"
     }
   },
   "additionalProperties": false,

--- a/supabase/migrations/20260723100000_accept_invitation.sql
+++ b/supabase/migrations/20260723100000_accept_invitation.sql
@@ -1,0 +1,136 @@
+-- Migration: accept_invitation + get_org_shared_config
+-- Cloud PR 2 of epic #121 (auth & organization). Adds the two RPCs the desktop
+-- app needs for invitation-based onboarding:
+--   * accept_invitation(token)      — an invitee joins an org from an invite.
+--   * get_org_shared_config(org_id) — an invitee inherits the org's shared config.
+--
+-- Both run SECURITY DEFINER with a locked search_path, mirroring the PR1 helpers
+-- (create_organization, is_org_member, ...). PR1 established: memberships has a
+-- unique (org_id, user_id) and an admin role gate on INSERT; invitations carry
+-- (email, role, token, status, expires_at, accepted_at); the org's admin/creator
+-- is organizations.created_by; configs is per-user (unique (org_id, user_id)).
+
+-- ---------------------------------------------------------------------------
+-- accept_invitation: an authenticated invitee joins an org from an invite token
+-- ---------------------------------------------------------------------------
+-- There is deliberately no self-service INSERT policy on memberships (PR1 gates
+-- inserts behind is_org_admin). Accepting an invitation must therefore run as
+-- the table owner: it validates the invite belongs to the caller (email match),
+-- is still pending and unexpired, then atomically creates the membership and
+-- marks the invitation accepted. Returns the joined org_id.
+create or replace function public.accept_invitation(invitation_token text)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  inv           public.invitations%rowtype;
+  current_uid   uuid := auth.uid();
+  current_email text := auth.jwt() ->> 'email';
+begin
+  if current_uid is null then
+    raise exception 'accept_invitation requires an authenticated user';
+  end if;
+
+  select * into inv
+  from public.invitations
+  where token = invitation_token
+  for update;
+
+  if not found then
+    raise exception 'invitation not found';
+  end if;
+
+  if inv.status <> 'pending' then
+    raise exception 'invitation is not pending (status: %)', inv.status;
+  end if;
+
+  if inv.expires_at is not null and inv.expires_at < now() then
+    -- Reject expired invitations. We deliberately do NOT flip status to 'expired'
+    -- here: this function raises, and any UPDATE would roll back with it (same
+    -- transaction), so it would look persisted but be a no-op. Expiry is derived
+    -- from expires_at at read time instead (see listInvitations in cloud/org.ts,
+    -- which reports a past-due pending invite as 'expired').
+    raise exception 'invitation has expired';
+  end if;
+
+  -- Email match is case-insensitive: the JWT email must equal the invite email.
+  if current_email is null or lower(current_email) <> lower(inv.email) then
+    raise exception 'invitation email does not match the authenticated user';
+  end if;
+
+  -- Create the membership with the role carried by the invitation. If the user
+  -- is somehow already a member, treat the invite as accepted rather than error.
+  insert into public.memberships (org_id, user_id, role)
+  values (inv.org_id, current_uid, inv.role)
+  on conflict (org_id, user_id) do nothing;
+
+  update public.invitations
+  set status = 'accepted', accepted_at = now()
+  where id = inv.id;
+
+  return inv.org_id;
+end;
+$$;
+
+revoke execute on function public.accept_invitation(text) from public;
+grant execute on function public.accept_invitation(text) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- get_org_shared_config: the shared config fields the invitee inherits
+-- ---------------------------------------------------------------------------
+-- configs is per-user (there is no org-level config row), so the "org shared
+-- config" is sourced from the org creator/admin's config row
+-- (organizations.created_by). Only the shared fields are exposed — languages,
+-- commit/PR format, and shared repo keywords — never per-user/local bits. The
+-- caller must be a member of the org (defense-in-depth on top of RLS, since
+-- SECURITY DEFINER bypasses it). Returns jsonb (an empty object when the admin
+-- has no config yet).
+create or replace function public.get_org_shared_config(p_org_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  admin_uid uuid;
+  admin_data jsonb;
+begin
+  if auth.uid() is null then
+    raise exception 'get_org_shared_config requires an authenticated user';
+  end if;
+
+  if not public.is_org_member(p_org_id) then
+    raise exception 'not a member of this organization';
+  end if;
+
+  select created_by into admin_uid
+  from public.organizations
+  where id = p_org_id;
+
+  if admin_uid is null then
+    return '{}'::jsonb;
+  end if;
+
+  select data into admin_data
+  from public.configs
+  where org_id = p_org_id
+    and user_id = admin_uid;
+
+  if admin_data is null then
+    return '{}'::jsonb;
+  end if;
+
+  -- Expose only the shared fields; strip nulls so absent keys are simply omitted.
+  return jsonb_strip_nulls(jsonb_build_object(
+    'languages',    admin_data -> 'languages',
+    'commit',       admin_data -> 'commit',
+    'pullRequest',  admin_data -> 'pullRequest',
+    'repoKeywords', admin_data -> 'repoKeywords'
+  ));
+end;
+$$;
+
+revoke execute on function public.get_org_shared_config(uuid) from public;
+grant execute on function public.get_org_shared_config(uuid) to authenticated;

--- a/supabase/tests/accept_invitation.test.sql
+++ b/supabase/tests/accept_invitation.test.sql
@@ -1,0 +1,125 @@
+-- pgTAP: prove accept_invitation + get_org_shared_config behave correctly.
+--
+-- Like rls_isolation.test.sql, we impersonate authenticated end users by setting
+--   set local role authenticated;
+--   set local request.jwt.claims = '{"sub":"<uuid>","email":"<email>"}';
+-- Both RPCs are SECURITY DEFINER: they run as the owner but read auth.uid() /
+-- auth.jwt() from the claims above. We `reset role;` to seed data as the owner.
+
+begin;
+select plan(8);
+
+-- ---------------------------------------------------------------------------
+-- Seed as the table owner (RLS bypassed). u1 = admin/creator of Org One.
+-- u2 has a pending invite to Org One. u3 has no invite (used for email mismatch).
+-- ---------------------------------------------------------------------------
+insert into auth.users (instance_id, id, aud, role, email, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000', '11111111-1111-1111-1111-111111111111', 'authenticated', 'authenticated', 'u1@example.com', now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '22222222-2222-2222-2222-222222222222', 'authenticated', 'authenticated', 'u2@example.com', now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '33333333-3333-3333-3333-333333333333', 'authenticated', 'authenticated', 'u3@example.com', now(), now());
+
+insert into public.organizations (id, name, created_by)
+values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Org One', '11111111-1111-1111-1111-111111111111');
+
+insert into public.memberships (org_id, user_id, role)
+values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', 'admin');
+
+-- Admin's per-user config carries the shared fields the invitee should inherit,
+-- plus a local-only field (repoPaths) that must NOT leak through the RPC.
+insert into public.configs (org_id, user_id, data)
+values (
+  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  '11111111-1111-1111-1111-111111111111',
+  '{"languages":{"commit":"en"},"commit":{"format":"conventional"},"pullRequest":{"autoLinkTickets":true},"repoKeywords":{"api":["api","backend"]},"repoPaths":{"api":"/local/only"}}'::jsonb
+);
+
+-- A pending invite for u2, a revoked invite (token reuse), and an expired invite.
+insert into public.invitations (org_id, email, role, token, status, expires_at)
+values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'u2@example.com', 'user', 'tok-pending', 'pending', now() + interval '7 days'),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'u3@example.com', 'user', 'tok-revoked', 'revoked', now() + interval '7 days'),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'u2@example.com', 'user', 'tok-expired', 'pending', now() - interval '1 day');
+
+-- ---------------------------------------------------------------------------
+-- Context: authenticate as u2 (the invitee)
+-- ---------------------------------------------------------------------------
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","email":"u2@example.com"}';
+
+-- 1. Accepting a valid pending invite returns the joined org_id.
+select is(
+  public.accept_invitation('tok-pending'),
+  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+  'accept_invitation returns the org_id'
+);
+
+-- 2. The membership now exists (read back as owner to bypass RLS below).
+reset role;
+select is(
+  (select count(*) from public.memberships
+   where org_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+     and user_id = '22222222-2222-2222-2222-222222222222'),
+  1::bigint,
+  'accept_invitation creates the membership'
+);
+
+-- 3. The invitation is now marked accepted.
+select is(
+  (select status::text from public.invitations where token = 'tok-pending'),
+  'accepted',
+  'accept_invitation marks the invitation accepted'
+);
+
+-- 4. Re-accepting an already-accepted invite is rejected.
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","email":"u2@example.com"}';
+select throws_ok(
+  $sql$ select public.accept_invitation('tok-pending') $sql$,
+  'invitation is not pending (status: accepted)',
+  're-accepting an accepted invitation is rejected'
+);
+
+-- 5. An expired invite is rejected.
+select throws_ok(
+  $sql$ select public.accept_invitation('tok-expired') $sql$,
+  'invitation has expired',
+  'an expired invitation is rejected'
+);
+
+-- 6. An email mismatch is rejected (u3 cannot accept a u2-addressed invite).
+reset role;
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"33333333-3333-3333-3333-333333333333","email":"u3@example.com"}';
+select throws_ok(
+  $sql$ select public.accept_invitation('tok-revoked') $sql$,
+  'invitation is not pending (status: revoked)',
+  'a revoked invitation is rejected'
+);
+
+-- ---------------------------------------------------------------------------
+-- get_org_shared_config
+-- ---------------------------------------------------------------------------
+-- 7. A member (u2, joined above) inherits only the shared fields — the admin's
+--    local-only repoPaths must not be present.
+reset role;
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","email":"u2@example.com"}';
+select is(
+  public.get_org_shared_config('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+  '{"commit":{"format":"conventional"},"languages":{"commit":"en"},"pullRequest":{"autoLinkTickets":true},"repoKeywords":{"api":["api","backend"]}}'::jsonb,
+  'get_org_shared_config returns only the shared fields'
+);
+
+-- 8. A non-member (u3) is rejected.
+reset role;
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"33333333-3333-3333-3333-333333333333","email":"u3@example.com"}';
+select throws_ok(
+  $sql$ select public.get_org_shared_config('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa') $sql$,
+  'not a member of this organization',
+  'get_org_shared_config rejects a non-member'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Description

Connects the desktop app to Supabase for **optional** authentication, organization management (members + invitations), and invitation-based onboarding. Cloud is entirely opt-in and fail-safe: with no Supabase env baked in, cloud UI is hidden and the app boots and works 100% offline. Part of epic #121, builds on the PR 1 schema.

The invitee inherits the org's shared config (languages, commit/PR format, repo keywords) and only configures the irreducibly local bits (repo paths), reducing install friction. No GitHub/Atlassian tokens are stored: GitHub uses `gh auth` detection (display only) and Atlassian remains a toggle handled by its MCP server.

## Related Issue

Closes #124

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- Supabase foundation: lazy client factory with `isCloudEnabled()` and a `safeStorage`-encrypted session store whose `loadSession()` never throws at boot
- Main-process auth (`signIn`/`signUp`/`signOut`/`getStatus`) with two sign-up branches — normal (creates a personal org via `create_organization`) and invitation (no forced personal org)
- Main-process org module: current org, members, invitations, `acceptInvitation` (creates membership first, then merges org shared config, preserving local repo paths + toggles)
- IPC handlers `auth:login/logout/status` and `org:current/members/invite/accept`, plus `config:getGitHubAuthStatus` / `config:setIntegration`, wired through the preload bridge with global types; auth emits `auth:statusChanged`
- Supabase migration: `accept_invitation(token)` (SECURITY DEFINER — validates pending/unexpired + JWT email match, atomically creates membership and marks accepted) and `get_org_shared_config(org_id)` (member-gated, returns only shared fields)
- Renderer: skippable `LoginScreen`, `InvitationOnboardingWizard`, and a Config → Organization tab; `useAuth`/`useOrg` hooks; `gh auth status` detection for display (no token stored); Atlassian shown as a toggle only
- Tests: unit tests for `getGitHubAuthStatus`/`parseGhAccount` and `mergeOrgSharedConfig`; pgTAP coverage for the two new RPCs

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

### Test Steps

1. Run the app with no Supabase env set (`npm run desktop`) → it boots and every feature works; no login/org UI blocks startup and no cloud tab errors appear.
2. Set `MAGIC_SLASH_SUPABASE_URL` and `MAGIC_SLASH_SUPABASE_ANON_KEY`, rebuild, open **Config → Organization → Sign up** with email + password + org name → account is created, you are logged in, and a personal org is shown.
3. As an admin, invite a colleague by email from the Organization tab → the invitation appears in the pending list.
4. As the invitee, open the invitation onboarding wizard with the token → sign up/in → the invitation is accepted and you join the org; the wizard asks only for repo paths, and the shared config (languages, commit/PR format, keywords) is inherited while local repo paths are preserved.
5. Restart the app → the session persists via the OS keychain and you remain logged in.
6. Run `npm test` and `cd desktop && npm run typecheck` → all tests pass (196) and typecheck is clean.

## Screenshots

N/A — reviewers can exercise the flows via the Config → Organization tab (see Test Steps).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

- Cloud is disabled by default: the env `define` in `vite.config.ts` ships empty, so `MAGIC_SLASH_SUPABASE_*` references are replaced with empty strings and cloud features stay hidden.
- No secrets are committed; the anon key is public by design with RLS as the real access gate.
- pgTAP tests were not executed live (they require a Docker-backed local Supabase stack) but follow the existing `rls_isolation.test.sql` pattern.
- Known follow-ups: member emails other than the caller's are not exposed by RLS (shown as user id); the org shared-config writer is not populated yet, so `get_org_shared_config` returns `{}` until a later PR wires it.