### PR TITLE
Add sidebar account button with login/sign-up entry point

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MAGIC_SLASH_SUPABASE_URL: ${{ secrets.MAGIC_SLASH_SUPABASE_URL }}
+          MAGIC_SLASH_SUPABASE_ANON_KEY: ${{ secrets.MAGIC_SLASH_SUPABASE_ANON_KEY }}
 
   notify:
     name: Post-Release

--- a/desktop/src/renderer/components/Sidebar.tsx
+++ b/desktop/src/renderer/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useScriptRunner } from '../hooks/useScriptRunner'
 import { useGroupedTerminals, useSplitGroupedTerminals, WORKFLOW_GROUPS, type WorkflowGroupKey, type TerminalWithRepos } from '../hooks/useGroupedTerminals'
 import { getProjectColorMap } from '../utils/projectColors'
 import { SidebarUsageCard } from './SidebarUsageCard'
+import { SidebarAccount } from './SidebarAccount'
 import { stateColors, stateBgColors, stateHoverBgColors } from '../utils/stateColors'
 import type { TerminalState, ScriptTerminalInfo } from '../../types'
 
@@ -609,6 +610,9 @@ export function Sidebar() {
 
       {/* Claude usage card */}
       {config?.usageCardEnabled && <SidebarUsageCard />}
+
+      {/* Account / login */}
+      <SidebarAccount />
 
       {/* Footer */}
       <div className="px-4 py-2 text-xs text-text-secondary flex items-center justify-start gap-2">

--- a/desktop/src/renderer/components/SidebarAccount.tsx
+++ b/desktop/src/renderer/components/SidebarAccount.tsx
@@ -1,0 +1,134 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { LogIn, LogOut, Building2, ChevronDown } from 'lucide-react'
+import { useAuth } from '../hooks/useAuth'
+import { useStore } from '../store'
+import { LoginScreen } from './LoginScreen'
+
+/**
+ * Derive a friendly display name from an email address. Until GitHub OAuth
+ * carries a real name (user_metadata.full_name), the local-part of the email is
+ * the best we have: "xavier@poppins.io" → "Xavier", "jean.dupont@x" → "Jean".
+ */
+function displayNameFromEmail(email?: string): string {
+  if (!email) return 'Account'
+  const local = email.split('@')[0]
+  const first = local.split(/[._+-]/)[0]
+  if (!first) return 'Account'
+  return first.charAt(0).toUpperCase() + first.slice(1)
+}
+
+/**
+ * Sidebar footer account control. Logged out → a "Login / Sign up" button that
+ * opens the existing email/password modal. Logged in → the user's first name
+ * with a small menu (organization, sign out). Hidden entirely when cloud is
+ * disabled, matching how the rest of the app treats `enabled: false`.
+ */
+export function SidebarAccount() {
+  const { status, logout } = useAuth()
+  const setCurrentPage = useStore((s) => s.setCurrentPage)
+  const setSettingsInitialTab = useStore((s) => s.setSettingsInitialTab)
+  const setActiveTerminal = useStore((s) => s.setActiveTerminal)
+
+  const [showLogin, setShowLogin] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Close the menu on outside click or Escape.
+  useEffect(() => {
+    if (!menuOpen) return
+    const onPointerDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); setMenuOpen(false) }
+    }
+    window.addEventListener('mousedown', onPointerDown)
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      window.removeEventListener('mousedown', onPointerDown)
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [menuOpen])
+
+  const openOrganization = useCallback(() => {
+    setMenuOpen(false)
+    setSettingsInitialTab('organization')
+    setActiveTerminal(null)
+    setCurrentPage('config')
+  }, [setSettingsInitialTab, setActiveTerminal, setCurrentPage])
+
+  const handleLogout = useCallback(async () => {
+    setMenuOpen(false)
+    try {
+      await logout()
+    } catch {
+      // logout is best-effort; the hook's statusChanged subscription reconciles state.
+    }
+  }, [logout])
+
+  // Cloud disabled → nothing to show.
+  if (!status.enabled) return null
+
+  if (!status.loggedIn) {
+    return (
+      <>
+        <div className="px-2 pb-2">
+          <button
+            onClick={() => setShowLogin(true)}
+            className="w-full flex items-center justify-center gap-2 px-2 py-2 text-xs font-medium text-text-secondary rounded-lg hover:bg-text-secondary/10 hover:text-white transition-all"
+          >
+            <LogIn className="w-3.5 h-3.5" />
+            <span>Login / Sign up</span>
+          </button>
+        </div>
+        {/* Portal to <body> so the fixed overlay covers the whole app, not just
+            the sidebar (the sidebar's backdrop-filter would otherwise be the
+            containing block for the fixed modal). */}
+        {createPortal(
+          <LoginScreen isOpen={showLogin} onClose={() => setShowLogin(false)} />,
+          document.body,
+        )}
+      </>
+    )
+  }
+
+  const name = displayNameFromEmail(status.user?.email)
+  const initial = name.charAt(0).toUpperCase()
+
+  return (
+    <div ref={containerRef} className="relative px-2 pb-2">
+      {menuOpen && (
+        <div className="absolute bottom-full left-2 right-2 mb-1 bg-bg-secondary border border-white/10 rounded-lg shadow-xl backdrop-blur-2xl overflow-hidden z-30">
+          <button
+            onClick={openOrganization}
+            className="w-full flex items-center gap-2 px-3 py-2 text-xs font-medium text-text-secondary hover:bg-white/10 hover:text-white transition-colors"
+          >
+            <Building2 className="w-3.5 h-3.5" />
+            <span>Account &amp; organization</span>
+          </button>
+          <button
+            onClick={handleLogout}
+            className="w-full flex items-center gap-2 px-3 py-2 text-xs font-medium text-text-secondary hover:bg-white/10 hover:text-white transition-colors"
+          >
+            <LogOut className="w-3.5 h-3.5" />
+            <span>Sign out</span>
+          </button>
+        </div>
+      )}
+
+      <button
+        onClick={() => setMenuOpen((o) => !o)}
+        className="w-full flex items-center gap-2 px-2 py-2 text-xs font-medium text-text-secondary rounded-lg hover:bg-text-secondary/10 hover:text-white transition-all"
+      >
+        <span className="flex items-center justify-center w-5 h-5 rounded-full bg-accent/20 text-accent text-[10px] font-semibold shrink-0">
+          {initial}
+        </span>
+        <span className="truncate">{name}</span>
+        <ChevronDown className={`w-3.5 h-3.5 ml-auto shrink-0 transition-transform ${menuOpen ? 'rotate-180' : ''}`} />
+      </button>
+    </div>
+  )
+}

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -6,7 +6,7 @@ import { OrgPage } from './OrgPage'
 import { LimitGauge } from '../../components/agent-info-sidebar/LimitGauge'
 import { useStore } from '../../store'
 import { useConfig } from '../../hooks/useConfig'
-import type { SpotlightShortcut, LaunchMode, ClaudeAccount, SpendSummary } from '../../../types'
+import type { SpotlightShortcut, LaunchMode, ClaudeAccount, SpendSummary, SettingsTab } from '../../../types'
 import { showToast } from '../../components/Toast'
 import { getProjectColorMap } from '../../utils/projectColors'
 
@@ -28,8 +28,6 @@ const LAUNCH_MODE_OPTIONS: { value: LaunchMode; label: string; description: stri
   { value: 'auto', label: 'Auto', description: 'Auto-approves most actions based on configured allowlists' },
   { value: 'bypassPermissions', label: 'Bypass', description: 'No permission checks — for sandboxed environments only' },
 ]
-
-type SettingsTab = 'profile' | 'repositories' | 'organization' | 'launch-mode' | 'features' | 'shortcuts' | 'usage' | 'about'
 
 const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
   { id: 'profile', label: 'Profile' },
@@ -67,16 +65,15 @@ const SEAT_TIER_LABELS: Record<string, string> = {
 function WelcomePage() {
   const { config, terminals, splitEnabled, toggleSplitEnabled, currentPage, setCurrentPage, setConfig, settingsInitialTab, setSettingsInitialTab } = useStore()
   const { addRepository, updateSplitEnabled, updateSpotlight, updateLaunchMode } = useConfig()
-  const [activeTab, setActiveTab] = useState<SettingsTab>('profile')
-
   // Deep-link support: another view can request a specific settings tab via the
-  // store (e.g. the sidebar account menu → Organization). Consume it once, then
-  // clear it so navigating back to Settings later starts on the default tab.
+  // store (e.g. the sidebar account menu → Organization). Initialise straight
+  // from it so the requested tab paints on first render (no Profile → target
+  // flash), then clear the store value once so later visits start on the default.
+  const [activeTab, setActiveTab] = useState<SettingsTab>(settingsInitialTab ?? 'profile')
+
   useEffect(() => {
     if (!settingsInitialTab) return
-    if (SETTINGS_TABS.some((t) => t.id === settingsInitialTab)) {
-      setActiveTab(settingsInitialTab as SettingsTab)
-    }
+    setActiveTab(settingsInitialTab)
     setSettingsInitialTab(null)
   }, [settingsInitialTab, setSettingsInitialTab])
   const [githubStatus, setGithubStatus] = useState<Record<string, boolean>>({})

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -65,9 +65,20 @@ const SEAT_TIER_LABELS: Record<string, string> = {
 }
 
 function WelcomePage() {
-  const { config, terminals, splitEnabled, toggleSplitEnabled, currentPage, setCurrentPage, setConfig } = useStore()
+  const { config, terminals, splitEnabled, toggleSplitEnabled, currentPage, setCurrentPage, setConfig, settingsInitialTab, setSettingsInitialTab } = useStore()
   const { addRepository, updateSplitEnabled, updateSpotlight, updateLaunchMode } = useConfig()
   const [activeTab, setActiveTab] = useState<SettingsTab>('profile')
+
+  // Deep-link support: another view can request a specific settings tab via the
+  // store (e.g. the sidebar account menu → Organization). Consume it once, then
+  // clear it so navigating back to Settings later starts on the default tab.
+  useEffect(() => {
+    if (!settingsInitialTab) return
+    if (SETTINGS_TABS.some((t) => t.id === settingsInitialTab)) {
+      setActiveTab(settingsInitialTab as SettingsTab)
+    }
+    setSettingsInitialTab(null)
+  }, [settingsInitialTab, setSettingsInitialTab])
   const [githubStatus, setGithubStatus] = useState<Record<string, boolean>>({})
   const [isAdding, setIsAdding] = useState(false)
   const [appVersion, setAppVersion] = useState('')

--- a/desktop/src/renderer/store/index.ts
+++ b/desktop/src/renderer/store/index.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
-import type { Config, TerminalInfo, TerminalState, TerminalMetadata, ScriptTerminalInfo } from '../../types'
+import type { Config, TerminalInfo, TerminalState, TerminalMetadata, ScriptTerminalInfo, SettingsTab } from '../../types'
 
 interface CloseAgentModalData {
   terminalId: string
@@ -30,7 +30,7 @@ interface AppState {
   currentPage: 'config' | 'terminals' | 'skills' | 'history'
   // When set, the Config page selects this settings tab on mount, then resets it
   // to null. Lets other views (e.g. the sidebar account menu) deep-link a tab.
-  settingsInitialTab: string | null
+  settingsInitialTab: SettingsTab | null
   rightSidebar: 'info' | null
   leftSidebarVisible: boolean
   iconSidebarVisible: boolean
@@ -67,7 +67,7 @@ interface AppState {
   moveTerminalToPane: (id: string, pane: 'left' | 'right') => void
 
   setCurrentPage: (page: 'config' | 'terminals' | 'skills' | 'history') => void
-  setSettingsInitialTab: (tab: string | null) => void
+  setSettingsInitialTab: (tab: SettingsTab | null) => void
   setRightSidebar: (sidebar: 'info' | null) => void
   toggleRightSidebar: (sidebar: 'info') => void
   toggleLeftSidebar: () => void

--- a/desktop/src/renderer/store/index.ts
+++ b/desktop/src/renderer/store/index.ts
@@ -28,6 +28,9 @@ interface AppState {
 
   // UI
   currentPage: 'config' | 'terminals' | 'skills' | 'history'
+  // When set, the Config page selects this settings tab on mount, then resets it
+  // to null. Lets other views (e.g. the sidebar account menu) deep-link a tab.
+  settingsInitialTab: string | null
   rightSidebar: 'info' | null
   leftSidebarVisible: boolean
   iconSidebarVisible: boolean
@@ -64,6 +67,7 @@ interface AppState {
   moveTerminalToPane: (id: string, pane: 'left' | 'right') => void
 
   setCurrentPage: (page: 'config' | 'terminals' | 'skills' | 'history') => void
+  setSettingsInitialTab: (tab: string | null) => void
   setRightSidebar: (sidebar: 'info' | null) => void
   toggleRightSidebar: (sidebar: 'info') => void
   toggleLeftSidebar: () => void
@@ -106,6 +110,7 @@ export const useStore = create<AppState>()(
         rightPaneTerminalIds: [],
 
         currentPage: 'terminals',
+        settingsInitialTab: null,
         rightSidebar: null,
         leftSidebarVisible: true,
         iconSidebarVisible: true,
@@ -249,6 +254,7 @@ export const useStore = create<AppState>()(
         },
 
         setCurrentPage: (currentPage) => set({ currentPage, selectedFile: null }),
+        setSettingsInitialTab: (settingsInitialTab) => set({ settingsInitialTab }),
         setRightSidebar: (rightSidebar) => set({ rightSidebar }),
         toggleRightSidebar: (sidebar) => set((state) => ({
           rightSidebar: state.rightSidebar === sidebar ? null : sidebar

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -171,6 +171,18 @@ export type MembershipRole = 'user' | 'admin'
 
 export type InvitationStatus = 'pending' | 'accepted' | 'revoked' | 'expired'
 
+/** Tabs of the Settings/Config page. Shared so other views (e.g. the sidebar
+ *  account menu) can deep-link a specific tab in a type-safe way. */
+export type SettingsTab =
+  | 'profile'
+  | 'repositories'
+  | 'organization'
+  | 'launch-mode'
+  | 'features'
+  | 'shortcuts'
+  | 'usage'
+  | 'about'
+
 /** Signed-in cloud user identity (subset of the Supabase session). */
 export interface CloudUser {
   id: string

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -1,10 +1,18 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import electron from 'vite-plugin-electron'
 import renderer from 'vite-plugin-electron-renderer'
 import { resolve } from 'path'
 
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  // Load .env / .env.local (any prefix) from the desktop dir, falling back to the
+  // shell's process.env. Lets you point at a Supabase project via an untracked
+  // .env.local instead of exporting env vars before every run.
+  const env = loadEnv(mode, process.cwd(), '')
+  const supabaseUrl = env.MAGIC_SLASH_SUPABASE_URL || process.env.MAGIC_SLASH_SUPABASE_URL || ''
+  const supabaseAnonKey = env.MAGIC_SLASH_SUPABASE_ANON_KEY || process.env.MAGIC_SLASH_SUPABASE_ANON_KEY || ''
+
+  return {
   plugins: [
     react(),
     electron([
@@ -19,8 +27,8 @@ export default defineConfig({
           // env vars are absent at build time they resolve to undefined and the
           // cloud client stays disabled — the app still boots and works offline.
           define: {
-            'process.env.MAGIC_SLASH_SUPABASE_URL': JSON.stringify(process.env.MAGIC_SLASH_SUPABASE_URL || ''),
-            'process.env.MAGIC_SLASH_SUPABASE_ANON_KEY': JSON.stringify(process.env.MAGIC_SLASH_SUPABASE_ANON_KEY || ''),
+            'process.env.MAGIC_SLASH_SUPABASE_URL': JSON.stringify(supabaseUrl),
+            'process.env.MAGIC_SLASH_SUPABASE_ANON_KEY': JSON.stringify(supabaseAnonKey),
           },
           build: {
             outDir: 'dist/main',
@@ -70,5 +78,6 @@ export default defineConfig({
         'quick-launch': resolve(__dirname, 'quick-launch.html'),
       },
     },
+  }
   }
 })


### PR DESCRIPTION
## Description

Adds an always-visible account control at the bottom of the left sidebar. Logged out, it shows a **Login / Sign up** button that opens the existing email/password auth modal; logged in, it shows the user's first name with a small menu (Account & organization, Sign out). Previously, cloud auth was only reachable from Settings → Organization.

This PR also makes the login modal render centered over the whole app (via a portal) and lets the desktop build read Supabase credentials from `.env` files.

## Related Issue

N/A — no linked issue.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- New `SidebarAccount` component: logged-out **Login / Sign up** button + logged-in first-name button with a popover menu (Account & organization → Settings/Organization tab, Sign out). Closes on outside-click / Escape.
- Mounted in `Sidebar.tsx` between the usage card and the footer; hidden entirely when cloud is disabled (`status.enabled === false`).
- Login modal now renders through `createPortal` to `document.body`, so the fixed overlay covers the whole app instead of being trapped by the sidebar's `backdrop-filter` containing block.
- Added a transient `settingsInitialTab` field to the Zustand store so the account menu can deep-link Settings → Organization; consumed and reset on mount in `Config`.
- `vite.config.ts` now loads `MAGIC_SLASH_SUPABASE_*` from `.env` / `.env.local` (via `loadEnv`), falling back to `process.env`.

Note: the first name is derived from the email local-part for now (e.g. `xavier@…` → `Xavier`) until GitHub OAuth carries a real name.

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

### Test Steps

1. Put `MAGIC_SLASH_SUPABASE_URL` and `MAGIC_SLASH_SUPABASE_ANON_KEY` in `desktop/.env.local`, then run `cd desktop && npm install && npm run dev`.
2. Logged out: confirm a **Login / Sign up** button appears at the bottom of the left sidebar (below the usage card). Click it → the auth modal opens **centered over the whole app**, not just the sidebar.
3. Sign in → the button becomes your first name with a chevron.
4. Click the name → a menu opens: **Account & organization** opens Settings on the Organization tab; **Sign out** returns the button to Login / Sign up.
5. Unset the Supabase env vars and restart → confirm the account button is hidden (cloud disabled).

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

GitHub OAuth login is intentionally out of scope and will follow in a separate PR (it needs an Electron deep-link flow + enabling the GitHub provider in Supabase). This PR wires the sidebar button to the existing email/password auth.
