### PR TITLE
[#137] Org member management & multi-org switching

### DIFF
--- a/desktop/src/main/cloud/org.ts
+++ b/desktop/src/main/cloud/org.ts
@@ -8,6 +8,7 @@ interface OrgRow {
   id: string
   name: string
   created_by: string | null
+  archived_at?: string | null
 }
 
 interface MembershipRow {
@@ -27,38 +28,19 @@ function firstOrg(rel: OrgRow | OrgRow[] | null): OrgRow | null {
  * cloud is disabled, the user is logged out, or has no membership.
  */
 export async function getCurrentOrg(): Promise<Org | null> {
-  const client = await getAuthedClient()
-  if (!client) return null
+  const orgs = await listOrgs()
+  if (orgs.length === 0) return null
 
-  const stored = loadSession()
-  const uid = stored?.user?.id
-  if (!uid) return null
-
-  const { data, error } = await client
-    .from('memberships')
-    .select('org_id, role, organizations(id, name, created_by)')
-    .eq('user_id', uid)
-
-  if (error || !data || data.length === 0) return null
-
-  const rows = data as unknown as MembershipRow[]
   const preferredId = readConfig().currentOrgId
-  const chosen = rows.find(r => r.org_id === preferredId) ?? rows[0]
-  const org = firstOrg(chosen.organizations)
-  if (!org) return null
-
-  return {
-    id: org.id,
-    name: org.name,
-    createdBy: org.created_by ?? undefined,
-    role: chosen.role,
-  }
+  return orgs.find((o) => o.id === preferredId) ?? orgs[0]
 }
 
 /**
- * Members of the given org (defaults to the current org). Emails are not
- * exposed by RLS on auth.users, so only the caller's own email is filled in;
- * others come back without an email (userId + role only).
+ * Members of the given org (defaults to the current org), including every
+ * member's email. Raw RLS on auth.users would only expose the caller's own
+ * email, so this goes through the list_org_members RPC (SECURITY DEFINER, gated
+ * to members of the org) which joins auth.users and returns emails for all
+ * members — safely, since a non-member gets rejected.
  */
 export async function listMembers(orgId?: string): Promise<Member[]> {
   const client = await getAuthedClient()
@@ -67,23 +49,95 @@ export async function listMembers(orgId?: string): Promise<Member[]> {
   const targetOrgId = orgId ?? (await getCurrentOrg())?.id
   if (!targetOrgId) return []
 
+  const { data, error } = await client.rpc('list_org_members', { p_org_id: targetOrgId })
+  if (error || !data) return []
+
+  return (data as Array<{ user_id: string; email: string | null; role: MembershipRole; created_at: string }>).map((row) => ({
+    userId: row.user_id,
+    role: row.role,
+    createdAt: row.created_at ?? undefined,
+    email: row.email ?? undefined,
+  }))
+}
+
+/**
+ * Every non-archived org the current user belongs to (for the multi-org
+ * switcher). Archived orgs are already filtered server-side by the
+ * is_org_member-gated RLS, so a membership row for an archived org never comes
+ * back. Degrades to [] when cloud is off or the user is logged out.
+ */
+export async function listOrgs(): Promise<Org[]> {
+  const client = await getAuthedClient()
+  if (!client) return []
+
+  const stored = loadSession()
+  const uid = stored?.user?.id
+  if (!uid) return []
+
   const { data, error } = await client
     .from('memberships')
-    .select('user_id, role, created_at')
-    .eq('org_id', targetOrgId)
+    .select('org_id, role, organizations(id, name, created_by, archived_at)')
+    .eq('user_id', uid)
 
   if (error || !data) return []
 
-  const stored = loadSession()
-  const selfId = stored?.user?.id
-  const selfEmail = stored?.user?.email
+  const rows = data as unknown as MembershipRow[]
+  const orgs: Org[] = []
+  for (const row of rows) {
+    const org = firstOrg(row.organizations)
+    // Defense-in-depth: skip archived orgs even though RLS already filters them.
+    if (!org || org.archived_at) continue
+    orgs.push({
+      id: org.id,
+      name: org.name,
+      createdBy: org.created_by ?? undefined,
+      role: row.role,
+    })
+  }
+  return orgs
+}
 
-  return data.map((row) => ({
-    userId: row.user_id as string,
-    role: row.role as MembershipRole,
-    createdAt: row.created_at as string | undefined,
-    email: row.user_id === selfId ? selfEmail : undefined,
-  }))
+/** Run a void-returning RPC through the authed client, surfacing failures as thrown errors. */
+async function callVoidRpc(fn: string, args: Record<string, unknown>): Promise<void> {
+  const client = await getAuthedClient()
+  if (!client) throw new Error('Cloud features are not available')
+
+  const { error } = await client.rpc(fn, args)
+  if (error) throw new Error(error.message)
+}
+
+/**
+ * Remove a member from an org (admin only). The remove_member RPC enforces the
+ * admin gate and the last-admin lockout guard server-side.
+ */
+export async function removeMember(orgId: string, userId: string): Promise<void> {
+  await callVoidRpc('remove_member', { p_org_id: orgId, p_user_id: userId })
+}
+
+/**
+ * Leave an org (removes the current user's own membership). The
+ * leave_organization RPC enforces the last-admin lockout guard, so a sole admin
+ * of an org that still has members cannot leave. When the user leaves the active
+ * org we clear the remembered currentOrgId so getCurrentOrg repoints cleanly.
+ */
+export async function leaveOrg(orgId: string): Promise<void> {
+  await callVoidRpc('leave_organization', { p_org_id: orgId })
+  if (readConfig().currentOrgId === orgId) setCurrentOrgId(undefined)
+}
+
+/** Change a member's role (admin only). The RPC enforces the last-admin guard on demotion. */
+export async function updateMemberRole(orgId: string, userId: string, role: MembershipRole): Promise<void> {
+  await callVoidRpc('update_member_role', { p_org_id: orgId, p_user_id: userId, p_role: role })
+}
+
+/**
+ * Archive (soft-delete) an org (admin only). The RPC sets archived_at; the org
+ * then drops out of every read path server-side. When it was the active org we
+ * clear the remembered currentOrgId so getCurrentOrg repoints cleanly.
+ */
+export async function archiveOrg(orgId: string): Promise<void> {
+  await callVoidRpc('archive_organization', { p_org_id: orgId })
+  if (readConfig().currentOrgId === orgId) setCurrentOrgId(undefined)
 }
 
 /** Create an invitation (admin only — RLS enforces the admin gate). */
@@ -159,18 +213,42 @@ export interface AcceptInvitationResult {
   config: Config
 }
 
-/** Read the org's shared config and merge it into the local config (best-effort). */
-async function mergeSharedConfigWith(client: SupabaseClient, orgId: string): Promise<Config> {
+/**
+ * Read the org's shared config and merge it into the local config (best-effort).
+ * 'fill' keeps existing local values (onboarding); 'replace' swaps the shared
+ * keys to the org's values (used when switching the active org).
+ */
+async function mergeSharedConfigWith(
+  client: SupabaseClient,
+  orgId: string,
+  mode: 'fill' | 'replace' = 'fill',
+): Promise<Config> {
   try {
     const { data: shared, error } = await client.rpc('get_org_shared_config', { p_org_id: orgId })
     if (!error && shared) {
-      return mergeOrgSharedConfig(shared as OrgSharedConfig, orgId)
+      return mergeOrgSharedConfig(shared as OrgSharedConfig, orgId, mode)
     }
   } catch (mergeError) {
     // Inheriting shared config is best-effort — never fail over it.
     console.error('[cloud] Failed to merge org shared config:', mergeError)
   }
   return readConfig()
+}
+
+/**
+ * Switch the active org: remember it locally, then RE-APPLY the org's shared
+ * config with REPLACE semantics so the shared skills/agents config (languages,
+ * commit/PR format, repo keywords) actually swaps to the newly-active org rather
+ * than retaining the previous org's values. Returns the updated local config.
+ * Degrades local-first: throws the standard error when cloud is unavailable, and
+ * the shared-config re-apply is best-effort (never fails the switch).
+ */
+export async function switchOrg(orgId: string): Promise<Config> {
+  const client = await getAuthedClient()
+  if (!client) throw new Error('Cloud features are not available')
+
+  setCurrentOrgId(orgId)
+  return mergeSharedConfigWith(client, orgId, 'replace')
 }
 
 /**

--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -417,59 +417,75 @@ export function setCurrentOrgId(orgId: string | undefined): Config {
   return config
 }
 
-/** Copy accepted source values onto target, but only where target has none yet. */
-function fillUnset(
+/**
+ * Copy accepted source values onto target. In 'fill' mode only keys the target
+ * has not set yet are written (local values win); in 'replace' mode every
+ * accepted source key overwrites the target (the org's value wins).
+ */
+function applyValues(
   target: Record<string, unknown>,
   source: Record<string, unknown>,
   accept: (value: unknown) => boolean,
+  mode: 'fill' | 'replace',
 ): void {
   for (const [key, value] of Object.entries(source)) {
-    if (accept(value) && target[key] === undefined) {
+    if (!accept(value)) continue
+    if (mode === 'replace' || target[key] === undefined) {
       target[key] = value
     }
   }
 }
 
 /**
- * Merge an org's shared config (inherited on invitation onboarding) into the
- * local config, applied as DEFAULTS over every existing repository: existing
- * local values always win, so local repo paths and integration toggles are
- * preserved. Only the shared fields are touched — languages, commit/PR format,
- * and repo keywords. Missing/malformed input is ignored (never throws on data).
+ * Merge an org's shared config into the local config across every existing
+ * repository. Only the shared fields are touched — languages, commit/PR format,
+ * and repo keywords; local-only bits (repo paths, integration toggles) are never
+ * modified. Missing/malformed input is ignored (never throws on data).
+ *
+ * Two modes:
+ *  - 'fill' (default): applied as DEFAULTS — existing local values always win.
+ *    Used on invitation onboarding so the invitee keeps anything they set.
+ *  - 'replace': the org's values overwrite the local ones for the shared keys.
+ *    Used when SWITCHING the active org, so the shared config actually swaps to
+ *    reflect the newly-active org instead of retaining the previous org's values.
  */
-export function mergeOrgSharedConfig(shared: OrgSharedConfig, orgId?: string): Config {
+export function mergeOrgSharedConfig(
+  shared: OrgSharedConfig,
+  orgId?: string,
+  mode: 'fill' | 'replace' = 'fill',
+): Config {
   const config = readConfig()
   config.repositories = config.repositories || {}
 
   for (const repo of Object.values(config.repositories)) {
-    // Languages: fill only keys the repo hasn't already set.
     if (shared.languages && typeof shared.languages === 'object') {
       repo.languages = repo.languages || {}
-      fillUnset(repo.languages, shared.languages, (v) => typeof v === 'string')
+      applyValues(repo.languages, shared.languages, (v) => typeof v === 'string', mode)
     }
 
-    // Commit settings: fill only unset fields.
     if (shared.commit && typeof shared.commit === 'object') {
       repo.commit = repo.commit || {}
-      fillUnset(repo.commit, shared.commit, (v) => v !== undefined)
+      applyValues(repo.commit, shared.commit, (v) => v !== undefined, mode)
     }
 
-    // Pull request settings: fill only unset fields.
     if (shared.pullRequest && typeof shared.pullRequest === 'object') {
       repo.pullRequest = repo.pullRequest || {}
-      fillUnset(repo.pullRequest, shared.pullRequest, (v) => v !== undefined)
+      applyValues(repo.pullRequest, shared.pullRequest, (v) => v !== undefined, mode)
     }
   }
 
-  // Repo keywords keyed by repo name: apply to a matching local repo only when
-  // it has no meaningful keywords yet (empty or defaulted to its own name).
+  // Repo keywords keyed by repo name. In 'fill' mode only a repo with no
+  // meaningful keywords yet inherits them; in 'replace' mode the matching repo's
+  // keywords are overwritten with the org's.
   if (shared.repoKeywords && typeof shared.repoKeywords === 'object') {
     for (const [name, keywords] of Object.entries(shared.repoKeywords)) {
       const repo = config.repositories[name]
-      if (!repo || !Array.isArray(keywords)) continue
-      const isDefaulted = repo.keywords.length === 0 || (repo.keywords.length === 1 && repo.keywords[0] === name)
-      if (isDefaulted && keywords.length > 0) {
+      if (!repo || !Array.isArray(keywords) || keywords.length === 0) continue
+      if (mode === 'replace') {
         repo.keywords = keywords
+      } else {
+        const isDefaulted = repo.keywords.length === 0 || (repo.keywords.length === 1 && repo.keywords[0] === name)
+        if (isDefaulted) repo.keywords = keywords
       }
     }
   }

--- a/desktop/src/main/ipc/org-handlers.ts
+++ b/desktop/src/main/ipc/org-handlers.ts
@@ -1,15 +1,33 @@
 import { ipcMain } from 'electron'
 import type { AcceptInvitationResult } from '../cloud/org'
 import type { Config, Invitation, Member, MembershipRole, Org } from '../../types'
-import { getCurrentOrg, listMembers, listInvitations, createInvitation, acceptInvitation, applySharedConfig } from '../cloud/org'
+import {
+  getCurrentOrg,
+  listMembers,
+  listInvitations,
+  createInvitation,
+  acceptInvitation,
+  applySharedConfig,
+  listOrgs,
+  removeMember,
+  leaveOrg,
+  updateMemberRole,
+  archiveOrg,
+  switchOrg,
+} from '../cloud/org'
 
 interface InviteArgs { email: string; role?: MembershipRole }
 interface AcceptArgs { token: string }
+interface OrgIdArgs { orgId: string }
+interface MemberArgs { orgId: string; userId: string }
+interface RoleArgs { orgId: string; userId: string; role: MembershipRole }
 
 export function setupOrgHandlers(): void {
   ipcMain.handle('org:current', async (): Promise<Org | null> => getCurrentOrg())
 
   ipcMain.handle('org:members', async (): Promise<Member[]> => listMembers())
+
+  ipcMain.handle('org:list', async (): Promise<Org[]> => listOrgs())
 
   ipcMain.handle('org:invitations', async (): Promise<Invitation[]> => listInvitations())
 
@@ -22,4 +40,18 @@ export function setupOrgHandlers(): void {
   )
 
   ipcMain.handle('org:applyShared', async (): Promise<Config> => applySharedConfig())
+
+  ipcMain.handle('org:removeMember', async (_event, { orgId, userId }: MemberArgs): Promise<void> =>
+    removeMember(orgId, userId),
+  )
+
+  ipcMain.handle('org:leave', async (_event, { orgId }: OrgIdArgs): Promise<void> => leaveOrg(orgId))
+
+  ipcMain.handle('org:updateRole', async (_event, { orgId, userId, role }: RoleArgs): Promise<void> =>
+    updateMemberRole(orgId, userId, role),
+  )
+
+  ipcMain.handle('org:archive', async (_event, { orgId }: OrgIdArgs): Promise<void> => archiveOrg(orgId))
+
+  ipcMain.handle('org:switch', async (_event, { orgId }: OrgIdArgs): Promise<Config> => switchOrg(orgId))
 }

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -413,16 +413,24 @@ const authApi = {
   },
 }
 
-// Org API (organization membership + invitations)
+// Org API (organization membership + invitations + multi-org management)
 const orgApi = {
   current: (): Promise<Org | null> => ipcRenderer.invoke('org:current'),
   members: (): Promise<Member[]> => ipcRenderer.invoke('org:members'),
+  list: (): Promise<Org[]> => ipcRenderer.invoke('org:list'),
   invitations: (): Promise<Invitation[]> => ipcRenderer.invoke('org:invitations'),
   invite: (email: string, role?: MembershipRole): Promise<Invitation> =>
     ipcRenderer.invoke('org:invite', { email, role }),
   accept: (token: string): Promise<{ orgId: string; config: Config }> =>
     ipcRenderer.invoke('org:accept', { token }),
   applySharedConfig: (): Promise<Config> => ipcRenderer.invoke('org:applyShared'),
+  removeMember: (orgId: string, userId: string): Promise<void> =>
+    ipcRenderer.invoke('org:removeMember', { orgId, userId }),
+  leave: (orgId: string): Promise<void> => ipcRenderer.invoke('org:leave', { orgId }),
+  updateRole: (orgId: string, userId: string, role: MembershipRole): Promise<void> =>
+    ipcRenderer.invoke('org:updateRole', { orgId, userId, role }),
+  archive: (orgId: string): Promise<void> => ipcRenderer.invoke('org:archive', { orgId }),
+  switch: (orgId: string): Promise<Config> => ipcRenderer.invoke('org:switch', { orgId }),
 }
 
 // Expose APIs to renderer

--- a/desktop/src/renderer/components/SidebarAccount.tsx
+++ b/desktop/src/renderer/components/SidebarAccount.tsx
@@ -1,9 +1,11 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
-import { LogIn, LogOut, Building2, ChevronDown } from 'lucide-react'
+import { LogIn, LogOut, Building2, ChevronDown, Check, Loader2 } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
+import { useOrg } from '../hooks/useOrg'
 import { useStore } from '../store'
 import { LoginScreen } from './LoginScreen'
+import { showToast } from './Toast'
 
 /**
  * Derive a friendly display name from an email address. Until GitHub OAuth
@@ -26,12 +28,14 @@ function displayNameFromEmail(email?: string): string {
  */
 export function SidebarAccount() {
   const { status, logout } = useAuth()
+  const { org, orgs, switchOrg } = useOrg()
   const setCurrentPage = useStore((s) => s.setCurrentPage)
   const setSettingsInitialTab = useStore((s) => s.setSettingsInitialTab)
   const setActiveTerminal = useStore((s) => s.setActiveTerminal)
 
   const [showLogin, setShowLogin] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [switching, setSwitching] = useState<string | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
   // Close the menu on outside click or Escape.
@@ -69,6 +73,20 @@ export function SidebarAccount() {
     }
   }, [logout])
 
+  const handleSwitchOrg = useCallback(async (orgId: string) => {
+    if (orgId === org?.id || switching) return
+    setSwitching(orgId)
+    try {
+      await switchOrg(orgId)
+      showToast('Switched organization', 'success')
+      setMenuOpen(false)
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to switch organization', 'error')
+    } finally {
+      setSwitching(null)
+    }
+  }, [org, switching, switchOrg])
+
   // Cloud disabled → nothing to show.
   if (!status.enabled) return null
 
@@ -102,6 +120,33 @@ export function SidebarAccount() {
     <div ref={containerRef} className="relative px-2 pb-2">
       {menuOpen && (
         <div className="absolute bottom-full left-2 right-2 mb-1 bg-bg-secondary border border-white/10 rounded-lg shadow-xl backdrop-blur-2xl overflow-hidden z-30">
+          {/* Multi-org switcher — only when the user belongs to more than one org. */}
+          {orgs.length > 1 && (
+            <div className="border-b border-white/10 py-1">
+              <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary/40">
+                Organizations
+              </div>
+              {orgs.map((o) => {
+                const isActive = o.id === org?.id
+                return (
+                  <button
+                    key={o.id}
+                    onClick={() => handleSwitchOrg(o.id)}
+                    disabled={switching !== null}
+                    className="w-full flex items-center gap-2 px-3 py-2 text-xs font-medium text-text-secondary hover:bg-white/10 hover:text-white transition-colors disabled:opacity-50"
+                  >
+                    <Building2 className="w-3.5 h-3.5 shrink-0" />
+                    <span className="truncate">{o.name}</span>
+                    {switching === o.id ? (
+                      <Loader2 className="w-3.5 h-3.5 ml-auto shrink-0 animate-spin" />
+                    ) : isActive ? (
+                      <Check className="w-3.5 h-3.5 ml-auto shrink-0 text-accent" />
+                    ) : null}
+                  </button>
+                )
+              })}
+            </div>
+          )}
           <button
             onClick={openOrganization}
             className="w-full flex items-center gap-2 px-3 py-2 text-xs font-medium text-text-secondary hover:bg-white/10 hover:text-white transition-colors"

--- a/desktop/src/renderer/hooks/useOrg.ts
+++ b/desktop/src/renderer/hooks/useOrg.ts
@@ -1,13 +1,21 @@
 import { useState, useEffect, useCallback } from 'react'
-import type { Invitation, Member, MembershipRole, Org } from '../../types'
+import type { Invitation, Member, MembershipRole } from '../../types'
+import { useStore } from '../store'
 
 /**
- * Organization state (membership + invitations). All calls degrade gracefully:
- * when cloud is disabled or the user is logged out, everything is empty/null and
- * nothing throws.
+ * Organization state (active org, org list, members, invitations) + the member-
+ * management actions. The active org and the org list live in the global store
+ * so the switcher, the org page, and any other view react live to the same
+ * source of truth. Everything degrades gracefully: when cloud is disabled or the
+ * user is logged out, lists are empty / org is null and nothing throws.
  */
 export function useOrg() {
-  const [org, setOrg] = useState<Org | null>(null)
+  const activeOrg = useStore((s) => s.activeOrg)
+  const orgs = useStore((s) => s.orgs)
+  const setActiveOrg = useStore((s) => s.setActiveOrg)
+  const setOrgs = useStore((s) => s.setOrgs)
+  const setConfig = useStore((s) => s.setConfig)
+
   const [members, setMembers] = useState<Member[]>([])
   const [invitations, setInvitations] = useState<Invitation[]>([])
   const [loading, setLoading] = useState(false)
@@ -16,7 +24,8 @@ export function useOrg() {
     setLoading(true)
     try {
       const current = await window.electronAPI.org.current()
-      setOrg(current)
+      setActiveOrg(current)
+      setOrgs(await window.electronAPI.org.list().catch(() => []))
       if (current) {
         setMembers(await window.electronAPI.org.members().catch(() => []))
         // Invitations are admin-only; a non-admin read simply yields [].
@@ -26,13 +35,14 @@ export function useOrg() {
         setInvitations([])
       }
     } catch {
-      setOrg(null)
+      setActiveOrg(null)
+      setOrgs([])
       setMembers([])
       setInvitations([])
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [setActiveOrg, setOrgs])
 
   useEffect(() => {
     refresh()
@@ -56,5 +66,62 @@ export function useOrg() {
     [refresh],
   )
 
-  return { org, members, invitations, loading, refresh, invite, accept }
+  const removeMember = useCallback(
+    async (orgId: string, userId: string) => {
+      await window.electronAPI.org.removeMember(orgId, userId)
+      await refresh()
+    },
+    [refresh],
+  )
+
+  const updateRole = useCallback(
+    async (orgId: string, userId: string, role: MembershipRole) => {
+      await window.electronAPI.org.updateRole(orgId, userId, role)
+      await refresh()
+    },
+    [refresh],
+  )
+
+  const leaveOrg = useCallback(
+    async (orgId: string) => {
+      await window.electronAPI.org.leave(orgId)
+      await refresh()
+    },
+    [refresh],
+  )
+
+  const archiveOrg = useCallback(
+    async (orgId: string) => {
+      await window.electronAPI.org.archive(orgId)
+      await refresh()
+    },
+    [refresh],
+  )
+
+  const switchOrg = useCallback(
+    async (orgId: string) => {
+      // switchOrg re-applies the org's shared config (replace semantics) and
+      // returns the updated local config — reflect it in the store immediately.
+      const config = await window.electronAPI.org.switch(orgId)
+      if (config) setConfig(config)
+      await refresh()
+    },
+    [refresh, setConfig],
+  )
+
+  return {
+    org: activeOrg,
+    orgs,
+    members,
+    invitations,
+    loading,
+    refresh,
+    invite,
+    accept,
+    removeMember,
+    updateRole,
+    leaveOrg,
+    archiveOrg,
+    switchOrg,
+  }
 }

--- a/desktop/src/renderer/pages/Config/OrgPage.tsx
+++ b/desktop/src/renderer/pages/Config/OrgPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Cloud, Users, Mail, LogOut, LogIn, UserPlus, Shield, Copy, Check, Github, Loader2, Building2, KeyRound, AtSign, Trash2, AlertTriangle } from 'lucide-react'
+import { Cloud, Users, Mail, LogOut, LogIn, UserPlus, Shield, Copy, Check, Github, Loader2, Building2, KeyRound, AtSign, Trash2, AlertTriangle, Archive, X } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import { useOrg } from '../../hooks/useOrg'
 import { useStore } from '../../store'
@@ -7,11 +7,11 @@ import { LoginScreen } from '../../components/LoginScreen'
 import { Modal } from '../../components/Modal'
 import { InvitationOnboardingWizard } from '../../components/InvitationOnboardingWizard'
 import { showToast } from '../../components/Toast'
-import type { GitHubAuthStatus } from '../../../types'
+import type { GitHubAuthStatus, MembershipRole } from '../../../types'
 
 export function OrgPage() {
   const { status, loading: authLoading, logout, updatePassword, requestEmailChange, confirmEmailChange, deleteAccount } = useAuth()
-  const { org, members, invitations, loading: orgLoading, refresh, invite } = useOrg()
+  const { org, members, invitations, loading: orgLoading, refresh, invite, removeMember, updateRole, leaveOrg, archiveOrg } = useOrg()
   const { config, setConfig } = useStore()
 
   const [showLogin, setShowLogin] = useState(false)
@@ -35,6 +35,13 @@ export function OrgPage() {
   const [showDeleteAccount, setShowDeleteAccount] = useState(false)
   const [deleting, setDeleting] = useState(false)
 
+  // Org member management + archiving.
+  const [showArchive, setShowArchive] = useState(false)
+  const [archiving, setArchiving] = useState(false)
+  const [leaving, setLeaving] = useState(false)
+  // user_id currently being mutated (role change / removal), to disable its row.
+  const [busyMember, setBusyMember] = useState<string | null>(null)
+
   // Integration status (DISPLAY only — no tokens stored).
   const [githubStatus, setGithubStatus] = useState<GitHubAuthStatus | null>(null)
   const atlassianEnabled = config?.integrations?.atlassian ?? true
@@ -44,6 +51,64 @@ export function OrgPage() {
   }, [])
 
   const isAdmin = org?.role === 'admin'
+  const currentUserId = status.user?.id
+  const adminCount = members.filter((m) => m.role === 'admin').length
+  // Sole admin: the last admin cannot leave/be demoted without lockout — such a
+  // user must archive the org instead of leaving it.
+  const isSoleAdmin = isAdmin && adminCount <= 1
+
+  const handleChangeRole = useCallback(async (userId: string, role: MembershipRole) => {
+    if (!org) return
+    setBusyMember(userId)
+    try {
+      await updateRole(org.id, userId, role)
+      showToast('Role updated', 'success')
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to update role', 'error')
+    } finally {
+      setBusyMember(null)
+    }
+  }, [org, updateRole])
+
+  const handleRemoveMember = useCallback(async (userId: string) => {
+    if (!org) return
+    setBusyMember(userId)
+    try {
+      await removeMember(org.id, userId)
+      showToast('Member removed', 'success')
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to remove member', 'error')
+    } finally {
+      setBusyMember(null)
+    }
+  }, [org, removeMember])
+
+  const handleLeave = useCallback(async () => {
+    if (!org || leaving) return
+    setLeaving(true)
+    try {
+      await leaveOrg(org.id)
+      showToast('You left the organization', 'success')
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to leave organization', 'error')
+    } finally {
+      setLeaving(false)
+    }
+  }, [org, leaving, leaveOrg])
+
+  const handleArchive = useCallback(async () => {
+    if (!org || archiving) return
+    setArchiving(true)
+    try {
+      await archiveOrg(org.id)
+      showToast('Organization archived', 'success')
+      setShowArchive(false)
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to archive organization', 'error')
+    } finally {
+      setArchiving(false)
+    }
+  }, [org, archiving, archiveOrg])
 
   const handleInvite = useCallback(async () => {
     if (inviting || !inviteEmail.trim()) return
@@ -252,15 +317,42 @@ export function OrgPage() {
                   <Loader2 className="w-4 h-4 animate-spin" />
                 </div>
               ) : org ? (
-                <div className="flex items-center justify-between">
-                  <div>
-                    <div className="text-sm font-medium">{org.name}</div>
-                    <div className="text-xs text-text-secondary/50 mt-0.5">Your role in this organization</div>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="text-sm font-medium">{org.name}</div>
+                      <div className="text-xs text-text-secondary/50 mt-0.5">Your role in this organization</div>
+                    </div>
+                    <span className={`flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium ${isAdmin ? 'bg-accent/15 text-accent' : 'bg-white/10 text-text-secondary'}`}>
+                      {isAdmin && <Shield className="w-3 h-3" />}
+                      {org.role}
+                    </span>
                   </div>
-                  <span className={`flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium ${isAdmin ? 'bg-accent/15 text-accent' : 'bg-white/10 text-text-secondary'}`}>
-                    {isAdmin && <Shield className="w-3 h-3" />}
-                    {org.role}
-                  </span>
+                  <div className="border-t border-white/5 pt-3 flex items-center gap-2">
+                    {isSoleAdmin ? (
+                      <p className="text-xs text-text-secondary/50">
+                        You are the last admin. Promote another member before leaving, or archive the organization below.
+                      </p>
+                    ) : (
+                      <button
+                        onClick={handleLeave}
+                        disabled={leaving}
+                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all disabled:opacity-40"
+                      >
+                        {leaving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <LogOut className="w-3.5 h-3.5" />}
+                        Leave organization
+                      </button>
+                    )}
+                    {isAdmin && (
+                      <button
+                        onClick={() => setShowArchive(true)}
+                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red border border-red/20 rounded-lg hover:bg-red/10 transition-all ml-auto"
+                      >
+                        <Archive className="w-3.5 h-3.5" />
+                        Archive organization
+                      </button>
+                    )}
+                  </div>
                 </div>
               ) : (
                 <div className="text-sm text-text-secondary/50 text-center py-2">No organization found for this account.</div>
@@ -279,14 +371,45 @@ export function OrgPage() {
                 {members.length === 0 ? (
                   <div className="text-sm text-text-secondary/50 text-center py-2">No members yet.</div>
                 ) : (
-                  members.map((m) => (
-                    <div key={m.userId} className="flex items-center justify-between py-1">
-                      <span className="text-sm truncate">{m.email ?? m.userId}</span>
-                      <span className={`px-2 py-0.5 rounded text-[11px] font-medium ${m.role === 'admin' ? 'bg-accent/15 text-accent' : 'bg-white/10 text-text-secondary'}`}>
-                        {m.role}
-                      </span>
-                    </div>
-                  ))
+                  members.map((m) => {
+                    const isSelf = m.userId === currentUserId
+                    const rowBusy = busyMember === m.userId
+                    return (
+                      <div key={m.userId} className="flex items-center justify-between gap-2 py-1">
+                        <span className="text-sm truncate flex-1">
+                          {m.email ?? m.userId}
+                          {isSelf && <span className="text-text-secondary/40"> (you)</span>}
+                        </span>
+                        {rowBusy ? (
+                          <Loader2 className="w-3.5 h-3.5 animate-spin text-text-secondary/50" />
+                        ) : isAdmin ? (
+                          <div className="flex items-center gap-2">
+                            <select
+                              value={m.role}
+                              onChange={(e) => handleChangeRole(m.userId, e.target.value as MembershipRole)}
+                              className="px-2 py-0.5 bg-white/[0.06] border border-white/10 rounded text-[11px] font-medium text-text-secondary focus:outline-none focus:border-accent transition-colors"
+                            >
+                              <option value="user">user</option>
+                              <option value="admin">admin</option>
+                            </select>
+                            {!isSelf && (
+                              <button
+                                onClick={() => handleRemoveMember(m.userId)}
+                                className="p-1 text-text-secondary/60 rounded hover:bg-red/10 hover:text-red transition-all"
+                                title="Remove member"
+                              >
+                                <X className="w-3.5 h-3.5" />
+                              </button>
+                            )}
+                          </div>
+                        ) : (
+                          <span className={`px-2 py-0.5 rounded text-[11px] font-medium ${m.role === 'admin' ? 'bg-accent/15 text-accent' : 'bg-white/10 text-text-secondary'}`}>
+                            {m.role}
+                          </span>
+                        )}
+                      </div>
+                    )
+                  })
                 )}
               </div>
             </div>
@@ -523,6 +646,43 @@ export function OrgPage() {
             <p className="text-sm text-white">This permanently deletes your account and personal data.</p>
             <p className="text-xs text-text-secondary/60">
               Organizations you created will be removed along with their data. This cannot be undone. Magic Slash keeps working locally without an account.
+            </p>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Archive organization (danger) */}
+      <Modal
+        isOpen={showArchive}
+        onClose={() => setShowArchive(false)}
+        title="Archive organization"
+        footer={
+          <>
+            <button
+              onClick={() => setShowArchive(false)}
+              className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleArchive}
+              disabled={archiving}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-red hover:bg-red/80 rounded-lg transition-all disabled:opacity-40"
+            >
+              {archiving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Archive className="w-3.5 h-3.5" />}
+              Archive organization
+            </button>
+          </>
+        }
+      >
+        <div className="flex items-start gap-3">
+          <div className="p-2 bg-red/10 rounded-lg flex-shrink-0">
+            <AlertTriangle className="w-4 h-4 text-red" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm text-white">Archive {org?.name ?? 'this organization'}?</p>
+            <p className="text-xs text-text-secondary/60">
+              The organization and its members lose access — it disappears for everyone. Its data is retained, not deleted, but this cannot be undone from the app.
             </p>
           </div>
         </div>

--- a/desktop/src/renderer/store/index.ts
+++ b/desktop/src/renderer/store/index.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
-import type { Config, TerminalInfo, TerminalState, TerminalMetadata, ScriptTerminalInfo, SettingsTab } from '../../types'
+import type { Config, TerminalInfo, TerminalState, TerminalMetadata, ScriptTerminalInfo, SettingsTab, Org } from '../../types'
 
 interface CloseAgentModalData {
   terminalId: string
@@ -12,6 +12,12 @@ interface AppState {
   config: Config | null
   configLoading: boolean
   configError: string | null
+
+  // Organization (cloud, multi-org). Held globally so the switcher and other
+  // views react live to the active org / membership set. Ephemeral (not
+  // persisted) — refreshed from the main process on mount and after mutations.
+  activeOrg: Org | null
+  orgs: Org[]
 
   // Terminals
   terminals: TerminalInfo[]
@@ -50,6 +56,9 @@ interface AppState {
   setConfig: (config: Config) => void
   setConfigLoading: (loading: boolean) => void
   setConfigError: (error: string | null) => void
+
+  setActiveOrg: (org: Org | null) => void
+  setOrgs: (orgs: Org[]) => void
 
   addTerminal: (terminal: TerminalInfo) => void
   updateTerminalState: (id: string, state: TerminalState) => void
@@ -98,6 +107,9 @@ export const useStore = create<AppState>()(
         configLoading: true,
         configError: null,
 
+        activeOrg: null,
+        orgs: [],
+
         terminals: [],
         activeTerminalId: null,
 
@@ -131,6 +143,9 @@ export const useStore = create<AppState>()(
         }),
         setConfigLoading: (configLoading) => set({ configLoading }),
         setConfigError: (configError) => set({ configError, configLoading: false }),
+
+        setActiveOrg: (activeOrg) => set({ activeOrg }),
+        setOrgs: (orgs) => set({ orgs }),
 
         addTerminal: (terminal) =>
           set((state) => {

--- a/supabase/migrations/20260723120000_org_member_management.sql
+++ b/supabase/migrations/20260723120000_org_member_management.sql
@@ -1,0 +1,387 @@
+-- Migration: org member management + multi-org support (issue #137)
+-- Builds on the invite/accept feature (PR2) and the RLS foundation (PR1). Adds
+-- the server-side pieces the desktop app needs to fully manage org membership:
+--   * organizations.archived_at — soft-delete (archiving), NEVER a hard delete.
+--   * a last-admin lockout guard so an org can never be left member-bearing but
+--     adminless (covers remove, leave and demote in one BEFORE trigger).
+--   * SECURITY DEFINER RPCs: remove_member, leave_organization,
+--     update_member_role, archive_organization, list_org_members.
+--
+-- Every function mirrors the established pattern (get_org_shared_config /
+-- create_organization): SECURITY DEFINER, locked search_path, an auth.uid()
+-- guard, and a defense-in-depth membership/admin check on top of RLS. Grants are
+-- revoked from PUBLIC and granted to authenticated only.
+
+-- ---------------------------------------------------------------------------
+-- Archiving: soft-delete column. Archived orgs are filtered out of every read
+-- path by the is_org_member / is_org_admin helpers below (which back the
+-- organizations/memberships SELECT policies), so nothing that lists orgs, their
+-- members, agents, etc. can ever surface an archived org. There is deliberately
+-- no unarchive path in scope: once archived, the helpers stop returning true for
+-- the org, so it disappears for everyone (its data is retained, not destroyed).
+-- ---------------------------------------------------------------------------
+alter table public.organizations add column if not exists archived_at timestamptz;
+
+-- ---------------------------------------------------------------------------
+-- Read-path filtering: exclude archived orgs from the membership/admin helpers.
+-- These back the organizations_select / memberships_select (and every
+-- is_org_member-gated) policy, so archiving an org removes it from all reads in
+-- one place. Preserves the PR1 SECURITY DEFINER + locked search_path style.
+-- ---------------------------------------------------------------------------
+create or replace function public.is_org_member(target_org uuid)
+returns boolean
+language sql
+security definer
+set search_path = public, pg_temp
+stable
+as $$
+  select exists (
+    select 1
+    from public.memberships m
+    join public.organizations o on o.id = m.org_id
+    where m.org_id = target_org
+      and m.user_id = auth.uid()
+      and o.archived_at is null
+  );
+$$;
+
+create or replace function public.is_org_admin(target_org uuid)
+returns boolean
+language sql
+security definer
+set search_path = public, pg_temp
+stable
+as $$
+  select exists (
+    select 1
+    from public.memberships m
+    join public.organizations o on o.id = m.org_id
+    where m.org_id = target_org
+      and m.user_id = auth.uid()
+      and m.role = 'admin'
+      and o.archived_at is null
+  );
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Last-admin lockout guard
+-- ---------------------------------------------------------------------------
+-- A single BEFORE DELETE OR UPDATE trigger on memberships enforces the
+-- invariant "an org that still has members always has at least one admin". It
+-- fires for every removal path (remove_member, leave_organization, direct admin
+-- DELETE) and for demotions (update_member_role, direct admin UPDATE), so the
+-- rule lives in exactly one place regardless of who performs the operation.
+--
+-- It blocks ONLY when the operation would leave zero admins AND other members
+-- remain (a genuine lockout). Removing the last admin of an org that has no
+-- other members is allowed — nobody is locked out, and this is the path
+-- delete_account and org cleanup rely on. SECURITY DEFINER so the admin/member
+-- counts are computed independent of the caller's RLS visibility.
+create or replace function public.prevent_last_admin_removal()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  remaining_admins  integer;
+  remaining_members integer;
+begin
+  -- Only an admin leaving/being demoted can cause a lockout; everything else
+  -- passes straight through.
+  if tg_op = 'DELETE' then
+    if old.role <> 'admin' then
+      return old;
+    end if;
+  elsif tg_op = 'UPDATE' then
+    -- Only a demotion (admin -> non-admin) is relevant. Promotions and any other
+    -- column change are always safe.
+    if not (old.role = 'admin' and new.role <> 'admin') then
+      return new;
+    end if;
+  end if;
+
+  -- Admins that would remain in the org, excluding this membership.
+  select count(*) into remaining_admins
+  from public.memberships m
+  where m.org_id = old.org_id
+    and m.role = 'admin'
+    and m.user_id <> old.user_id;
+
+  -- Members that would remain after the operation. On DELETE the row is gone; on
+  -- a demotion the row stays (as a plain member), so it still counts.
+  if tg_op = 'DELETE' then
+    select count(*) into remaining_members
+    from public.memberships m
+    where m.org_id = old.org_id
+      and m.user_id <> old.user_id;
+  else
+    select count(*) into remaining_members
+    from public.memberships m
+    where m.org_id = old.org_id;
+  end if;
+
+  if remaining_admins = 0 and remaining_members > 0 then
+    raise exception 'cannot remove or demote the last admin while other members remain';
+  end if;
+
+  if tg_op = 'DELETE' then
+    return old;
+  else
+    return new;
+  end if;
+end;
+$$;
+
+drop trigger if exists prevent_last_admin_removal on public.memberships;
+create trigger prevent_last_admin_removal
+  before delete or update on public.memberships
+  for each row execute function public.prevent_last_admin_removal();
+
+-- ---------------------------------------------------------------------------
+-- remove_member: an admin removes another member from the org
+-- ---------------------------------------------------------------------------
+-- Caller must be an admin of the org (defense-in-depth on top of the
+-- memberships_delete RLS policy). The last-admin trigger blocks removing the
+-- sole admin while other members remain.
+create or replace function public.remove_member(p_org_id uuid, p_user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'remove_member requires an authenticated user';
+  end if;
+
+  if not public.is_org_admin(p_org_id) then
+    raise exception 'not an admin of this organization';
+  end if;
+
+  delete from public.memberships
+  where org_id = p_org_id
+    and user_id = p_user_id;
+end;
+$$;
+
+revoke execute on function public.remove_member(uuid, uuid) from public;
+grant execute on function public.remove_member(uuid, uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- leave_organization: a member removes their own membership
+-- ---------------------------------------------------------------------------
+-- Any member may leave; the last-admin trigger stops a sole admin from leaving
+-- an org that still has other members (they must archive it or promote someone
+-- first). SECURITY DEFINER because PR1 has no self-serve DELETE policy on
+-- memberships (deletes are admin-gated); leaving must run as the table owner.
+create or replace function public.leave_organization(p_org_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'leave_organization requires an authenticated user';
+  end if;
+
+  if not public.is_org_member(p_org_id) then
+    raise exception 'not a member of this organization';
+  end if;
+
+  delete from public.memberships
+  where org_id = p_org_id
+    and user_id = auth.uid();
+end;
+$$;
+
+revoke execute on function public.leave_organization(uuid) from public;
+grant execute on function public.leave_organization(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- update_member_role: an admin changes a member's role
+-- ---------------------------------------------------------------------------
+-- Caller must be an admin. The last-admin trigger blocks demoting the sole admin
+-- while other members remain.
+create or replace function public.update_member_role(p_org_id uuid, p_user_id uuid, p_role public.membership_role)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'update_member_role requires an authenticated user';
+  end if;
+
+  if not public.is_org_admin(p_org_id) then
+    raise exception 'not an admin of this organization';
+  end if;
+
+  update public.memberships
+  set role = p_role
+  where org_id = p_org_id
+    and user_id = p_user_id;
+end;
+$$;
+
+revoke execute on function public.update_member_role(uuid, uuid, public.membership_role) from public;
+grant execute on function public.update_member_role(uuid, uuid, public.membership_role) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- archive_organization: soft-delete an org (admin only)
+-- ---------------------------------------------------------------------------
+-- Sets archived_at = now(). The is_org_member / is_org_admin helpers then stop
+-- returning true for the org, so it drops out of every read path for everyone.
+-- No hard delete: the org's data is retained. Idempotent (a re-archive is a
+-- no-op). The admin check runs while the org is still un-archived.
+create or replace function public.archive_organization(p_org_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'archive_organization requires an authenticated user';
+  end if;
+
+  if not public.is_org_admin(p_org_id) then
+    raise exception 'not an admin of this organization';
+  end if;
+
+  update public.organizations
+  set archived_at = now()
+  where id = p_org_id
+    and archived_at is null;
+end;
+$$;
+
+revoke execute on function public.archive_organization(uuid) from public;
+grant execute on function public.archive_organization(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- list_org_members: members + their emails, for any member of the org
+-- ---------------------------------------------------------------------------
+-- RLS on memberships exposes user_id + role but NOT emails (auth.users is not
+-- readable by the authenticated role). This SECURITY DEFINER function joins
+-- auth.users to surface each member's email, but ONLY to a caller who is a
+-- member of the org — so emails never leak across tenants. auth.users is
+-- schema-qualified because `auth` is intentionally off the search_path.
+create or replace function public.list_org_members(p_org_id uuid)
+returns table (
+  user_id    uuid,
+  email      text,
+  role       public.membership_role,
+  created_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'list_org_members requires an authenticated user';
+  end if;
+
+  if not public.is_org_member(p_org_id) then
+    raise exception 'not a member of this organization';
+  end if;
+
+  return query
+    select m.user_id, u.email::text, m.role, m.created_at
+    from public.memberships m
+    join auth.users u on u.id = m.user_id
+    where m.org_id = p_org_id
+    order by m.created_at asc;
+end;
+$$;
+
+revoke execute on function public.list_org_members(uuid) from public;
+grant execute on function public.list_org_members(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- delete_account: keep it compatible with the new last-admin guard
+-- ---------------------------------------------------------------------------
+-- The prior version (migration 20260723110000) reassigned created_by of shared
+-- orgs the caller created but did NOT ensure an admin remained. With the
+-- last-admin trigger now in place, deleting the caller's membership from any org
+-- where they are the SOLE admin and other members remain would be blocked,
+-- breaking account deletion. So before removing the caller's memberships we
+-- promote a replacement admin (the oldest remaining member) in exactly those
+-- orgs — preserving the no-lockout invariant everywhere. Everything else is
+-- unchanged from the original.
+create or replace function public.delete_account()
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  current_uid uuid := auth.uid();
+begin
+  if current_uid is null then
+    raise exception 'delete_account requires an authenticated user';
+  end if;
+
+  -- 1. Hand off orgs the caller created that still have OTHER members: reassign
+  --    created_by to another member (preferring an admin) so the org and every
+  --    other member's data survive.
+  update public.organizations o
+  set created_by = (
+    select m.user_id
+    from public.memberships m
+    where m.org_id = o.id and m.user_id <> current_uid
+    order by (m.role = 'admin') desc, m.created_at asc
+    limit 1
+  )
+  where o.created_by = current_uid
+    and exists (
+      select 1 from public.memberships m
+      where m.org_id = o.id and m.user_id <> current_uid
+    );
+
+  -- 2. Delete only the orgs the caller created that have NO other members (their
+  --    personal/solo orgs). Cascades all of that org's data.
+  delete from public.organizations o
+  where o.created_by = current_uid
+    and not exists (
+      select 1 from public.memberships m
+      where m.org_id = o.id and m.user_id <> current_uid
+    );
+
+  -- 3. Clear references to the caller that would otherwise block the users delete.
+  update public.invitations set invited_by = null where invited_by = current_uid;
+
+  -- 3b. Promote a replacement admin (the oldest remaining member) in every org
+  --     where the caller is the SOLE admin and other members remain, so removing
+  --     the caller's membership below does not trip the last-admin guard and
+  --     leave a member-bearing org adminless.
+  update public.memberships target
+  set role = 'admin'
+  where target.id in (
+    select distinct on (o.id) other.id
+    from public.organizations o
+    join public.memberships caller
+      on caller.org_id = o.id and caller.user_id = current_uid and caller.role = 'admin'
+    join public.memberships other
+      on other.org_id = o.id and other.user_id <> current_uid
+    where not exists (
+      select 1 from public.memberships a
+      where a.org_id = o.id and a.role = 'admin' and a.user_id <> current_uid
+    )
+    order by o.id, other.created_at asc
+  );
+
+  -- 4. Remove the caller's remaining memberships (in handed-off or other orgs).
+  delete from public.memberships where user_id = current_uid;
+
+  -- 5. Delete the account itself. Cascades the caller's configs; nulls the
+  --    append-only usage/activity actor and skills.created_by.
+  delete from auth.users where id = current_uid;
+end;
+$$;
+
+revoke execute on function public.delete_account() from public;
+grant execute on function public.delete_account() to authenticated;

--- a/supabase/tests/org_member_management.test.sql
+++ b/supabase/tests/org_member_management.test.sql
@@ -1,0 +1,200 @@
+-- pgTAP: prove the org member-management RPCs, the last-admin lockout guard, and
+-- archiving behave correctly and keep RLS isolation intact.
+--
+-- Like the other suites, we impersonate authenticated end users per assertion:
+--   set local role authenticated;
+--   set local request.jwt.claims = '{"sub":"<uuid>"}';
+-- auth.uid() reads the "sub" claim. The RPCs are SECURITY DEFINER: they run as
+-- the owner but read auth.uid() from these claims. We `reset role;` to seed data
+-- and to read results back bypassing RLS.
+
+begin;
+select plan(15);
+
+-- ---------------------------------------------------------------------------
+-- Seed as the table owner (RLS bypassed).
+--   Org One (aaaa): u1 admin, u2 admin, u3 user — a second admin is present, so
+--                   removals/demotions/leaves succeed here.
+--   Org Two (bbbb): u4 SOLE admin, u5 user — used to prove the last-admin guard.
+-- ---------------------------------------------------------------------------
+insert into auth.users (instance_id, id, aud, role, email, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000', '11111111-1111-1111-1111-111111111111', 'authenticated', 'authenticated', 'u1@example.com', now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '22222222-2222-2222-2222-222222222222', 'authenticated', 'authenticated', 'u2@example.com', now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '33333333-3333-3333-3333-333333333333', 'authenticated', 'authenticated', 'u3@example.com', now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '44444444-4444-4444-4444-444444444444', 'authenticated', 'authenticated', 'u4@example.com', now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '55555555-5555-5555-5555-555555555555', 'authenticated', 'authenticated', 'u5@example.com', now(), now());
+
+insert into public.organizations (id, name, created_by)
+values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Org One', '11111111-1111-1111-1111-111111111111'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Org Two', '44444444-4444-4444-4444-444444444444');
+
+-- created_at values are staggered so list_org_members / promotion ordering is
+-- deterministic.
+insert into public.memberships (org_id, user_id, role, created_at)
+values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', 'admin', now() - interval '3 days'),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', 'admin', now() - interval '2 days'),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '33333333-3333-3333-3333-333333333333', 'user',  now() - interval '1 day'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '44444444-4444-4444-4444-444444444444', 'admin', now() - interval '2 days'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '55555555-5555-5555-5555-555555555555', 'user',  now() - interval '1 day');
+
+-- ===========================================================================
+-- Last-admin lockout guard (Org Two: u4 is the sole admin, u5 is a member).
+-- ===========================================================================
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444"}';
+
+-- 1. The sole admin cannot be removed (remove_member) while other members remain.
+select throws_ok(
+  $sql$ select public.remove_member('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '44444444-4444-4444-4444-444444444444') $sql$,
+  'cannot remove or demote the last admin while other members remain',
+  'remove_member is blocked for the last admin'
+);
+
+-- 2. The sole admin cannot be demoted (update_member_role) while members remain.
+select throws_ok(
+  $sql$ select public.update_member_role('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '44444444-4444-4444-4444-444444444444', 'user') $sql$,
+  'cannot remove or demote the last admin while other members remain',
+  'update_member_role is blocked for the last admin'
+);
+
+-- 3. The sole admin cannot leave (leave_organization) while members remain.
+select throws_ok(
+  $sql$ select public.leave_organization('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb') $sql$,
+  'cannot remove or demote the last admin while other members remain',
+  'leave_organization is blocked for the last admin'
+);
+
+-- ===========================================================================
+-- Successful management with a second admin present (Org One).
+-- ===========================================================================
+reset role;
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111"}';  -- u1, admin
+
+-- 4. An admin removes a member.
+select lives_ok(
+  $sql$ select public.remove_member('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '33333333-3333-3333-3333-333333333333') $sql$,
+  'remove_member succeeds when another admin remains'
+);
+
+-- 5. The removed member is gone.
+reset role;
+select is(
+  (select count(*) from public.memberships
+   where org_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+     and user_id = '33333333-3333-3333-3333-333333333333'),
+  0::bigint,
+  'remove_member deletes the membership'
+);
+
+-- 6. An admin demotes the OTHER admin (u1 still admin, so no lockout).
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111"}';
+select lives_ok(
+  $sql$ select public.update_member_role('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', 'user') $sql$,
+  'update_member_role succeeds when another admin remains'
+);
+
+-- 7. The demoted member's role is now 'user'.
+reset role;
+select is(
+  (select role::text from public.memberships
+   where org_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+     and user_id = '22222222-2222-2222-2222-222222222222'),
+  'user',
+  'update_member_role changes the role'
+);
+
+-- 8. A member leaves the org (u2, now a plain user; u1 remains admin).
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select lives_ok(
+  $sql$ select public.leave_organization('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa') $sql$,
+  'leave_organization succeeds for a non-last-admin member'
+);
+
+-- 9. That membership is gone.
+reset role;
+select is(
+  (select count(*) from public.memberships
+   where org_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+     and user_id = '22222222-2222-2222-2222-222222222222'),
+  0::bigint,
+  'leave_organization deletes the caller membership'
+);
+
+-- ===========================================================================
+-- RLS isolation: a non-member of Org Two cannot manage it or read its members.
+-- ===========================================================================
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111"}';  -- u1: NOT a member of Org Two
+
+-- 10. A non-admin (here a non-member) cannot remove members from another org.
+select throws_ok(
+  $sql$ select public.remove_member('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '55555555-5555-5555-5555-555555555555') $sql$,
+  'not an admin of this organization',
+  'remove_member rejects a non-admin of the org'
+);
+
+-- 11. A non-member cannot list another org's members.
+select throws_ok(
+  $sql$ select public.list_org_members('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb') $sql$,
+  'not a member of this organization',
+  'list_org_members rejects a non-member'
+);
+
+-- ===========================================================================
+-- list_org_members exposes emails to members (safe member-email exposure).
+-- ===========================================================================
+reset role;
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444"}';  -- u4, member of Org Two
+
+-- 12. A member sees other members' emails (which raw RLS never exposes).
+select is(
+  (select email from public.list_org_members('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
+   where user_id = '55555555-5555-5555-5555-555555555555'),
+  'u5@example.com',
+  'list_org_members returns member emails to a member'
+);
+
+-- ===========================================================================
+-- Archiving (Org Two).
+-- ===========================================================================
+
+-- 13. A non-admin member cannot archive the org.
+reset role;
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"55555555-5555-5555-5555-555555555555"}';  -- u5, plain member
+select throws_ok(
+  $sql$ select public.archive_organization('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb') $sql$,
+  'not an admin of this organization',
+  'archive_organization rejects a non-admin'
+);
+
+-- 14. The admin archives the org (soft-delete: archived_at is set, row kept).
+reset role;
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444"}';  -- u4, admin
+select public.archive_organization('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+
+reset role;  -- read back as owner (bypass RLS)
+select ok(
+  (select archived_at is not null from public.organizations where id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+  'archive_organization sets archived_at (row is retained, not deleted)'
+);
+
+-- 15. The archived org drops out of the member read path: is_org_member is now
+--     false for a member of the archived org.
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"44444444-4444-4444-4444-444444444444"}';
+select ok(
+  not public.is_org_member('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+  'an archived org is filtered out of the member read path'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Description

Complete org member management and multi-org support on top of the existing invite/accept flow (#124 / #134): remove a member, leave an org, change role, last-admin lockout guard, org archiving, an active-org concept + switcher UI, and safe member-email exposure. RLS isolation is preserved and everything degrades local-first (no cloud never blocks the app).

## Related Issue

Closes #137

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **Migration** `supabase/migrations/20260723120000_org_member_management.sql`: adds `organizations.archived_at`; rewrites `is_org_member`/`is_org_admin` to exclude archived orgs (auto-filters them from every gated read path); a single `prevent_last_admin_removal` `BEFORE DELETE OR UPDATE` trigger enforcing the no-lockout invariant across remove/demote/leave; SECURITY DEFINER RPCs `remove_member`, `leave_organization`, `update_member_role`, `archive_organization`, `list_org_members` (all mirroring the `get_org_shared_config` auth + membership/admin pattern with locked `search_path`). `delete_account` is updated to promote the oldest remaining member to admin before dropping a sole-admin membership, so the new trigger doesn't break account deletion.
- **Tests** `supabase/tests/org_member_management.test.sql`: 15 pgTAP assertions covering last-admin lockout (remove/demote/leave), RLS isolation (non-member/non-admin rejected), successful mutations with a second admin present, archiving, and safe email exposure via `list_org_members`.
- **Service** `desktop/src/main/cloud/org.ts`: adds `listOrgs`, `removeMember`, `leaveOrg`, `updateMemberRole`, `archiveOrg`, `switchOrg` (re-applies the shared config with replace semantics on switch); rewrites `listMembers` to use the RPC so all member emails surface; clears `currentOrgId` on leave/archive of the active org. All paths degrade local-first.
- **Config** `desktop/src/main/config/config.ts`: `mergeOrgSharedConfig` gains a `'fill' | 'replace'` mode so switching orgs actually swaps org-owned keys instead of only filling unset ones.
- **IPC / preload**: new channels `org:list`, `org:removeMember`, `org:leave`, `org:updateRole`, `org:archive`, `org:switch`.
- **State**: active org + org list promoted to the Zustand store; `useOrg` fans out a `refresh()` after each mutation.
- **UI**: per-member role dropdown + remove button (admin only, self excluded), a "Leave organization" button (replaced by a hint when the user is the sole admin), an archive danger-zone modal (mirrors delete-account) in `OrgPage.tsx`; a multi-org switcher in `SidebarAccount.tsx` (shown only when the user belongs to >1 org).

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`) — 0 errors (3 pre-existing `any` warnings in `RepoPage.tsx`, untouched here)
- [ ] Tested installation script
- [ ] Tested affected slash commands

TypeScript typecheck (`tsc --noEmit`) passes clean. The pgTAP suite is written to convention but was not executed in this environment (no local Postgres).

### Test Steps

1. Configure cloud env (`MAGIC_SLASH_SUPABASE_URL` / `MAGIC_SLASH_SUPABASE_ANON_KEY`), apply migration `20260723120000_org_member_management.sql`, then run `supabase/tests/org_member_management.test.sql` → all 15 assertions pass.
2. Sign in as a user belonging to 2+ orgs → open the account menu (sidebar), use the org switcher to change the active org → confirm the shared config (languages/commit/PR/keywords) reflects the newly active org.
3. As an admin in Settings → Organization: change a member's role (user ↔ admin) and remove a member → confirm real member emails are displayed (not user ids).
4. Attempt to remove or demote the last admin of an org that still has other members → the action is blocked (error/toast) and unavailable in the UI.
5. Leave an org as a non-sole-admin member; then use the danger-zone "Archive organization" (admin) → the org disappears from lists and the switcher.
6. Launch with no Supabase env configured → no cloud features are visible and the app remains fully functional (local-first).

## Screenshots

N/A — no user-facing visual assets to capture for this change beyond the described flows.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

**Product decisions (agreed before implementation):**
- Org deletion = **archiving** via `archived_at` (data retained, org hidden everywhere), not hard delete.
- "Shared skills/agents follow the active org" is satisfied by re-applying the **existing** `OrgSharedConfig` on switch — no new skills/agents schema.
- Audit log deferred (optional, out of scope).

**Attention points for the reviewer:**
- No unit tests for the new `replace` config-merge mode / `switchOrg` — that path is currently exercised manually only.
- `archive_organization` is gated on `is_org_admin` (any admin), whereas the ticket phrased delete/archive as an owner action — flag if owner-only is desired.
- `replace` mode overwrites local per-repo config tweaks (commit/PR/language/keywords) with the org's values on switch; there is no per-org local retention.