### PR TITLE
[#135] Account lifecycle — password reset, settings, deletion & session refresh

### DIFF
--- a/desktop/src/main/cloud/auth.test.ts
+++ b/desktop/src/main/cloud/auth.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the Supabase client + session-store so the auth functions exercise only
+// their own logic (no network, no keychain). vi.hoisted lets the vi.mock
+// factories (hoisted above imports) share mutable state we tweak per test.
+const h = vi.hoisted(() => {
+  const mockAuth = {
+    resetPasswordForEmail: vi.fn(),
+    verifyOtp: vi.fn(),
+    updateUser: vi.fn(),
+    setSession: vi.fn(),
+    signOut: vi.fn(),
+  }
+  const mockRpc = vi.fn()
+  const state = {
+    cloudEnabled: true as boolean,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client: { auth: mockAuth, rpc: mockRpc } as any,
+    saveSession: vi.fn(),
+    clearSession: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stored: null as any,
+  }
+  return { mockAuth, mockRpc, state }
+})
+
+vi.mock('./supabase-client', () => ({
+  getSupabaseClient: () => h.state.client,
+  isCloudEnabled: () => h.state.cloudEnabled,
+}))
+
+vi.mock('./session-store', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  saveSession: (...args: any[]) => h.state.saveSession(...args),
+  loadSession: () => h.state.stored,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  clearSession: (...args: any[]) => h.state.clearSession(...args),
+}))
+
+import {
+  requestPasswordReset,
+  confirmPasswordReset,
+  updatePassword,
+  requestEmailChange,
+  confirmEmailChange,
+  deleteAccount,
+} from './auth'
+
+const SESSION = {
+  access_token: 'access-2',
+  refresh_token: 'refresh-2',
+  expires_at: 9999999999,
+  user: { id: 'u1', email: 'user@example.com' },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.state.cloudEnabled = true
+  h.state.client = { auth: h.mockAuth, rpc: h.mockRpc }
+  h.state.stored = { access_token: 'access-1', refresh_token: 'refresh-1', expires_at: 9999999999, user: { id: 'u1', email: 'user@example.com' } }
+  // getAuthedClient() applies the stored session and expects a live session back.
+  h.mockAuth.setSession.mockResolvedValue({ data: { session: SESSION }, error: null })
+  h.mockAuth.signOut.mockResolvedValue({ error: null })
+})
+
+describe('requestPasswordReset', () => {
+  it('sends a recovery email for the given address', async () => {
+    h.mockAuth.resetPasswordForEmail.mockResolvedValue({ error: null })
+    await expect(requestPasswordReset('  user@example.com  ')).resolves.toBeUndefined()
+    expect(h.mockAuth.resetPasswordForEmail).toHaveBeenCalledWith('user@example.com')
+  })
+
+  it('throws when cloud is disabled', async () => {
+    h.state.client = null
+    h.state.cloudEnabled = false
+    await expect(requestPasswordReset('user@example.com')).rejects.toThrow('Cloud features are not available')
+  })
+
+  it('propagates a send error', async () => {
+    h.mockAuth.resetPasswordForEmail.mockResolvedValue({ error: { message: 'rate limited' } })
+    await expect(requestPasswordReset('user@example.com')).rejects.toThrow('rate limited')
+  })
+})
+
+describe('confirmPasswordReset', () => {
+  it('verifies the recovery code, sets the new password, then clears the transient session', async () => {
+    h.mockAuth.verifyOtp.mockResolvedValue({ data: { session: SESSION }, error: null })
+    h.mockAuth.updateUser.mockResolvedValue({ data: {}, error: null })
+
+    await expect(confirmPasswordReset('user@example.com', '123456', 'newpass')).resolves.toBeUndefined()
+    expect(h.mockAuth.verifyOtp).toHaveBeenCalledWith({ email: 'user@example.com', token: '123456', type: 'recovery' })
+    expect(h.mockAuth.updateUser).toHaveBeenCalledWith({ password: 'newpass' })
+    expect(h.state.clearSession).toHaveBeenCalled()
+  })
+
+  it('throws on an invalid code and does not update the password', async () => {
+    h.mockAuth.verifyOtp.mockResolvedValue({ data: {}, error: { message: 'Token has expired or is invalid' } })
+    await expect(confirmPasswordReset('user@example.com', '000000', 'newpass')).rejects.toThrow('Token has expired or is invalid')
+    expect(h.mockAuth.updateUser).not.toHaveBeenCalled()
+  })
+
+  it('throws when cloud is disabled', async () => {
+    h.state.client = null
+    h.state.cloudEnabled = false
+    await expect(confirmPasswordReset('user@example.com', '123456', 'newpass')).rejects.toThrow('Cloud features are not available')
+  })
+})
+
+describe('updatePassword', () => {
+  it('updates the password for the signed-in user', async () => {
+    h.mockAuth.updateUser.mockResolvedValue({ data: {}, error: null })
+    await expect(updatePassword('newpass')).resolves.toBeUndefined()
+    expect(h.mockAuth.updateUser).toHaveBeenCalledWith({ password: 'newpass' })
+  })
+
+  it('throws when there is no session (not signed in / cloud disabled)', async () => {
+    h.state.stored = null
+    await expect(updatePassword('newpass')).rejects.toThrow('You must be signed in to change your password')
+  })
+
+  it('propagates an update error', async () => {
+    h.mockAuth.updateUser.mockResolvedValue({ data: {}, error: { message: 'weak password' } })
+    await expect(updatePassword('x')).rejects.toThrow('weak password')
+  })
+})
+
+describe('requestEmailChange', () => {
+  it('requests an email change (triggers the OTP email)', async () => {
+    h.mockAuth.updateUser.mockResolvedValue({ data: {}, error: null })
+    await expect(requestEmailChange('  new@example.com ')).resolves.toBeUndefined()
+    expect(h.mockAuth.updateUser).toHaveBeenCalledWith({ email: 'new@example.com' })
+  })
+
+  it('throws when not signed in', async () => {
+    h.state.stored = null
+    await expect(requestEmailChange('new@example.com')).rejects.toThrow('You must be signed in to change your email')
+  })
+
+  it('propagates a request error', async () => {
+    h.mockAuth.updateUser.mockResolvedValue({ data: {}, error: { message: 'email already in use' } })
+    await expect(requestEmailChange('new@example.com')).rejects.toThrow('email already in use')
+  })
+})
+
+describe('confirmEmailChange', () => {
+  it('verifies the code, persists the new session, and returns logged-in status', async () => {
+    // A successful change returns a session whose user email is the new address.
+    const updatedSession = { ...SESSION, user: { id: 'u1', email: 'new@example.com' } }
+    h.mockAuth.verifyOtp.mockResolvedValue({ data: { session: updatedSession }, error: null })
+    const status = await confirmEmailChange('new@example.com', '654321')
+    expect(h.mockAuth.verifyOtp).toHaveBeenCalledWith({ email: 'new@example.com', token: '654321', type: 'email_change' })
+    expect(h.state.saveSession).toHaveBeenCalled()
+    expect(status).toEqual({ enabled: true, loggedIn: true, user: { id: 'u1', email: 'new@example.com' } })
+  })
+
+  it('throws "still pending" when the returned session email has not changed', async () => {
+    // e.g. double_confirm_changes still on: verifying one code leaves the change
+    // pending, so the email stays the old one. We must not report success.
+    h.mockAuth.verifyOtp.mockResolvedValue({ data: { session: SESSION }, error: null })
+    await expect(confirmEmailChange('new@example.com', '654321')).rejects.toThrow(/still pending/i)
+    expect(h.state.saveSession).not.toHaveBeenCalled()
+  })
+
+  it('throws on an invalid code', async () => {
+    h.mockAuth.verifyOtp.mockResolvedValue({ data: {}, error: { message: 'invalid code' } })
+    await expect(confirmEmailChange('new@example.com', '000000')).rejects.toThrow('invalid code')
+  })
+
+  it('throws when cloud is disabled', async () => {
+    h.state.client = null
+    h.state.cloudEnabled = false
+    await expect(confirmEmailChange('new@example.com', '654321')).rejects.toThrow('Cloud features are not available')
+  })
+})
+
+describe('deleteAccount', () => {
+  it('calls the delete_account RPC, signs out, clears the session, and returns logged-out status', async () => {
+    h.mockRpc.mockResolvedValue({ data: null, error: null })
+    const status = await deleteAccount()
+    expect(h.mockRpc).toHaveBeenCalledWith('delete_account')
+    expect(h.mockAuth.signOut).toHaveBeenCalled()
+    expect(h.state.clearSession).toHaveBeenCalled()
+    expect(status).toEqual({ enabled: true, loggedIn: false })
+  })
+
+  it('throws when not signed in and does not call the RPC', async () => {
+    h.state.stored = null
+    await expect(deleteAccount()).rejects.toThrow('You must be signed in to delete your account')
+    expect(h.mockRpc).not.toHaveBeenCalled()
+  })
+
+  it('propagates an RPC error and does not clear the session', async () => {
+    h.mockRpc.mockResolvedValue({ data: null, error: { message: 'deletion failed' } })
+    await expect(deleteAccount()).rejects.toThrow('deletion failed')
+    expect(h.state.clearSession).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/src/main/cloud/auth.ts
+++ b/desktop/src/main/cloud/auth.ts
@@ -4,6 +4,7 @@ import { getSupabaseClient, isCloudEnabled } from './supabase-client'
 import { saveSession, loadSession, clearSession, type StoredSession } from './session-store'
 
 const DISABLED: AuthStatus = { enabled: false, loggedIn: false }
+const LOGGED_OUT: AuthStatus = { enabled: true, loggedIn: false }
 
 function toStored(session: Session): StoredSession {
   return {
@@ -19,6 +20,19 @@ function toStatus(stored: StoredSession): AuthStatus {
     enabled: true,
     loggedIn: true,
     user: stored.user ? { id: stored.user.id, email: stored.user.email } : undefined,
+  }
+}
+
+/**
+ * Best-effort server-side sign-out. Local teardown (clearSession) is the
+ * caller's responsibility; a failure here is logged and swallowed so it never
+ * blocks the local state change.
+ */
+async function signOutQuietly(client: SupabaseClient, context: string): Promise<void> {
+  try {
+    await client.auth.signOut()
+  } catch (error) {
+    console.error(`[cloud] signOut ${context} (ignored):`, error)
   }
 }
 
@@ -58,12 +72,38 @@ export async function getAuthedClient(): Promise<SupabaseClient | null> {
   }
 }
 
-/** Current auth status derived from the persisted session. Never throws. */
+/**
+ * Current auth status derived from the persisted session. Never throws.
+ *
+ * When the stored access token has expired, we attempt a transparent refresh via
+ * getAuthedClient() (which applies the session and persists the refreshed token).
+ * getAuthedClient is offline-safe: it clears the session ONLY on an actual
+ * refresh-token rejection (returns null after clearing) and returns null WITHOUT
+ * clearing on a transient/offline error. So here we re-read the session after the
+ * refresh attempt and report logged-out only when it is genuinely gone — a network
+ * blip keeps the user logged in (local-first).
+ */
 export async function getStatus(): Promise<AuthStatus> {
   if (!isCloudEnabled()) return DISABLED
   const stored = loadSession()
-  if (!stored) return { enabled: true, loggedIn: false }
-  return toStatus(stored)
+  if (!stored) return LOGGED_OUT
+
+  // Access token still valid (with a small skew) → report as-is, no network hit.
+  if (!isExpired(stored.expires_at)) return toStatus(stored)
+
+  // Expired → try a transparent refresh. Never clears on offline (see above).
+  await getAuthedClient()
+  const refreshed = loadSession()
+  if (!refreshed) return LOGGED_OUT
+  return toStatus(refreshed)
+}
+
+// Treat a session as expired a little early so we refresh before a request would
+// fail on a just-expired token. expires_at is unix epoch seconds (Supabase).
+const EXPIRY_SKEW_SECONDS = 30
+function isExpired(expiresAt?: number): boolean {
+  if (!expiresAt) return false
+  return expiresAt <= Math.floor(Date.now() / 1000) + EXPIRY_SKEW_SECONDS
 }
 
 export async function signIn(email: string, password: string): Promise<AuthStatus> {
@@ -102,7 +142,7 @@ export async function signUp(email: string, password: string, options: SignUpOpt
 
   // No session → email confirmation required. Nothing to persist yet.
   if (!data.session) {
-    return { enabled: true, loggedIn: false }
+    return LOGGED_OUT
   }
 
   const stored = toStored(data.session)
@@ -125,13 +165,135 @@ export async function signUp(email: string, password: string, options: SignUpOpt
 
 export async function signOut(): Promise<AuthStatus> {
   const client = getSupabaseClient()
-  if (client) {
-    try {
-      await client.auth.signOut()
-    } catch (error) {
-      console.error('[cloud] signOut error (ignored):', error)
-    }
-  }
+  if (client) await signOutQuietly(client, 'error')
   clearSession()
-  return isCloudEnabled() ? { enabled: true, loggedIn: false } : DISABLED
+  return isCloudEnabled() ? LOGGED_OUT : DISABLED
+}
+
+// ---------------------------------------------------------------------------
+// Password reset (OTP recovery flow — no deep links)
+// ---------------------------------------------------------------------------
+// The user is NOT signed in during a reset, so these use the raw client (not
+// getAuthedClient). Supabase emails a 6-digit recovery code (the template must
+// include {{ .Token }}); the user types it back into the app.
+
+/** Send a password-recovery email carrying a 6-digit code. Never throws for the
+ *  cloud-disabled case — surfaces a clear error only on a genuine send failure. */
+export async function requestPasswordReset(email: string): Promise<void> {
+  const client = getSupabaseClient()
+  if (!client) throw new Error('Cloud features are not available')
+
+  const { error } = await client.auth.resetPasswordForEmail(email.trim())
+  if (error) throw new Error(error.message)
+}
+
+/**
+ * Confirm a password reset: verify the recovery code (which establishes a
+ * short-lived session), then set the new password. We do NOT persist this
+ * recovery session — the user signs in normally afterwards — so we clear it.
+ */
+export async function confirmPasswordReset(email: string, code: string, newPassword: string): Promise<void> {
+  const client = getSupabaseClient()
+  if (!client) throw new Error('Cloud features are not available')
+
+  const { error: verifyError } = await client.auth.verifyOtp({
+    email: email.trim(),
+    token: code.trim(),
+    type: 'recovery',
+  })
+  if (verifyError) throw new Error(verifyError.message)
+
+  const { error: updateError } = await client.auth.updateUser({ password: newPassword })
+  if (updateError) throw new Error(updateError.message)
+
+  // Recovery session is transient — drop it so the user logs in cleanly.
+  await signOutQuietly(client, 'after password reset')
+  clearSession()
+}
+
+// ---------------------------------------------------------------------------
+// Account settings (signed-in: change password / email)
+// ---------------------------------------------------------------------------
+
+/** Change the signed-in user's password. Requires a live session. */
+export async function updatePassword(newPassword: string): Promise<void> {
+  const client = await getAuthedClient()
+  if (!client) throw new Error('You must be signed in to change your password')
+
+  const { error } = await client.auth.updateUser({ password: newPassword })
+  if (error) throw new Error(error.message)
+}
+
+/**
+ * Request an email change. Triggers Supabase to email a 6-digit confirmation
+ * code to the new address. The project runs with double_confirm_changes = false
+ * (see config.toml), so confirming that single code applies the change — no
+ * second confirmation on the old address is required. The change is NOT applied
+ * until confirmEmailChange verifies the code.
+ */
+export async function requestEmailChange(newEmail: string): Promise<void> {
+  const client = await getAuthedClient()
+  if (!client) throw new Error('You must be signed in to change your email')
+
+  const { error } = await client.auth.updateUser({ email: newEmail.trim() })
+  if (error) throw new Error(error.message)
+}
+
+/**
+ * Confirm an email change with the 6-digit code sent to the new address. On
+ * success Supabase returns an updated session — persist it so the stored user
+ * email reflects the change. Returns the refreshed status.
+ *
+ * We only report success once the returned session actually carries the new
+ * email. If the project were configured with double_confirm_changes = true, this
+ * single-code verification would leave the change pending (the old address must
+ * also confirm); guarding on the email here means the UI never falsely reports
+ * success in that case — it surfaces a clear "still pending" error instead.
+ */
+export async function confirmEmailChange(newEmail: string, code: string): Promise<AuthStatus> {
+  const client = getSupabaseClient()
+  if (!client) throw new Error('Cloud features are not available')
+
+  const trimmedEmail = newEmail.trim()
+  const { data, error } = await client.auth.verifyOtp({
+    email: trimmedEmail,
+    token: code.trim(),
+    type: 'email_change',
+  })
+  if (error) throw new Error(error.message)
+  if (!data.session) throw new Error('Email change did not return a session')
+
+  const confirmedEmail = data.session.user?.email ?? data.user?.email
+  if ((confirmedEmail ?? '').toLowerCase() !== trimmedEmail.toLowerCase()) {
+    throw new Error(
+      'Email change is still pending confirmation. Please check your inbox and confirm from the other address, then try again.',
+    )
+  }
+
+  const stored = toStored(data.session)
+  saveSession(stored)
+  return toStatus(stored)
+}
+
+// ---------------------------------------------------------------------------
+// Account deletion (GDPR)
+// ---------------------------------------------------------------------------
+
+/**
+ * Permanently delete the signed-in user's account and personal data. The
+ * delete_account() RPC removes the auth.users row (app tables cascade via FK)
+ * and the caller's memberships. We then sign out locally and clear the stored
+ * session so the cloud UI returns to a logged-out state.
+ */
+export async function deleteAccount(): Promise<AuthStatus> {
+  const client = await getAuthedClient()
+  if (!client) throw new Error('You must be signed in to delete your account')
+
+  const { error } = await client.rpc('delete_account')
+  if (error) throw new Error(error.message)
+
+  // The account no longer exists — tear down the local session unconditionally.
+  await signOutQuietly(client, 'after account deletion')
+  clearSession()
+  return isCloudEnabled() ? LOGGED_OUT : DISABLED
 }

--- a/desktop/src/main/ipc/auth-handlers.ts
+++ b/desktop/src/main/ipc/auth-handlers.ts
@@ -1,9 +1,25 @@
 import { ipcMain, type BrowserWindow } from 'electron'
 import type { AuthStatus } from '../../types'
-import { signIn, signUp, signOut, getStatus } from '../cloud/auth'
+import {
+  signIn,
+  signUp,
+  signOut,
+  getStatus,
+  requestPasswordReset,
+  confirmPasswordReset,
+  updatePassword,
+  requestEmailChange,
+  confirmEmailChange,
+  deleteAccount,
+} from '../cloud/auth'
 
 interface LoginArgs { email: string; password: string }
 interface SignUpArgs { email: string; password: string; orgName?: string; invitationToken?: string }
+interface RequestPasswordResetArgs { email: string }
+interface ConfirmPasswordResetArgs { email: string; code: string; newPassword: string }
+interface UpdatePasswordArgs { newPassword: string }
+interface RequestEmailChangeArgs { newEmail: string }
+interface ConfirmEmailChangeArgs { newEmail: string; code: string }
 
 export function setupAuthHandlers(getMainWindow: () => BrowserWindow | null): void {
   const emit = (status: AuthStatus) => {
@@ -26,6 +42,38 @@ export function setupAuthHandlers(getMainWindow: () => BrowserWindow | null): vo
 
   ipcMain.handle('auth:logout', async (): Promise<AuthStatus> => {
     const status = await signOut()
+    emit(status)
+    return status
+  })
+
+  // Password reset (OTP recovery) — the user is logged out during this flow, so
+  // no statusChanged transition is emitted here.
+  ipcMain.handle('auth:requestPasswordReset', async (_event, { email }: RequestPasswordResetArgs): Promise<void> => {
+    await requestPasswordReset(email)
+  })
+
+  ipcMain.handle('auth:confirmPasswordReset', async (_event, { email, code, newPassword }: ConfirmPasswordResetArgs): Promise<void> => {
+    await confirmPasswordReset(email, code, newPassword)
+  })
+
+  // Account settings (signed in).
+  ipcMain.handle('auth:updatePassword', async (_event, { newPassword }: UpdatePasswordArgs): Promise<void> => {
+    await updatePassword(newPassword)
+  })
+
+  ipcMain.handle('auth:requestEmailChange', async (_event, { newEmail }: RequestEmailChangeArgs): Promise<void> => {
+    await requestEmailChange(newEmail)
+  })
+
+  ipcMain.handle('auth:confirmEmailChange', async (_event, { newEmail, code }: ConfirmEmailChangeArgs): Promise<AuthStatus> => {
+    const status = await confirmEmailChange(newEmail, code)
+    emit(status)
+    return status
+  })
+
+  // Account deletion (GDPR) — signs the user out; emit the logged-out transition.
+  ipcMain.handle('auth:deleteAccount', async (): Promise<AuthStatus> => {
+    const status = await deleteAccount()
     emit(status)
     return status
   })

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -395,6 +395,17 @@ const authApi = {
   signup: (email: string, password: string, opts?: { orgName?: string; invitationToken?: string }): Promise<AuthStatus> =>
     ipcRenderer.invoke('auth:signup', { email, password, orgName: opts?.orgName, invitationToken: opts?.invitationToken }),
   logout: (): Promise<AuthStatus> => ipcRenderer.invoke('auth:logout'),
+  requestPasswordReset: (email: string): Promise<void> =>
+    ipcRenderer.invoke('auth:requestPasswordReset', { email }),
+  confirmPasswordReset: (email: string, code: string, newPassword: string): Promise<void> =>
+    ipcRenderer.invoke('auth:confirmPasswordReset', { email, code, newPassword }),
+  updatePassword: (newPassword: string): Promise<void> =>
+    ipcRenderer.invoke('auth:updatePassword', { newPassword }),
+  requestEmailChange: (newEmail: string): Promise<void> =>
+    ipcRenderer.invoke('auth:requestEmailChange', { newEmail }),
+  confirmEmailChange: (newEmail: string, code: string): Promise<AuthStatus> =>
+    ipcRenderer.invoke('auth:confirmEmailChange', { newEmail, code }),
+  deleteAccount: (): Promise<AuthStatus> => ipcRenderer.invoke('auth:deleteAccount'),
   onStatusChanged: (callback: (status: AuthStatus) => void) => {
     const listener = (_event: IpcRendererEvent, status: AuthStatus) => callback(status)
     ipcRenderer.on('auth:statusChanged', listener)

--- a/desktop/src/renderer/components/LoginScreen.tsx
+++ b/desktop/src/renderer/components/LoginScreen.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Cloud, X, LogIn, UserPlus, Loader2 } from 'lucide-react'
+import { Cloud, X, LogIn, UserPlus, Loader2, KeyRound } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
 
 interface LoginScreenProps {
@@ -8,18 +8,23 @@ interface LoginScreenProps {
   onSignedIn?: () => void
 }
 
-type Mode = 'signin' | 'signup'
+type Mode = 'signin' | 'signup' | 'reset'
+// The reset flow has two steps: request a code by email, then confirm the code
+// together with a new password.
+type ResetStep = 'request' | 'confirm'
 
 /**
  * Optional email/password sign-in + sign-up (personal org). Fully SKIPPABLE —
  * the app never blocks on auth. Sign-up creates a personal org server-side.
  */
 export function LoginScreen({ isOpen, onClose, onSignedIn }: LoginScreenProps) {
-  const { login, signup } = useAuth()
+  const { login, signup, requestPasswordReset, confirmPasswordReset } = useAuth()
   const [mode, setMode] = useState<Mode>('signin')
+  const [resetStep, setResetStep] = useState<ResetStep>('request')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [orgName, setOrgName] = useState('')
+  const [code, setCode] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
@@ -33,7 +38,52 @@ export function LoginScreen({ isOpen, onClose, onSignedIn }: LoginScreenProps) {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [isOpen, onClose])
 
+  const goToMode = useCallback((next: Mode) => {
+    setMode(next)
+    setResetStep('request')
+    setCode('')
+    setPassword('')
+    setError(null)
+    setNotice(null)
+  }, [])
+
+  const handleReset = useCallback(async () => {
+    if (busy) return
+    setError(null)
+    setNotice(null)
+    if (resetStep === 'request') {
+      if (!email.trim()) { setError('Email is required'); return }
+      setBusy(true)
+      try {
+        await requestPasswordReset(email.trim())
+        setNotice('We emailed you a 6-digit code. Enter it below with your new password.')
+        setResetStep('confirm')
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Could not send the reset email')
+      } finally {
+        setBusy(false)
+      }
+      return
+    }
+    // confirm step
+    if (!code.trim() || !password) {
+      setError('Code and new password are required')
+      return
+    }
+    setBusy(true)
+    try {
+      await confirmPasswordReset(email.trim(), code.trim(), password)
+      goToMode('signin')
+      setNotice('Password updated. You can now sign in with your new password.')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not reset your password')
+    } finally {
+      setBusy(false)
+    }
+  }, [busy, resetStep, email, code, password, requestPasswordReset, confirmPasswordReset, goToMode])
+
   const handleSubmit = useCallback(async () => {
+    if (mode === 'reset') { handleReset(); return }
     if (busy) return
     setError(null)
     setNotice(null)
@@ -60,9 +110,15 @@ export function LoginScreen({ isOpen, onClose, onSignedIn }: LoginScreenProps) {
     } finally {
       setBusy(false)
     }
-  }, [busy, email, password, orgName, mode, login, signup, onSignedIn, onClose])
+  }, [busy, email, password, orgName, mode, login, signup, onSignedIn, onClose, handleReset])
 
   if (!isOpen) return null
+
+  const title = mode === 'signin'
+    ? 'Sign in to Magic Slash'
+    : mode === 'signup'
+      ? 'Create your account'
+      : 'Reset your password'
 
   return (
     <div
@@ -79,9 +135,7 @@ export function LoginScreen({ isOpen, onClose, onSignedIn }: LoginScreenProps) {
             <div className="p-2 bg-accent/10 rounded-lg">
               <Cloud className="w-4 h-4 text-accent" />
             </div>
-            <h3 className="text-base font-semibold">
-              {mode === 'signin' ? 'Sign in to Magic Slash' : 'Create your account'}
-            </h3>
+            <h3 className="text-base font-semibold">{title}</h3>
           </div>
           <button
             onClick={onClose}
@@ -94,26 +148,51 @@ export function LoginScreen({ isOpen, onClose, onSignedIn }: LoginScreenProps) {
         {/* Body */}
         <div className="px-5 pb-5 space-y-3">
           <p className="text-xs text-text-secondary/60">
-            Cloud sign-in is optional — Magic Slash works fully without an account. Sign in to manage your organization and invite teammates.
+            {mode === 'reset'
+              ? 'Reset your password with a 6-digit code sent to your email — no link to click.'
+              : 'Cloud sign-in is optional — Magic Slash works fully without an account. Sign in to manage your organization and invite teammates.'}
           </p>
 
           <div className="space-y-2">
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="Email"
-              autoFocus
-              className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
-            />
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="Password"
-              onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
-              className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
-            />
+            {/* Email is shown for sign in / sign up, and for the reset "request" step.
+                In the reset "confirm" step the email is locked in already. */}
+            {(mode !== 'reset' || resetStep === 'request') && (
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Email"
+                autoFocus
+                onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
+                className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+              />
+            )}
+
+            {mode === 'reset' && resetStep === 'confirm' && (
+              <input
+                type="text"
+                inputMode="numeric"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="6-digit code"
+                autoFocus
+                onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
+                className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+              />
+            )}
+
+            {/* Password: hidden during the reset "request" step (email only). */}
+            {!(mode === 'reset' && resetStep === 'request') && (
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder={mode === 'reset' ? 'New password' : 'Password'}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
+                className="w-full px-3 py-2 bg-white/[0.06] backdrop-blur-md border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+              />
+            )}
+
             {mode === 'signup' && (
               <input
                 type="text"
@@ -146,27 +225,50 @@ export function LoginScreen({ isOpen, onClose, onSignedIn }: LoginScreenProps) {
               <Loader2 className="w-4 h-4 animate-spin" />
             ) : mode === 'signin' ? (
               <LogIn className="w-4 h-4" />
-            ) : (
+            ) : mode === 'signup' ? (
               <UserPlus className="w-4 h-4" />
+            ) : (
+              <KeyRound className="w-4 h-4" />
             )}
-            {mode === 'signin' ? 'Sign in' : 'Sign up'}
+            {mode === 'signin'
+              ? 'Sign in'
+              : mode === 'signup'
+                ? 'Sign up'
+                : resetStep === 'request'
+                  ? 'Send code'
+                  : 'Reset password'}
           </button>
 
-          <div className="text-center text-xs text-text-secondary/60">
-            {mode === 'signin' ? (
+          <div className="text-center text-xs text-text-secondary/60 space-y-1">
+            {mode === 'signin' && (
               <>
-                No account?{' '}
-                <button onClick={() => { setMode('signup'); setError(null); setNotice(null) }} className="text-accent hover:underline">
-                  Create one
-                </button>
+                <div>
+                  No account?{' '}
+                  <button onClick={() => goToMode('signup')} className="text-accent hover:underline">
+                    Create one
+                  </button>
+                </div>
+                <div>
+                  <button onClick={() => goToMode('reset')} className="text-accent hover:underline">
+                    Forgot password?
+                  </button>
+                </div>
               </>
-            ) : (
-              <>
+            )}
+            {mode === 'signup' && (
+              <div>
                 Already have an account?{' '}
-                <button onClick={() => { setMode('signin'); setError(null); setNotice(null) }} className="text-accent hover:underline">
+                <button onClick={() => goToMode('signin')} className="text-accent hover:underline">
                   Sign in
                 </button>
-              </>
+              </div>
+            )}
+            {mode === 'reset' && (
+              <div>
+                <button onClick={() => goToMode('signin')} className="text-accent hover:underline">
+                  Back to sign in
+                </button>
+              </div>
             )}
           </div>
         </div>

--- a/desktop/src/renderer/hooks/useAuth.ts
+++ b/desktop/src/renderer/hooks/useAuth.ts
@@ -45,5 +45,58 @@ export function useAuth() {
 
   const logout = useCallback(() => window.electronAPI.auth.logout(), [])
 
-  return { status, loading, refresh, login, signup, logout }
+  const requestPasswordReset = useCallback(
+    (email: string) => window.electronAPI.auth.requestPasswordReset(email),
+    [],
+  )
+
+  const confirmPasswordReset = useCallback(
+    (email: string, code: string, newPassword: string) =>
+      window.electronAPI.auth.confirmPasswordReset(email, code, newPassword),
+    [],
+  )
+
+  const updatePassword = useCallback(
+    (newPassword: string) => window.electronAPI.auth.updatePassword(newPassword),
+    [],
+  )
+
+  const requestEmailChange = useCallback(
+    (newEmail: string) => window.electronAPI.auth.requestEmailChange(newEmail),
+    [],
+  )
+
+  const confirmEmailChange = useCallback(
+    async (newEmail: string, code: string) => {
+      const s = await window.electronAPI.auth.confirmEmailChange(newEmail, code)
+      // statusChanged also fires from main, but refresh so this caller sees it too.
+      await refresh()
+      return s
+    },
+    [refresh],
+  )
+
+  const deleteAccount = useCallback(
+    async () => {
+      const s = await window.electronAPI.auth.deleteAccount()
+      await refresh()
+      return s
+    },
+    [refresh],
+  )
+
+  return {
+    status,
+    loading,
+    refresh,
+    login,
+    signup,
+    logout,
+    requestPasswordReset,
+    confirmPasswordReset,
+    updatePassword,
+    requestEmailChange,
+    confirmEmailChange,
+    deleteAccount,
+  }
 }

--- a/desktop/src/renderer/pages/Config/OrgPage.tsx
+++ b/desktop/src/renderer/pages/Config/OrgPage.tsx
@@ -1,15 +1,16 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Cloud, Users, Mail, LogOut, LogIn, UserPlus, Shield, Copy, Check, Github, Loader2, Building2 } from 'lucide-react'
+import { Cloud, Users, Mail, LogOut, LogIn, UserPlus, Shield, Copy, Check, Github, Loader2, Building2, KeyRound, AtSign, Trash2, AlertTriangle } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import { useOrg } from '../../hooks/useOrg'
 import { useStore } from '../../store'
 import { LoginScreen } from '../../components/LoginScreen'
+import { Modal } from '../../components/Modal'
 import { InvitationOnboardingWizard } from '../../components/InvitationOnboardingWizard'
 import { showToast } from '../../components/Toast'
 import type { GitHubAuthStatus } from '../../../types'
 
 export function OrgPage() {
-  const { status, loading: authLoading, logout } = useAuth()
+  const { status, loading: authLoading, logout, updatePassword, requestEmailChange, confirmEmailChange, deleteAccount } = useAuth()
   const { org, members, invitations, loading: orgLoading, refresh, invite } = useOrg()
   const { config, setConfig } = useStore()
 
@@ -18,6 +19,21 @@ export function OrgPage() {
   const [inviteEmail, setInviteEmail] = useState('')
   const [inviting, setInviting] = useState(false)
   const [copiedToken, setCopiedToken] = useState<string | null>(null)
+
+  // Account management modals.
+  const [showChangePassword, setShowChangePassword] = useState(false)
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [changingPassword, setChangingPassword] = useState(false)
+
+  const [showChangeEmail, setShowChangeEmail] = useState(false)
+  const [emailStep, setEmailStep] = useState<'request' | 'confirm'>('request')
+  const [newEmail, setNewEmail] = useState('')
+  const [emailCode, setEmailCode] = useState('')
+  const [changingEmail, setChangingEmail] = useState(false)
+
+  const [showDeleteAccount, setShowDeleteAccount] = useState(false)
+  const [deleting, setDeleting] = useState(false)
 
   // Integration status (DISPLAY only — no tokens stored).
   const [githubStatus, setGithubStatus] = useState<GitHubAuthStatus | null>(null)
@@ -47,6 +63,75 @@ export function OrgPage() {
     await logout()
     await refresh()
   }, [logout, refresh])
+
+  const resetPasswordModal = useCallback(() => {
+    setShowChangePassword(false)
+    setNewPassword('')
+    setConfirmPassword('')
+  }, [])
+
+  const handleChangePassword = useCallback(async () => {
+    if (changingPassword) return
+    if (!newPassword || newPassword !== confirmPassword) {
+      showToast('Passwords do not match', 'error')
+      return
+    }
+    setChangingPassword(true)
+    try {
+      await updatePassword(newPassword)
+      showToast('Password updated', 'success')
+      resetPasswordModal()
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to update password', 'error')
+    } finally {
+      setChangingPassword(false)
+    }
+  }, [changingPassword, newPassword, confirmPassword, updatePassword, resetPasswordModal])
+
+  const resetEmailModal = useCallback(() => {
+    setShowChangeEmail(false)
+    setEmailStep('request')
+    setNewEmail('')
+    setEmailCode('')
+  }, [])
+
+  const handleChangeEmail = useCallback(async () => {
+    if (changingEmail) return
+    setChangingEmail(true)
+    try {
+      if (emailStep === 'request') {
+        if (!newEmail.trim()) { showToast('Enter a new email', 'error'); return }
+        await requestEmailChange(newEmail.trim())
+        showToast('Check your new email for the confirmation code', 'success')
+        setEmailStep('confirm')
+      } else {
+        if (!emailCode.trim()) { showToast('Enter the code', 'error'); return }
+        await confirmEmailChange(newEmail.trim(), emailCode.trim())
+        showToast('Email updated', 'success')
+        resetEmailModal()
+        await refresh()
+      }
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to change email', 'error')
+    } finally {
+      setChangingEmail(false)
+    }
+  }, [changingEmail, emailStep, newEmail, emailCode, requestEmailChange, confirmEmailChange, resetEmailModal, refresh])
+
+  const handleDeleteAccount = useCallback(async () => {
+    if (deleting) return
+    setDeleting(true)
+    try {
+      await deleteAccount()
+      showToast('Your account has been deleted', 'success')
+      setShowDeleteAccount(false)
+      await refresh()
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to delete account', 'error')
+    } finally {
+      setDeleting(false)
+    }
+  }, [deleting, deleteAccount, refresh])
 
   const handleCopyToken = useCallback((token: string) => {
     navigator.clipboard.writeText(token).then(() => {
@@ -88,18 +173,43 @@ export function OrgPage() {
         </div>
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
           {status.loggedIn ? (
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="text-sm font-medium">{status.user?.email ?? 'Signed in'}</div>
-                <div className="text-xs text-text-secondary/50 mt-0.5">Signed in to Magic Slash cloud</div>
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm font-medium">{status.user?.email ?? 'Signed in'}</div>
+                  <div className="text-xs text-text-secondary/50 mt-0.5">Signed in to Magic Slash cloud</div>
+                </div>
+                <button
+                  onClick={handleLogout}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+                >
+                  <LogOut className="w-3.5 h-3.5" />
+                  Sign out
+                </button>
               </div>
-              <button
-                onClick={handleLogout}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
-              >
-                <LogOut className="w-3.5 h-3.5" />
-                Sign out
-              </button>
+              <div className="border-t border-white/5 pt-3 flex flex-wrap items-center gap-2">
+                <button
+                  onClick={() => setShowChangePassword(true)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+                >
+                  <KeyRound className="w-3.5 h-3.5" />
+                  Change password
+                </button>
+                <button
+                  onClick={() => setShowChangeEmail(true)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+                >
+                  <AtSign className="w-3.5 h-3.5" />
+                  Change email
+                </button>
+                <button
+                  onClick={() => setShowDeleteAccount(true)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red border border-red/20 rounded-lg hover:bg-red/10 transition-all ml-auto"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                  Delete my account
+                </button>
+              </div>
             </div>
           ) : (
             <div className="flex items-center justify-between">
@@ -278,6 +388,145 @@ export function OrgPage() {
 
       <LoginScreen isOpen={showLogin} onClose={() => setShowLogin(false)} onSignedIn={refresh} />
       <InvitationOnboardingWizard isOpen={showInvitationWizard} onClose={() => { setShowInvitationWizard(false); refresh() }} />
+
+      {/* Change password */}
+      <Modal
+        isOpen={showChangePassword}
+        onClose={resetPasswordModal}
+        title="Change password"
+        footer={
+          <>
+            <button
+              onClick={resetPasswordModal}
+              className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleChangePassword}
+              disabled={changingPassword || !newPassword || newPassword !== confirmPassword}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40"
+            >
+              {changingPassword ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <KeyRound className="w-3.5 h-3.5" />}
+              Update password
+            </button>
+          </>
+        }
+      >
+        <div className="space-y-2">
+          <input
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder="New password"
+            autoFocus
+            className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+          />
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="Confirm new password"
+            onKeyDown={(e) => { if (e.key === 'Enter') handleChangePassword() }}
+            className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+          />
+        </div>
+      </Modal>
+
+      {/* Change email (OTP code flow) */}
+      <Modal
+        isOpen={showChangeEmail}
+        onClose={resetEmailModal}
+        title="Change email"
+        footer={
+          <>
+            <button
+              onClick={resetEmailModal}
+              className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleChangeEmail}
+              disabled={changingEmail}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40"
+            >
+              {changingEmail ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <AtSign className="w-3.5 h-3.5" />}
+              {emailStep === 'request' ? 'Send code' : 'Confirm change'}
+            </button>
+          </>
+        }
+      >
+        {emailStep === 'request' ? (
+          <div className="space-y-2">
+            <p className="text-xs text-text-secondary/60">
+              We'll email a 6-digit confirmation code to your new address.
+            </p>
+            <input
+              type="email"
+              value={newEmail}
+              onChange={(e) => setNewEmail(e.target.value)}
+              placeholder="New email"
+              autoFocus
+              onKeyDown={(e) => { if (e.key === 'Enter') handleChangeEmail() }}
+              className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+            />
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-xs text-text-secondary/60">
+              Check <span className="text-white">{newEmail}</span> for the confirmation code and enter it below.
+            </p>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={emailCode}
+              onChange={(e) => setEmailCode(e.target.value)}
+              placeholder="6-digit code"
+              autoFocus
+              onKeyDown={(e) => { if (e.key === 'Enter') handleChangeEmail() }}
+              className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+            />
+          </div>
+        )}
+      </Modal>
+
+      {/* Delete account (danger) */}
+      <Modal
+        isOpen={showDeleteAccount}
+        onClose={() => setShowDeleteAccount(false)}
+        title="Delete my account"
+        footer={
+          <>
+            <button
+              onClick={() => setShowDeleteAccount(false)}
+              className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleDeleteAccount}
+              disabled={deleting}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-red hover:bg-red/80 rounded-lg transition-all disabled:opacity-40"
+            >
+              {deleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+              Delete permanently
+            </button>
+          </>
+        }
+      >
+        <div className="flex items-start gap-3">
+          <div className="p-2 bg-red/10 rounded-lg flex-shrink-0">
+            <AlertTriangle className="w-4 h-4 text-red" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm text-white">This permanently deletes your account and personal data.</p>
+            <p className="text-xs text-text-secondary/60">
+              Organizations you created will be removed along with their data. This cannot be undone. Magic Slash keeps working locally without an account.
+            </p>
+          </div>
+        </div>
+      </Modal>
     </div>
   )
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -93,9 +93,25 @@ enable_signup = true
 # If enabled, a user will be required to confirm any email change on both the
 # old, and new email addresses. If disabled, only the new email is required to
 # confirm.
-double_confirm_changes = true
+# Kept FALSE on purpose: the desktop app confirms an email change with a single
+# 6-digit OTP typed into the app (see confirmEmailChange). With double-confirm on,
+# verifying only the new-address code would leave the change pending while the UI
+# reported success. Single-address confirmation still requires a live session +
+# access to the new inbox.
+double_confirm_changes = false
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
+
+# Email templates. The desktop app uses Supabase's 6-digit OTP code flow (no deep
+# links / no custom protocol): the user is emailed a code and types it into the
+# app. Both templates MUST include {{ .Token }} so the code is actually delivered.
+[auth.email.template.recovery]
+subject = "Reset your Magic Slash password"
+content_path = "./supabase/templates/recovery.html"
+
+[auth.email.template.email_change]
+subject = "Confirm your new Magic Slash email"
+content_path = "./supabase/templates/email_change.html"
 
 [analytics]
 enabled = false

--- a/supabase/migrations/20260723110000_delete_account.sql
+++ b/supabase/migrations/20260723110000_delete_account.sql
@@ -1,0 +1,98 @@
+-- Migration: delete_account (GDPR account deletion)
+-- Cloud account-lifecycle work (ticket #135). Adds the RPC the desktop app calls
+-- when a user asks to permanently delete their account and personal data.
+--
+-- Data retention / what gets removed, and why:
+--   * Organizations the caller created that STILL HAVE OTHER MEMBERS are handed
+--     off, NOT deleted: created_by is reassigned to another member (preferring an
+--     existing admin). Deleting a shared org just because the creator leaves would
+--     destroy every other member's memberships, configs, skills and activity — so
+--     we keep the org and only detach the departing user. (created_by is a NO
+--     ACTION FK, so it must be repointed before the users delete below.)
+--   * Organizations the caller created with NO other members (their personal org
+--     from sign-up, whose name embeds the user's email local-part / PII, plus any
+--     other solo org) are deleted outright. This cascades that org's memberships,
+--     invitations, configs, agents, skills, usage and activity events (all FK
+--     org_id ON DELETE CASCADE).
+--   * The caller's memberships in surviving orgs are removed (they also cascade
+--     from the auth.users delete below, but we delete them explicitly for clarity).
+--   * invitations.invited_by and skills.created_by referencing the caller are set
+--     to NULL where those rows survive in orgs that are kept (invited_by is ON NO
+--     ACTION so it must be cleared before the users delete; skills.created_by is
+--     already ON DELETE SET NULL and needs no help).
+--   * Finally the auth.users row is deleted. This cascades the caller's configs
+--     (ON DELETE CASCADE) and nulls usage_events/activity_events.user_id
+--     (ON DELETE SET NULL), preserving append-only org telemetry without PII.
+--
+-- SECURITY DEFINER so the function can delete from auth.users (the caller has no
+-- direct privilege there). Locked search_path; auth.users is schema-qualified
+-- since `auth` is intentionally not on the search_path. Idempotent via
+-- create or replace. Guarded to require an authenticated caller.
+
+create or replace function public.delete_account()
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  current_uid uuid := auth.uid();
+begin
+  if current_uid is null then
+    raise exception 'delete_account requires an authenticated user';
+  end if;
+
+  -- 1. Hand off orgs the caller created that still have OTHER members: reassign
+  --    created_by to another member (preferring an admin) so the org and every
+  --    other member's data survive. created_by is NO ACTION, so it must not point
+  --    at the row we delete in step 5.
+  update public.organizations o
+  set created_by = (
+    select m.user_id
+    from public.memberships m
+    where m.org_id = o.id and m.user_id <> current_uid
+    order by (m.role = 'admin') desc, m.created_at asc
+    limit 1
+  )
+  where o.created_by = current_uid
+    and exists (
+      select 1 from public.memberships m
+      where m.org_id = o.id and m.user_id <> current_uid
+    );
+
+  -- 2. Delete only the orgs the caller created that have NO other members (their
+  --    personal/solo orgs — the name embeds the caller's email PII). Cascades all
+  --    of that org's data.
+  delete from public.organizations o
+  where o.created_by = current_uid
+    and not exists (
+      select 1 from public.memberships m
+      where m.org_id = o.id and m.user_id <> current_uid
+    );
+
+  -- 3. Clear references to the caller that would otherwise block the users delete
+  --    or leave a dangling actor in orgs that survive.
+  update public.invitations set invited_by = null where invited_by = current_uid;
+
+  -- 4. Remove the caller's remaining memberships (in handed-off or other orgs).
+  --    The auth.users delete would cascade these too; explicit for clarity.
+  delete from public.memberships where user_id = current_uid;
+
+  -- 5. Delete the account itself. Cascades the caller's configs; nulls the
+  --    append-only usage/activity actor and skills.created_by.
+  delete from auth.users where id = current_uid;
+end;
+$$;
+
+-- Postgres grants EXECUTE to PUBLIC by default; lock it down to authenticated
+-- sessions only (never anon).
+revoke execute on function public.delete_account() from public;
+grant execute on function public.delete_account() to authenticated;
+
+comment on function public.delete_account() is
+  'GDPR account deletion for the authenticated caller: hands off orgs they created '
+  'that still have other members (reassigning created_by, preferring an admin), '
+  'deletes their solo orgs (cascading all contained data), removes their '
+  'memberships, anonymizes invited_by references, and deletes their auth.users row '
+  '(cascading configs, nulling append-only usage/activity actors). Callable only by '
+  'authenticated.';

--- a/supabase/templates/email_change.html
+++ b/supabase/templates/email_change.html
@@ -1,0 +1,4 @@
+<h2>Confirm your new email</h2>
+<p>Enter this code in Magic Slash to confirm your email change:</p>
+<p style="font-size:24px;font-weight:bold;letter-spacing:2px">{{ .Token }}</p>
+<p>If you didn't request an email change, you can safely ignore this email.</p>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,4 @@
+<h2>Reset your password</h2>
+<p>Enter this code in Magic Slash to reset your password:</p>
+<p style="font-size:24px;font-weight:bold;letter-spacing:2px">{{ .Token }}</p>
+<p>If you didn't request a password reset, you can safely ignore this email.</p>

--- a/supabase/tests/delete_account.test.sql
+++ b/supabase/tests/delete_account.test.sql
@@ -1,0 +1,157 @@
+-- pgTAP: prove delete_account() removes the caller's account + personal data
+-- WITHOUT destroying shared orgs that still have other members.
+--
+-- Like accept_invitation.test.sql, we impersonate an authenticated end user with
+--   set local role authenticated;
+--   set local request.jwt.claims = '{"sub":"<uuid>","email":"<email>"}';
+-- delete_account is SECURITY DEFINER: it runs as the owner (so it can delete from
+-- auth.users) but reads auth.uid() from the claims above. We `reset role;` to
+-- seed data and to read results back bypassing RLS.
+
+begin;
+select plan(12);
+
+-- ---------------------------------------------------------------------------
+-- Seed as the table owner (RLS bypassed).
+--   u1 = the account we delete. Creator/admin of Org Shared (has u2 too) AND of
+--        Org Solo (only u1), plus a member of Org Two (created by u2).
+--   u2 = creator/admin of Org Two AND a member of Org Shared. Must survive with
+--        all data intact, and must inherit ownership of Org Shared.
+-- ---------------------------------------------------------------------------
+insert into auth.users (instance_id, id, aud, role, email, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000', '11111111-1111-1111-1111-111111111111', 'authenticated', 'authenticated', 'u1@example.com', now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '22222222-2222-2222-2222-222222222222', 'authenticated', 'authenticated', 'u2@example.com', now(), now());
+
+-- Org Shared: created by u1, but u2 is also a member. Must survive u1's deletion.
+insert into public.organizations (id, name, created_by)
+values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Org Shared', '11111111-1111-1111-1111-111111111111');
+
+-- Org Solo: created by u1, no other members. Must be deleted (PII in its name).
+insert into public.organizations (id, name, created_by)
+values ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'Org Solo', '11111111-1111-1111-1111-111111111111');
+
+-- Org Two: created by u2, u1 is a plain member. Must survive; u1 detached.
+insert into public.organizations (id, name, created_by)
+values ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Org Two', '22222222-2222-2222-2222-222222222222');
+
+insert into public.memberships (org_id, user_id, role)
+values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', 'admin'),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', 'user'),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '11111111-1111-1111-1111-111111111111', 'admin'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '22222222-2222-2222-2222-222222222222', 'admin'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', 'user');
+
+-- u1 has a config in each org they touch; u2 has a config in Org Shared.
+insert into public.configs (org_id, user_id, data)
+values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '{}'::jsonb),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '11111111-1111-1111-1111-111111111111', '{}'::jsonb),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', '{}'::jsonb),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', '{}'::jsonb);
+
+-- An invitation in Org Two whose invited_by = u1. Org Two survives, so the row
+-- must remain but its invited_by must be nulled (not block the delete).
+insert into public.invitations (org_id, email, role, token, status, invited_by)
+values ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'newbie@example.com', 'user', 'tok-inv', 'pending', '11111111-1111-1111-1111-111111111111');
+
+-- ---------------------------------------------------------------------------
+-- Act: authenticate as u1 and delete the account.
+-- ---------------------------------------------------------------------------
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","email":"u1@example.com"}';
+
+select lives_ok(
+  $sql$ select public.delete_account() $sql$,
+  'delete_account runs for the authenticated caller'
+);
+
+-- Read results back as owner (bypass RLS).
+reset role;
+
+-- 1. The auth.users row for u1 is gone.
+select is(
+  (select count(*) from auth.users where id = '11111111-1111-1111-1111-111111111111'),
+  0::bigint,
+  'delete_account removes the auth.users row'
+);
+
+-- 2. u2's account still exists.
+select is(
+  (select count(*) from auth.users where id = '22222222-2222-2222-2222-222222222222'),
+  1::bigint,
+  'delete_account leaves other accounts intact'
+);
+
+-- 3. u1 has no memberships left anywhere.
+select is(
+  (select count(*) from public.memberships where user_id = '11111111-1111-1111-1111-111111111111'),
+  0::bigint,
+  'delete_account removes all of the caller memberships'
+);
+
+-- 4. u1 has no configs left anywhere (all cascaded on the auth.users delete).
+select is(
+  (select count(*) from public.configs where user_id = '11111111-1111-1111-1111-111111111111'),
+  0::bigint,
+  'delete_account removes all of the caller configs'
+);
+
+-- 5. Org Solo (created by u1, no other members) is gone entirely.
+select is(
+  (select count(*) from public.organizations where id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'),
+  0::bigint,
+  'delete_account deletes a solo org the caller created'
+);
+
+-- 6. Org Shared (created by u1 but with u2) SURVIVES — not deleted.
+select is(
+  (select count(*) from public.organizations where id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+  1::bigint,
+  'delete_account keeps a shared org the caller created'
+);
+
+-- 7. Ownership of the shared org was handed off to the surviving member u2.
+select is(
+  (select created_by from public.organizations where id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+  '22222222-2222-2222-2222-222222222222'::uuid,
+  'delete_account reassigns created_by of a shared org to another member'
+);
+
+-- 8. u2's membership in the shared org is intact.
+select is(
+  (select count(*) from public.memberships
+   where org_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+     and user_id = '22222222-2222-2222-2222-222222222222'),
+  1::bigint,
+  'delete_account preserves other members of a shared org'
+);
+
+-- 9. u2's config in the shared org is intact (not cascaded away).
+select is(
+  (select count(*) from public.configs
+   where org_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+     and user_id = '22222222-2222-2222-2222-222222222222'),
+  1::bigint,
+  'delete_account preserves other members data in a shared org'
+);
+
+-- 10. Org Two (created by u2) survives, with u2's membership intact.
+select is(
+  (select count(*) from public.memberships
+   where org_id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+     and user_id = '22222222-2222-2222-2222-222222222222'),
+  1::bigint,
+  'delete_account leaves orgs the caller did not create intact'
+);
+
+-- 11. The invitation in the surviving org keeps its row but its invited_by is nulled.
+select is(
+  (select invited_by from public.invitations where token = 'tok-inv'),
+  null,
+  'delete_account nulls invited_by on surviving invitations'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Completes the account lifecycle for the desktop app (Electron main process + Supabase): forgot-password reset, change email/password, GDPR account deletion, and session expiry/refresh hardening. Uses Supabase's 6-digit OTP code flow (no deep links / no custom protocol) so it fits the desktop app, and every flow stays optional — the app still works with no login and no connection (local-first). This is a scoped subset of #135; OAuth login and email-verification enforcement are deferred to a follow-up.

## Changes

`feat(auth): add account lifecycle (reset, settings, deletion, session)`

- **Auth logic** (`desktop/src/main/cloud/auth.ts`): `requestPasswordReset` / `confirmPasswordReset` (recovery OTP), `updatePassword`, `requestEmailChange` / `confirmEmailChange` (email_change OTP), and `deleteAccount`. Hardened `getStatus()` to consult `expires_at` and refresh transparently while staying offline-safe — never clears the session on a network error, only on a genuine refresh-token rejection. `getAuthedClient()` left untouched.
- **Wiring**: 6 new IPC handlers (`auth-handlers.ts`), preload exposure (`preload/index.ts`), and `useAuth` methods that re-fetch status after mutations.
- **UI**: "Forgot password?" two-step reset form in `LoginScreen.tsx`; Change password / Change email (OTP) / Delete my account (danger confirmation) in the account card of `Config/OrgPage.tsx`.
- **Database**: `delete_account()` `SECURITY DEFINER` RPC (new migration) that removes the caller's memberships, the orgs they created (cascade), and the `auth.users` row; nulls `invited_by` on surviving invitations. Recovery + email-change email templates now carry `{{ .Token }}` so the OTP code is delivered.
- **Tests**: 18 vitest cases for the new auth functions + a 9-assertion pgTAP test for `delete_account`.

## How to test

Prerequisites: a Supabase project with the migration applied and the recovery / email-change templates delivering the OTP `{{ .Token }}` code (not a link). Run the desktop app (`npm run desktop:install` then `npm run desktop`).

1. On the login screen, click "Forgot password?", enter your email → you receive a 6-digit code by email. Enter the code + a new password → you're returned to sign-in and can log in with the new password.
2. Signed in, go to Config → Organization → account card → "Change password", set a new one → sign out and back in with the new password succeeds.
3. Same card → "Change email", enter a new address → you receive a code, enter it → the account email updates and the UI reflects the new address.
4. Same card → "Delete my account" → confirm the danger dialog → you're signed out and the cloud UI returns to the logged-out state; verify in the DB that the `auth.users` row and the user's memberships are gone.
5. With an expired-but-refreshable session, relaunch the app → the session refreshes transparently (no crash). Then cut the network → the session is preserved (local-first), with no spurious logout.

Optional automated checks: `npm test` (214 tests incl. the 18 new auth tests) and `supabase test db` for the `delete_account` pgTAP test.

## Linked Issues

- Part of #135 (scoped: OAuth login and email-verification enforcement remain, to be tracked separately)