### PR TITLE
[Cloud PR 3] Storage abstraction — config/agents/history in the cloud (#125)

### DIFF
--- a/desktop/src/main/cloud/org.ts
+++ b/desktop/src/main/cloud/org.ts
@@ -2,7 +2,8 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Config, Invitation, InvitationStatus, Member, MembershipRole, Org, OrgSharedConfig } from '../../types'
 import { getAuthedClient } from './auth'
 import { loadSession } from './session-store'
-import { readConfig, mergeOrgSharedConfig, setCurrentOrgId } from '../config/config'
+import { readConfig, writeConfig, hydrateConfig, mergeOrgSharedConfig, setCurrentOrgId } from '../config/config'
+import { getStore } from '../store/Store'
 
 interface OrgRow {
   id: string
@@ -247,8 +248,24 @@ export async function switchOrg(orgId: string): Promise<Config> {
   const client = await getAuthedClient()
   if (!client) throw new Error('Cloud features are not available')
 
-  setCurrentOrgId(orgId)
-  return mergeSharedConfigWith(client, orgId, 'replace')
+  // Configs are per (org, user): point the store at the newly-active org and
+  // re-hydrate that org's config row (rather than mutating the current one).
+  getStore().setActiveOrgId(orgId)
+  const config = await hydrateConfig()
+  config.currentOrgId = orgId
+  writeConfig(config)
+  return config
+}
+
+/**
+ * Admin-only: push the org's shared config (languages, commit/PR format, repo
+ * keywords) to the backend via the set_org_shared_config RPC, so every member
+ * inherits it through get_org_shared_config / applySharedConfig.
+ */
+export async function setOrgSharedConfig(shared: OrgSharedConfig, orgId?: string): Promise<void> {
+  const targetOrgId = orgId ?? (await getCurrentOrg())?.id
+  if (!targetOrgId) throw new Error('No organization to update')
+  await getStore().setOrgSharedConfig(targetOrgId, shared)
 }
 
 /**

--- a/desktop/src/main/config/activity-history.test.ts
+++ b/desktop/src/main/config/activity-history.test.ts
@@ -1,61 +1,39 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import * as fs from 'fs'
-import * as path from 'path'
-import * as os from 'os'
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { HistoryEntry } from '../../types'
+import type { Store } from '../store/Store'
+import { setStore, NOOP_STORE } from '../store/Store'
+import { readHistory, addHistoryEntry, hydrateHistory } from './activity-history'
 
-let tmpDir: string
+// History lives in the append-only Supabase `activity_events` table behind the
+// Store — there is no local history.json and no clear operation (dropped: the
+// table is append-only; a read limit replaces the old purge).
 
-beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'activity-history-test-'))
-})
+let appended: HistoryEntry[] = []
 
-afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true })
-})
-
-function writeHistoryFile(data: unknown): void {
-  fs.writeFileSync(path.join(tmpDir, 'history.json'), JSON.stringify(data, null, 2))
+function fakeStore(initial: HistoryEntry[] = []): Store {
+  appended = structuredClone(initial)
+  return {
+    ...NOOP_STORE,
+    loadHistory: async (limit) => structuredClone(appended).slice(-limit),
+    appendHistory: async (e) => { appended.push(structuredClone(e)) },
+  }
 }
 
-function readHistoryFile(): unknown {
-  return JSON.parse(fs.readFileSync(path.join(tmpDir, 'history.json'), 'utf8'))
+async function seed(initial: HistoryEntry[] = []): Promise<void> {
+  setStore(fakeStore(initial))
+  await hydrateHistory()
 }
 
-describe('readHistory', () => {
-  let readHistory: typeof import('./activity-history').readHistory
-
-  beforeEach(async () => {
-    vi.doMock('./config', () => ({
-      CONFIG_DIR: tmpDir,
-    }))
-    vi.resetModules()
-    const mod = await import('./activity-history')
-    readHistory = mod.readHistory
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('should return [] when history.json does not exist', () => {
+describe('hydrateHistory / readHistory', () => {
+  it('returns [] when the store has no history', async () => {
+    await seed([])
     expect(readHistory()).toEqual([])
   })
 
-  it('should return [] when file contains non-array', () => {
-    writeHistoryFile({ foo: 'bar' })
-    expect(readHistory()).toEqual([])
-  })
-
-  it('should return [] when file contains invalid JSON', () => {
-    fs.writeFileSync(path.join(tmpDir, 'history.json'), '{broken')
-    expect(readHistory()).toEqual([])
-  })
-
-  it('should return entries when file contains a valid array', () => {
-    const entries = [
+  it('returns the entries loaded from the store', async () => {
+    await seed([
       { id: '1', agentId: 'a1', agentName: 'Claude 1', action: 'started', repositories: [], timestamp: 1000 },
-    ]
-    writeHistoryFile(entries)
+    ])
     const result = readHistory()
     expect(result).toHaveLength(1)
     expect(result[0].id).toBe('1')
@@ -63,24 +41,9 @@ describe('readHistory', () => {
 })
 
 describe('addHistoryEntry', () => {
-  let addHistoryEntry: typeof import('./activity-history').addHistoryEntry
-  let readHistory: typeof import('./activity-history').readHistory
+  beforeEach(async () => { await seed([]) })
 
-  beforeEach(async () => {
-    vi.doMock('./config', () => ({
-      CONFIG_DIR: tmpDir,
-    }))
-    vi.resetModules()
-    const mod = await import('./activity-history')
-    addHistoryEntry = mod.addHistoryEntry
-    readHistory = mod.readHistory
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('should create an entry with all fields', () => {
+  it('creates an entry with all fields', () => {
     const entry = addHistoryEntry({
       agentId: 'a1',
       agentName: 'Claude 1',
@@ -89,7 +52,6 @@ describe('addHistoryEntry', () => {
       description: 'Fix login',
       repositories: ['/repo1'],
     })
-
     expect(entry.id).toBeDefined()
     expect(entry.agentId).toBe('a1')
     expect(entry.agentName).toBe('Claude 1')
@@ -100,37 +62,29 @@ describe('addHistoryEntry', () => {
     expect(entry.timestamp).toBeGreaterThan(0)
   })
 
-  it('should persist to history.json', () => {
-    addHistoryEntry({
-      agentId: 'a1',
-      agentName: 'Claude 1',
-      action: 'committed',
-      repositories: [],
-    })
-
-    const data = readHistoryFile() as unknown[]
-    expect(data).toHaveLength(1)
+  it('appends to the in-memory cache', () => {
+    addHistoryEntry({ agentId: 'a1', agentName: 'Claude 1', action: 'committed', repositories: [] })
+    expect(readHistory()).toHaveLength(1)
   })
 
-  it('should append to existing entries', () => {
-    writeHistoryFile([
+  it('writes through to the store', async () => {
+    addHistoryEntry({ agentId: 'a1', agentName: 'Claude 1', action: 'committed', repositories: [] })
+    await Promise.resolve()
+    expect(appended).toHaveLength(1)
+  })
+
+  it('appends after existing entries', async () => {
+    await seed([
       { id: 'existing', agentId: 'a0', agentName: 'Old', action: 'started', repositories: [], timestamp: 1000 },
     ])
-
-    addHistoryEntry({
-      agentId: 'a1',
-      agentName: 'Claude 1',
-      action: 'committed',
-      repositories: [],
-    })
-
+    addHistoryEntry({ agentId: 'a1', agentName: 'Claude 1', action: 'committed', repositories: [] })
     const result = readHistory()
     expect(result).toHaveLength(2)
     expect(result[0].id).toBe('existing')
   })
 
-  it('should cap entries at 500 by removing oldest', () => {
-    const existing = Array.from({ length: 500 }, (_, i) => ({
+  it('caps the in-memory cache at the read limit (500)', async () => {
+    const existing: HistoryEntry[] = Array.from({ length: 500 }, (_, i) => ({
       id: `entry-${i}`,
       agentId: 'a1',
       agentName: 'Claude',
@@ -138,52 +92,13 @@ describe('addHistoryEntry', () => {
       repositories: [],
       timestamp: i,
     }))
-    writeHistoryFile(existing)
+    await seed(existing)
 
-    addHistoryEntry({
-      agentId: 'a2',
-      agentName: 'Claude 2',
-      action: 'committed',
-      repositories: [],
-    })
+    addHistoryEntry({ agentId: 'a2', agentName: 'Claude 2', action: 'committed', repositories: [] })
 
     const result = readHistory()
     expect(result).toHaveLength(500)
     expect(result[0].id).toBe('entry-1')
     expect(result[result.length - 1].agentName).toBe('Claude 2')
-  })
-})
-
-describe('clearHistory', () => {
-  let clearHistory: typeof import('./activity-history').clearHistory
-  let readHistory: typeof import('./activity-history').readHistory
-
-  beforeEach(async () => {
-    vi.doMock('./config', () => ({
-      CONFIG_DIR: tmpDir,
-    }))
-    vi.resetModules()
-    const mod = await import('./activity-history')
-    clearHistory = mod.clearHistory
-    readHistory = mod.readHistory
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('should clear all entries', () => {
-    writeHistoryFile([
-      { id: '1', agentId: 'a1', agentName: 'Claude', action: 'started', repositories: [], timestamp: 1000 },
-      { id: '2', agentId: 'a1', agentName: 'Claude', action: 'committed', repositories: [], timestamp: 2000 },
-    ])
-
-    clearHistory()
-    expect(readHistory()).toEqual([])
-  })
-
-  it('should handle clearing when file does not exist', () => {
-    clearHistory()
-    expect(readHistory()).toEqual([])
   })
 })

--- a/desktop/src/main/config/activity-history.ts
+++ b/desktop/src/main/config/activity-history.ts
@@ -1,38 +1,34 @@
-import * as fs from 'fs'
-import * as path from 'path'
 import * as crypto from 'crypto'
 import type { HistoryEntry, HistoryAction } from '../../types'
-import { CONFIG_DIR } from './config'
+import { getStore, reportWriteError } from '../store/Store'
 
-const HISTORY_FILE = path.join(CONFIG_DIR, 'history.json')
-const MAX_ENTRIES = 500
+// Read limit for the activity feed. activity_events is append-only (there is no
+// clear/purge), so instead of capping on write we simply read the most recent
+// READ_LIMIT entries. This replaces the old MAX_ENTRIES=500 purge.
+const READ_LIMIT = 500
 
-export function readHistory(): HistoryEntry[] {
+// In-memory history cache. History lives in the Supabase `activity_events` table
+// (see store/CloudStore.ts) — there is no local history.json.
+let historyCache: HistoryEntry[] = []
+
+/** Load recent history from the store into the cache. Call after auth is established. */
+export async function hydrateHistory(): Promise<HistoryEntry[]> {
   try {
-    if (!fs.existsSync(HISTORY_FILE)) {
-      return []
-    }
-    const content = fs.readFileSync(HISTORY_FILE, 'utf8')
-    const data = JSON.parse(content)
-    if (!Array.isArray(data)) {
-      return []
-    }
-    return data
+    historyCache = await getStore().loadHistory(READ_LIMIT)
   } catch (error) {
-    console.error('Error reading activity history:', error)
-    return []
+    console.error('Error hydrating activity history:', error)
+    historyCache = []
   }
+  return historyCache
 }
 
-function writeHistory(entries: HistoryEntry[]): void {
-  try {
-    if (!fs.existsSync(CONFIG_DIR)) {
-      fs.mkdirSync(CONFIG_DIR, { recursive: true })
-    }
-    fs.writeFileSync(HISTORY_FILE, JSON.stringify(entries, null, 2))
-  } catch (error) {
-    console.error('Error writing activity history:', error)
-  }
+/** Drop the cached history (on sign-out). */
+export function resetHistoryCache(): void {
+  historyCache = []
+}
+
+export function readHistory(): HistoryEntry[] {
+  return historyCache
 }
 
 export function addHistoryEntry(params: {
@@ -54,18 +50,18 @@ export function addHistoryEntry(params: {
     timestamp: Date.now(),
   }
 
-  const entries = readHistory()
-  entries.push(entry)
-
-  // Purge oldest entries if over the limit
-  if (entries.length > MAX_ENTRIES) {
-    entries.splice(0, entries.length - MAX_ENTRIES)
+  historyCache.push(entry)
+  // Keep the in-memory cache bounded to the read limit (oldest-first order).
+  if (historyCache.length > READ_LIMIT) {
+    historyCache.splice(0, historyCache.length - READ_LIMIT)
   }
 
-  writeHistory(entries)
-  return entry
-}
+  void getStore()
+    .appendHistory(entry)
+    .catch((error) => {
+      console.error('Error persisting activity history:', error)
+      reportWriteError('history', error)
+    })
 
-export function clearHistory(): void {
-  writeHistory([])
+  return entry
 }

--- a/desktop/src/main/config/agents.test.ts
+++ b/desktop/src/main/config/agents.test.ts
@@ -1,75 +1,40 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import * as fs from 'fs'
-import * as path from 'path'
-import * as os from 'os'
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Agent } from '../../types'
+import type { Store } from '../store/Store'
+import { setStore, NOOP_STORE } from '../store/Store'
+import {
+  createDefaultMetadata,
+  mergeMetadata,
+  readAgents,
+  writeAgents,
+  saveAgent,
+  removeAgent,
+  updateAgentMetadata,
+  updateAgentSplitPane,
+  hydrateAgents,
+} from './agents'
 
-// We need to mock CONFIG_DIR before importing agents, so that all file I/O
-// goes to a temp directory instead of the real ~/.config/magic-slash.
-let tmpDir: string
+// Agents live in the Supabase `agents` table behind the Store — there is no local
+// agents.json. These tests seed a fake store, hydrate the cache, then exercise the
+// synchronous cache API (which writes through to the store).
 
-beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-test-'))
-})
+let savedAgents: unknown[] = []
 
-afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true })
-})
-
-// Helper: write agents.json in the temp dir
-function writeAgentsFile(data: unknown): void {
-  fs.writeFileSync(path.join(tmpDir, 'agents.json'), JSON.stringify(data, null, 2))
-}
-
-// Helper: read agents.json from the temp dir
-function readAgentsFile(): unknown {
-  return JSON.parse(fs.readFileSync(path.join(tmpDir, 'agents.json'), 'utf8'))
-}
-
-// We dynamically import agents.ts in each test after setting up mocks.
-// To avoid module cache issues, we use vi.mock + vi.doMock.
-
-vi.mock('./config', async () => {
+function fakeStore(initial: unknown[] = []): Store {
+  savedAgents = structuredClone(initial)
   return {
-    filterValidRepositories: (repos: string[]) => repos,
-    get CONFIG_DIR() {
-      // This will be set per-test via tmpDir
-      return tmpDir
-    },
+    ...NOOP_STORE,
+    loadAgents: async () => structuredClone(savedAgents) as Agent[],
+    saveAgents: async (a) => { savedAgents = structuredClone(a) },
   }
-})
+}
 
-// We also need to mock the CONFIG_DIR import used by agents.ts.
-// Since agents.ts does: const AGENTS_FILE = path.join(CONFIG_DIR, 'agents.json')
-// and that's evaluated at module load time, we need to handle this differently.
-// Let's instead re-import the module for each test.
+async function seed(initial: unknown[] = []): Promise<void> {
+  setStore(fakeStore(initial))
+  await hydrateAgents()
+}
 
-// Actually, the simpler approach: since CONFIG_DIR is used at module level to compute
-// AGENTS_FILE, we need to mock it before the module loads. Let's use a different approach:
-// We'll mock the fs module calls instead to redirect to our temp dir.
-
-// Let me take a cleaner approach: mock the config module to return tmpDir,
-// and since AGENTS_FILE is computed once at module load, we need to reset modules.
-
-vi.unmock('./config')
-
-// Clean approach: We'll directly use the exported functions but mock the underlying
-// fs operations by overriding AGENTS_FILE. Since AGENTS_FILE is derived from CONFIG_DIR
-// at module load time, we'll use vi.mock for the config module.
-
-// Actually, the cleanest approach for this codebase: import the pure functions
-// (mergeMetadata, createDefaultMetadata) directly, and for the fs-dependent functions
-// we'll create a small wrapper that sets up the right file paths.
-
-// Let's just test by writing files to a tmp dir and using dynamic imports with
-// module reset. But vitest doesn't easily support per-test module resets.
-
-// Simplest viable approach: mock fs functions to redirect the agents file path.
-
-vi.restoreAllMocks()
-
-// --- Pure function tests (no fs needed) ---
-
-import { createDefaultMetadata, mergeMetadata } from './agents'
+// --- Pure function tests (no store needed) ---
 
 describe('createDefaultMetadata', () => {
   it('should return a default metadata object', () => {
@@ -99,31 +64,22 @@ describe('mergeMetadata', () => {
 
   it('should deep-merge repositoryMetadata', () => {
     const existing = createDefaultMetadata()
-    existing.repositoryMetadata = {
-      'repo-a': { branchName: 'main', path: '/a' } as never,
-    }
+    existing.repositoryMetadata = { 'repo-a': { branchName: 'main', path: '/a' } as never }
 
     const result = mergeMetadata(existing, {
-      repositoryMetadata: {
-        'repo-b': { branchName: 'dev', path: '/b' } as never,
-      },
+      repositoryMetadata: { 'repo-b': { branchName: 'dev', path: '/b' } as never },
     })
 
-    expect(result.repositoryMetadata).toBeDefined()
     expect(result.repositoryMetadata!['repo-a']).toBeDefined()
     expect(result.repositoryMetadata!['repo-b']).toBeDefined()
   })
 
   it('should overwrite same-key repositoryMetadata entries', () => {
     const existing = createDefaultMetadata()
-    existing.repositoryMetadata = {
-      'repo-a': { branchName: 'main', path: '/a' } as never,
-    }
+    existing.repositoryMetadata = { 'repo-a': { branchName: 'main', path: '/a' } as never }
 
     const result = mergeMetadata(existing, {
-      repositoryMetadata: {
-        'repo-a': { branchName: 'develop', path: '/a2' } as never,
-      },
+      repositoryMetadata: { 'repo-a': { branchName: 'develop', path: '/a2' } as never },
     })
 
     expect((result.repositoryMetadata!['repo-a'] as Record<string, string>).branchName).toBe('develop')
@@ -132,12 +88,7 @@ describe('mergeMetadata', () => {
   it('should clean undefined values from the merged result', () => {
     const existing = createDefaultMetadata()
     existing.title = 'hello'
-
     const result = mergeMetadata(existing, { title: undefined } as never)
-    // title is undefined in incoming, but spread keeps existing value
-    // The clean loop removes keys that ended up undefined
-    // In this case, ...existing sets title='hello', ...incoming has title=undefined
-    // so the merged title is undefined, and the clean loop deletes it
     expect('title' in result).toBe(false)
   })
 
@@ -149,231 +100,85 @@ describe('mergeMetadata', () => {
 
   it('should set repositoryMetadata to undefined when both are empty', () => {
     const result = mergeMetadata(undefined, {})
-    // Both existing and incoming repositoryMetadata are empty/undefined
-    // mergedRepoMetadata = {}, Object.keys({}).length === 0 => undefined
-    // then the clean loop removes it
     expect(result.repositoryMetadata).toBeUndefined()
   })
 })
 
-// --- FS-dependent tests ---
-// We mock the AGENTS_FILE constant by mocking the config module's CONFIG_DIR export,
-// but since AGENTS_FILE = path.join(CONFIG_DIR, 'agents.json') is computed at import
-// time, we use a different strategy: directly mock the module-level AGENTS_FILE.
+// --- Store-backed cache tests ---
 
-// The best approach: since agents.ts exports AGENTS_FILE, we can use vi.spyOn on fs
-// to intercept reads/writes. But that's complex. Instead, let's use a helper that
-// writes to a temp dir and then imports agents with mocked paths.
-
-// Final clean approach: We'll use vi.doMock to mock the config import and then
-// dynamically import agents for each describe block.
-
-describe('readAgents (file-based)', () => {
-  let readAgents: typeof import('./agents').readAgents
-
+describe('hydrateAgents / readAgents', () => {
   beforeEach(async () => {
-    vi.doMock('./config', () => ({
-      filterValidRepositories: (repos: string[]) => repos,
-      CONFIG_DIR: tmpDir,
-    }))
-    // Reset the agents module so AGENTS_FILE picks up the new CONFIG_DIR
-    vi.resetModules()
-    const mod = await import('./agents')
-    readAgents = mod.readAgents
+    await seed([])
   })
 
-  afterEach(() => {
-    vi.restoreAllMocks()
+  it('returns [] when the store has no agents', () => {
+    expect(readAgents()).toEqual([])
   })
 
-  it('should return [] when agents.json does not exist', () => {
-    const result = readAgents()
-    expect(result).toEqual([])
-  })
-
-  it('should return [] when file contains non-array (object)', () => {
-    writeAgentsFile({ foo: 'bar' })
-    const result = readAgents()
-    expect(result).toEqual([])
-  })
-
-  it('should return [] when file contains non-array (string)', () => {
-    fs.writeFileSync(path.join(tmpDir, 'agents.json'), '"hello"')
-    const result = readAgents()
-    expect(result).toEqual([])
-  })
-
-  it('should return [] when file contains invalid JSON', () => {
-    fs.writeFileSync(path.join(tmpDir, 'agents.json'), '{broken json')
-    const result = readAgents()
-    expect(result).toEqual([])
-  })
-
-  it('should deduplicate by ID, keeping the last entry', () => {
-    writeAgentsFile([
+  it('deduplicates by id, keeping the last entry', async () => {
+    await seed([
       { id: 'a1', name: 'Agent v1', repositories: [] },
       { id: 'a2', name: 'Agent 2', repositories: [] },
       { id: 'a1', name: 'Agent v2', repositories: [] },
     ])
     const result = readAgents()
     expect(result).toHaveLength(2)
-    const a1 = result.find(a => a.id === 'a1')
-    expect(a1!.name).toBe('Agent v2')
+    expect(result.find(a => a.id === 'a1')!.name).toBe('Agent v2')
   })
 
-  it('should normalize missing repositories to []', () => {
-    writeAgentsFile([{ id: 'a1', name: 'Test' }])
-    const result = readAgents()
-    expect(result[0].repositories).toEqual([])
+  it('normalizes missing repositories/metadata/splitPane', async () => {
+    await seed([{ id: 'a1', name: 'Test' }])
+    const a = readAgents()[0]
+    expect(a.repositories).toEqual([])
+    expect(a.metadata!.title).toBe('')
+    expect(a.metadata!.repositoryMetadata).toEqual({})
+    expect(a.splitPane).toBe('left')
   })
 
-  it('should normalize missing metadata with defaults', () => {
-    writeAgentsFile([{ id: 'a1', name: 'Test', repositories: [] }])
-    const result = readAgents()
-    expect(result[0].metadata).toBeDefined()
-    expect(result[0].metadata!.title).toBe('')
-    expect(result[0].metadata!.relatedWorktrees).toEqual([])
-    expect(result[0].metadata!.repositoryMetadata).toEqual({})
+  it('preserves an existing splitPane value', async () => {
+    await seed([{ id: 'a1', name: 'Test', repositories: [], splitPane: 'right' }])
+    expect(readAgents()[0].splitPane).toBe('right')
   })
 
-  it('should preserve existing metadata fields while filling defaults', () => {
-    writeAgentsFile([{
-      id: 'a1',
-      name: 'Test',
-      repositories: [],
-      metadata: { title: 'My Task', ticketId: 'PROJ-1' },
-    }])
-    const result = readAgents()
-    expect(result[0].metadata!.title).toBe('My Task')
-    expect(result[0].metadata!.ticketId).toBe('PROJ-1')
-    // Defaults filled in
-    expect(result[0].metadata!.branchName).toBe('')
-  })
-
-  it('should normalize missing splitPane to "left"', () => {
-    writeAgentsFile([{ id: 'a1', name: 'Test', repositories: [] }])
-    const result = readAgents()
-    expect(result[0].splitPane).toBe('left')
-  })
-
-  it('should preserve existing splitPane value', () => {
-    writeAgentsFile([{ id: 'a1', name: 'Test', repositories: [], splitPane: 'right' }])
-    const result = readAgents()
-    expect(result[0].splitPane).toBe('right')
-  })
-
-  it('should skip entries without a valid id', () => {
-    writeAgentsFile([
-      { id: 'a1', name: 'Good Agent', repositories: [] },
-      { name: 'No ID Agent', repositories: [] },
-      { id: '', name: 'Empty ID Agent', repositories: [] },
-      { id: null, name: 'Null ID Agent', repositories: [] },
-      { id: 123, name: 'Numeric ID Agent', repositories: [] },
-      { id: 'a2', name: 'Another Good Agent', repositories: [] },
+  it('skips entries without a valid id', async () => {
+    await seed([
+      { id: 'a1', name: 'Good', repositories: [] },
+      { name: 'No ID', repositories: [] },
+      { id: '', name: 'Empty ID', repositories: [] },
+      { id: 'a2', name: 'Good 2', repositories: [] },
     ])
     const result = readAgents()
-    expect(result).toHaveLength(2)
-    expect(result[0].id).toBe('a1')
-    expect(result[1].id).toBe('a2')
+    expect(result.map(a => a.id)).toEqual(['a1', 'a2'])
   })
 })
 
 describe('writeAgents', () => {
-  let writeAgentsFn: typeof import('./agents').writeAgents
+  beforeEach(async () => { await seed([]) })
 
-  beforeEach(async () => {
-    vi.doMock('./config', () => ({
-      filterValidRepositories: (repos: string[]) => repos,
-      CONFIG_DIR: tmpDir,
-    }))
-    vi.resetModules()
-    const mod = await import('./agents')
-    writeAgentsFn = mod.writeAgents
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('should write valid JSON to agents.json', () => {
-    const agents = [
+  it('replaces the cache and writes through to the store', async () => {
+    const agents: Agent[] = [
       { id: 'a1', name: 'Agent 1', repositories: ['/repo1'], tsCreate: 1000 },
       { id: 'a2', name: 'Agent 2', repositories: [], tsCreate: 2000 },
     ]
-    writeAgentsFn(agents as never)
-    const written = readAgentsFile()
-    expect(written).toEqual(agents)
-  })
-
-  it('should create the config directory if it does not exist', () => {
-    const nestedDir = path.join(tmpDir, 'nested', 'dir')
-    // Re-mock with nested dir
-    vi.doMock('./config', () => ({
-      filterValidRepositories: (repos: string[]) => repos,
-      CONFIG_DIR: nestedDir,
-    }))
-    vi.resetModules()
-
-    // Dynamically re-import
-    return import('./agents').then(mod => {
-      mod.writeAgents([{ id: 'a1', name: 'Test', repositories: [], tsCreate: 1 } as never])
-      const content = JSON.parse(fs.readFileSync(path.join(nestedDir, 'agents.json'), 'utf8'))
-      expect(content).toHaveLength(1)
-      expect(content[0].id).toBe('a1')
-    })
-  })
-
-  it('should write an empty array', () => {
-    writeAgentsFn([])
-    const written = readAgentsFile()
-    expect(written).toEqual([])
+    writeAgents(agents)
+    expect(readAgents()).toEqual(agents)
+    await Promise.resolve()
+    expect(savedAgents).toEqual(agents)
   })
 })
 
 describe('saveAgent', () => {
-  let saveAgent: typeof import('./agents').saveAgent
-  let readAgents: typeof import('./agents').readAgents
+  beforeEach(async () => { await seed([]) })
 
-  beforeEach(async () => {
-    vi.doMock('./config', () => ({
-      filterValidRepositories: (repos: string[]) => repos,
-      CONFIG_DIR: tmpDir,
-    }))
-    vi.resetModules()
-    const mod = await import('./agents')
-    saveAgent = mod.saveAgent
-    readAgents = mod.readAgents
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('should create a new agent', () => {
-    // Start with empty agents file
-    writeAgentsFile([])
-
+  it('creates a new agent', () => {
     saveAgent('a1', 'My Agent', ['/repo1'], undefined, 12345)
     const agents = readAgents()
     expect(agents).toHaveLength(1)
-    expect(agents[0].id).toBe('a1')
-    expect(agents[0].name).toBe('My Agent')
-    expect(agents[0].repositories).toEqual(['/repo1'])
-    expect(agents[0].tsCreate).toBe(12345)
+    expect(agents[0]).toMatchObject({ id: 'a1', name: 'My Agent', repositories: ['/repo1'], tsCreate: 12345 })
   })
 
-  it('should preserve existing splitPane when re-saving', () => {
-    // Create initial agent with splitPane = right
-    writeAgentsFile([{
-      id: 'a1',
-      name: 'Agent',
-      repositories: [],
-      tsCreate: 100,
-      splitPane: 'right',
-      metadata: { title: '', branchName: '', ticketId: '', description: '', status: '', fullStackTaskId: '', relatedWorktrees: [], repositoryMetadata: {} },
-    }])
-
-    // Re-save the same agent with new name
+  it('preserves existing splitPane when re-saving', async () => {
+    await seed([{ id: 'a1', name: 'Agent', repositories: [], tsCreate: 100, splitPane: 'right' }])
     saveAgent('a1', 'Updated Agent', ['/repo1'])
     const agents = readAgents()
     expect(agents).toHaveLength(1)
@@ -381,185 +186,73 @@ describe('saveAgent', () => {
     expect(agents[0].splitPane).toBe('right')
   })
 
-  it('should preserve tsCreate from existing agent when not provided', () => {
-    writeAgentsFile([{
-      id: 'a1',
-      name: 'Agent',
-      repositories: [],
-      tsCreate: 5555,
-      metadata: { title: '', branchName: '', ticketId: '', description: '', status: '', fullStackTaskId: '', relatedWorktrees: [], repositoryMetadata: {} },
-    }])
-
+  it('preserves tsCreate from the existing agent when not provided', async () => {
+    await seed([{ id: 'a1', name: 'Agent', repositories: [], tsCreate: 5555 }])
     saveAgent('a1', 'Updated', [])
-    const agents = readAgents()
-    expect(agents[0].tsCreate).toBe(5555)
+    expect(readAgents()[0].tsCreate).toBe(5555)
   })
 
-  it('should add a new agent alongside existing ones', () => {
-    writeAgentsFile([{
-      id: 'a1',
-      name: 'Agent 1',
-      repositories: [],
-      tsCreate: 100,
-      metadata: { title: '', branchName: '', ticketId: '', description: '', status: '', fullStackTaskId: '', relatedWorktrees: [], repositoryMetadata: {} },
-    }])
-
+  it('adds a new agent alongside existing ones', async () => {
+    await seed([{ id: 'a1', name: 'Agent 1', repositories: [], tsCreate: 100 }])
     saveAgent('a2', 'Agent 2', ['/new-repo'], undefined, 200)
     const agents = readAgents()
     expect(agents).toHaveLength(2)
-    expect(agents.find(a => a.id === 'a1')).toBeDefined()
-    expect(agents.find(a => a.id === 'a2')).toBeDefined()
   })
 })
 
 describe('removeAgent', () => {
-  let removeAgent: typeof import('./agents').removeAgent
-  let readAgents: typeof import('./agents').readAgents
-
-  beforeEach(async () => {
-    vi.doMock('./config', () => ({
-      filterValidRepositories: (repos: string[]) => repos,
-      CONFIG_DIR: tmpDir,
-    }))
-    vi.resetModules()
-    const mod = await import('./agents')
-    removeAgent = mod.removeAgent
-    readAgents = mod.readAgents
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('should remove an agent by ID', () => {
-    writeAgentsFile([
+  it('removes an agent by id', async () => {
+    await seed([
       { id: 'a1', name: 'Agent 1', repositories: [], tsCreate: 100 },
       { id: 'a2', name: 'Agent 2', repositories: [], tsCreate: 200 },
     ])
-
     removeAgent('a1')
     const agents = readAgents()
     expect(agents).toHaveLength(1)
     expect(agents[0].id).toBe('a2')
   })
 
-  it('should be a no-op if the ID does not exist', () => {
-    writeAgentsFile([
-      { id: 'a1', name: 'Agent 1', repositories: [], tsCreate: 100 },
-    ])
-
-    removeAgent('nonexistent')
-    const agents = readAgents()
-    expect(agents).toHaveLength(1)
+  it('is a no-op if the id does not exist', async () => {
+    await seed([{ id: 'a1', name: 'Agent 1', repositories: [], tsCreate: 100 }])
+    removeAgent('nope')
+    expect(readAgents()).toHaveLength(1)
   })
 })
 
 describe('updateAgentMetadata', () => {
-  let updateAgentMetadata: typeof import('./agents').updateAgentMetadata
-  let readAgents: typeof import('./agents').readAgents
-
-  beforeEach(async () => {
-    vi.doMock('./config', () => ({
-      filterValidRepositories: (repos: string[]) => repos,
-      CONFIG_DIR: tmpDir,
-    }))
-    vi.resetModules()
-    const mod = await import('./agents')
-    updateAgentMetadata = mod.updateAgentMetadata
-    readAgents = mod.readAgents
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('should deep-merge repositoryMetadata', () => {
-    writeAgentsFile([{
-      id: 'a1',
-      name: 'Agent',
-      repositories: [],
-      tsCreate: 100,
-      metadata: {
-        title: 'Task',
-        repositoryMetadata: {
-          'repo-a': { branchName: 'main' },
-        },
-      },
+  it('deep-merges repositoryMetadata', async () => {
+    await seed([{
+      id: 'a1', name: 'Agent', repositories: [], tsCreate: 100,
+      metadata: { title: 'Task', repositoryMetadata: { 'repo-a': { branchName: 'main' } } },
     }])
-
     updateAgentMetadata('a1', {
       ticketId: 'PROJ-1',
-      repositoryMetadata: {
-        'repo-b': { branchName: 'dev' } as never,
-      },
+      repositoryMetadata: { 'repo-b': { branchName: 'dev' } as never },
     })
-
-    const agents = readAgents()
-    expect(agents[0].metadata!.ticketId).toBe('PROJ-1')
-    expect(agents[0].metadata!.title).toBe('Task')
-    expect(agents[0].metadata!.repositoryMetadata!['repo-a']).toBeDefined()
-    expect(agents[0].metadata!.repositoryMetadata!['repo-b']).toBeDefined()
+    const a = readAgents()[0]
+    expect(a.metadata!.ticketId).toBe('PROJ-1')
+    expect(a.metadata!.title).toBe('Task')
+    expect(a.metadata!.repositoryMetadata!['repo-a']).toBeDefined()
+    expect(a.metadata!.repositoryMetadata!['repo-b']).toBeDefined()
   })
 
-  it('should not modify agents if ID is not found', () => {
-    writeAgentsFile([{
-      id: 'a1',
-      name: 'Agent',
-      repositories: [],
-      tsCreate: 100,
-      metadata: { title: 'Original' },
-    }])
-
-    updateAgentMetadata('nonexistent', { title: 'Changed' })
-    const agents = readAgents()
-    expect(agents[0].metadata!.title).toBe('Original')
+  it('does not modify agents if the id is not found', async () => {
+    await seed([{ id: 'a1', name: 'Agent', repositories: [], tsCreate: 100, metadata: { title: 'Original' } }])
+    updateAgentMetadata('nope', { title: 'Changed' })
+    expect(readAgents()[0].metadata!.title).toBe('Original')
   })
 })
 
 describe('updateAgentSplitPane', () => {
-  let updateAgentSplitPane: typeof import('./agents').updateAgentSplitPane
-  let readAgents: typeof import('./agents').readAgents
-
-  beforeEach(async () => {
-    vi.doMock('./config', () => ({
-      filterValidRepositories: (repos: string[]) => repos,
-      CONFIG_DIR: tmpDir,
-    }))
-    vi.resetModules()
-    const mod = await import('./agents')
-    updateAgentSplitPane = mod.updateAgentSplitPane
-    readAgents = mod.readAgents
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('should update the splitPane value', () => {
-    writeAgentsFile([{
-      id: 'a1',
-      name: 'Agent',
-      repositories: [],
-      tsCreate: 100,
-      splitPane: 'left',
-    }])
-
+  it('updates the splitPane value', async () => {
+    await seed([{ id: 'a1', name: 'Agent', repositories: [], tsCreate: 100, splitPane: 'left' }])
     updateAgentSplitPane('a1', 'right')
-    const agents = readAgents()
-    expect(agents[0].splitPane).toBe('right')
+    expect(readAgents()[0].splitPane).toBe('right')
   })
 
-  it('should not modify agents if ID is not found', () => {
-    writeAgentsFile([{
-      id: 'a1',
-      name: 'Agent',
-      repositories: [],
-      tsCreate: 100,
-      splitPane: 'left',
-    }])
-
-    updateAgentSplitPane('nonexistent', 'right')
-    const agents = readAgents()
-    expect(agents[0].splitPane).toBe('left')
+  it('does not modify agents if the id is not found', async () => {
+    await seed([{ id: 'a1', name: 'Agent', repositories: [], tsCreate: 100, splitPane: 'left' }])
+    updateAgentSplitPane('nope', 'right')
+    expect(readAgents()[0].splitPane).toBe('left')
   })
 })

--- a/desktop/src/main/config/agents.ts
+++ b/desktop/src/main/config/agents.ts
@@ -1,9 +1,6 @@
-import * as fs from 'fs'
-import * as path from 'path'
 import type { Agent, TerminalMetadata } from '../../types'
-import { filterValidRepositories, CONFIG_DIR } from './config'
-
-const AGENTS_FILE = path.join(CONFIG_DIR, 'agents.json')
+import { filterValidRepositories } from './config'
+import { getStore, reportWriteError } from '../store/Store'
 
 export function createDefaultMetadata(): TerminalMetadata {
   return {
@@ -43,61 +40,65 @@ export function mergeMetadata(existing: TerminalMetadata | undefined, incoming: 
 }
 
 /**
- * Reads agents from the dedicated agents.json file.
- * Returns [] if the file is absent or malformed.
- * Performs deduplication, normalization, and validation on load.
+ * Deduplicate + normalize a raw agent list (fill default metadata, repositories
+ * and splitPane, drop entries without a valid id). Applied when hydrating from
+ * the store.
  */
-export function readAgents(): Agent[] {
-  try {
-    if (!fs.existsSync(AGENTS_FILE)) {
-      return []
-    }
-    const content = fs.readFileSync(AGENTS_FILE, 'utf8')
-    const raw = JSON.parse(content)
-
-    if (!Array.isArray(raw)) {
-      console.warn('agents.json is not an array, returning empty list')
-      return []
-    }
-
-    const agentsMap = new Map<string, Agent>()
-    for (const agent of raw) {
-      if (!agent.id || typeof agent.id !== 'string') {
-        continue
-      }
-      if (!agent.repositories) {
-        agent.repositories = []
-      }
-      agent.metadata = {
-        ...createDefaultMetadata(),
-        ...agent.metadata
-      }
-      if (!agent.splitPane) {
-        agent.splitPane = 'left'
-      }
-      agentsMap.set(agent.id, agent)
-    }
-
-    return Array.from(agentsMap.values())
-  } catch (error) {
-    console.error('Error reading agents:', error)
-    return []
+function normalizeAgents(raw: unknown): Agent[] {
+  if (!Array.isArray(raw)) return []
+  const agentsMap = new Map<string, Agent>()
+  for (const agent of raw as Agent[]) {
+    if (!agent.id || typeof agent.id !== 'string') continue
+    if (!agent.repositories) agent.repositories = []
+    agent.metadata = { ...createDefaultMetadata(), ...agent.metadata }
+    if (!agent.splitPane) agent.splitPane = 'left'
+    agentsMap.set(agent.id, agent)
   }
+  return Array.from(agentsMap.values())
+}
+
+// ---------------------------------------------------------------------------
+// In-memory agents cache. Agents live in the Supabase `agents` table (see
+// store/CloudStore.ts) — there is no local agents.json. readAgents() serves the
+// cache synchronously; writeAgents() updates it and writes through to the store.
+// ---------------------------------------------------------------------------
+
+let agentsCache: Agent[] = []
+
+/** Load agents from the store into the cache. Call after auth is established. */
+export async function hydrateAgents(): Promise<Agent[]> {
+  try {
+    agentsCache = normalizeAgents(await getStore().loadAgents())
+  } catch (error) {
+    console.error('Error hydrating agents:', error)
+    agentsCache = []
+  }
+  return agentsCache
+}
+
+/** Drop the cached agents (on sign-out). */
+export function resetAgentsCache(): void {
+  agentsCache = []
 }
 
 /**
- * Writes the agents array to agents.json atomically.
+ * Returns the in-memory agents cache (deduplicated + normalized on hydration).
+ */
+export function readAgents(): Agent[] {
+  return agentsCache
+}
+
+/**
+ * Replace the agents cache and write through to the store.
  */
 export function writeAgents(agents: Agent[]): void {
-  try {
-    if (!fs.existsSync(CONFIG_DIR)) {
-      fs.mkdirSync(CONFIG_DIR, { recursive: true })
-    }
-    fs.writeFileSync(AGENTS_FILE, JSON.stringify(agents, null, 2))
-  } catch (error) {
-    console.error('Error writing agents:', error)
-    throw error
-  }
+  agentsCache = agents
+  void getStore()
+    .saveAgents(agents)
+    .catch((error) => {
+      console.error('Error persisting agents:', error)
+      reportWriteError('agents', error)
+    })
 }
 
 export function saveAgent(id: string, name: string, repositories: string[], metadata?: TerminalMetadata, tsCreate?: number): void {
@@ -156,5 +157,3 @@ export function updateAgentSplitPane(id: string, pane: 'left' | 'right'): void {
     writeAgents(agents)
   }
 }
-
-export { AGENTS_FILE }

--- a/desktop/src/main/config/config-merge.test.ts
+++ b/desktop/src/main/config/config-merge.test.ts
@@ -1,39 +1,27 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import type { Config, OrgSharedConfig } from '../../types'
+import type { Store } from '../store/Store'
+import { setStore, NOOP_STORE } from '../store/Store'
+import { mergeOrgSharedConfig, hydrateConfig } from './config'
 
-// In-memory config file so readConfig/writeConfig have no real FS side effects.
-let store = ''
+// The DB is the single source of truth: config lives behind the Store. These
+// tests seed a fake in-memory store, hydrate the config cache from it, then
+// exercise mergeOrgSharedConfig against the cache.
 
-vi.mock('fs', () => ({
-  existsSync: () => true,
-  readFileSync: () => store,
-  writeFileSync: (_path: string, data: string) => {
-    store = data
-  },
-  mkdirSync: () => undefined,
-}))
+let saved: Config | null = null
 
-// Neutralise schema validation and defaults so readConfig returns our config as-is.
-vi.mock('./schema-validator', () => ({
-  validateConfig: () => ({ valid: true, errors: [] }),
-  hasCriticalErrors: () => false,
-}))
+function fakeStore(initial: Config): Store {
+  saved = structuredClone(initial)
+  return {
+    ...NOOP_STORE,
+    loadConfig: async () => (saved ? structuredClone(saved) : null),
+    saveConfig: async (c) => { saved = structuredClone(c) },
+  }
+}
 
-vi.mock('./defaults', () => ({
-  DEFAULT_REPOSITORY_FIELDS: {},
-  DEFAULT_SPOTLIGHT: {},
-  isValidSpotlightConfig: () => true,
-}))
-
-vi.mock('./validation', () => ({
-  expandPath: (p: string) => p,
-}))
-
-import { mergeOrgSharedConfig } from './config'
-
-/** Seed the in-memory config file. */
-function seed(config: Config): void {
-  store = JSON.stringify(config)
+async function seed(config: Config): Promise<void> {
+  setStore(fakeStore(config))
+  await hydrateConfig()
 }
 
 function baseConfig(): Config {
@@ -43,35 +31,30 @@ function baseConfig(): Config {
     splitEnabled: false,
     splitActive: false,
     integrations: { github: true, atlassian: true },
-    spotlight: {},
-  } as unknown as Config
+    spotlight: { enabled: true, shortcut: 'Control+Space' },
+  }
 }
 
 describe('mergeOrgSharedConfig', () => {
-  beforeEach(() => {
-    store = ''
-  })
-
-  it('fills unset language fields but never overrides existing local ones', () => {
+  it('fills unset language fields but never overrides existing local ones', async () => {
     const config = baseConfig()
     config.repositories = {
       web: { path: '/local/web', keywords: ['web'], languages: { commit: 'fr' } },
     }
-    seed(config)
+    await seed(config)
 
     const shared: OrgSharedConfig = { languages: { commit: 'en', pullRequest: 'en' } }
     const result = mergeOrgSharedConfig(shared)
 
-    // Existing local value wins; missing one is inherited.
     expect(result.repositories.web.languages).toEqual({ commit: 'fr', pullRequest: 'en' })
   })
 
-  it('fills unset commit and pullRequest fields, preserving those already set', () => {
+  it('fills unset commit and pullRequest fields, preserving those already set', async () => {
     const config = baseConfig()
     config.repositories = {
       api: { path: '/local/api', keywords: ['api'], commit: { format: 'gitmoji' } },
     }
-    seed(config)
+    await seed(config)
 
     const shared: OrgSharedConfig = {
       commit: { format: 'angular', style: 'single-line', coAuthor: false },
@@ -87,14 +70,14 @@ describe('mergeOrgSharedConfig', () => {
     expect(result.repositories.api.pullRequest).toEqual({ autoLinkTickets: true })
   })
 
-  it('applies shared keywords only to repos with defaulted keywords', () => {
+  it('applies shared keywords only to repos with defaulted keywords', async () => {
     const config = baseConfig()
     config.repositories = {
       empty: { path: '/local/empty', keywords: [] },
-      defaulted: { path: '/local/defaulted', keywords: ['defaulted'] }, // == repo name
+      defaulted: { path: '/local/defaulted', keywords: ['defaulted'] },
       customized: { path: '/local/customized', keywords: ['payments', 'billing'] },
     }
-    seed(config)
+    await seed(config)
 
     const shared: OrgSharedConfig = {
       repoKeywords: {
@@ -107,42 +90,41 @@ describe('mergeOrgSharedConfig', () => {
 
     expect(result.repositories.empty.keywords).toEqual(['shared', 'kw'])
     expect(result.repositories.defaulted.keywords).toEqual(['shared', 'kw'])
-    expect(result.repositories.customized.keywords).toEqual(['payments', 'billing']) // untouched
+    expect(result.repositories.customized.keywords).toEqual(['payments', 'billing'])
   })
 
-  it('never touches local repo paths', () => {
+  it('never touches local repo paths', async () => {
     const config = baseConfig()
     config.repositories = {
       web: { path: '/very/local/path', keywords: [] },
     }
-    seed(config)
+    await seed(config)
 
     const result = mergeOrgSharedConfig({ languages: { commit: 'en' }, repoKeywords: { web: ['x'] } })
 
     expect(result.repositories.web.path).toBe('/very/local/path')
   })
 
-  it('records the org id when provided', () => {
-    seed(baseConfig())
+  it('records the org id when provided', async () => {
+    await seed(baseConfig())
     const result = mergeOrgSharedConfig({}, 'org-123')
     expect(result.currentOrgId).toBe('org-123')
   })
 
-  it('does not set an org id when none is provided', () => {
-    seed(baseConfig())
+  it('does not set an org id when none is provided', async () => {
+    await seed(baseConfig())
     const result = mergeOrgSharedConfig({})
     expect(result.currentOrgId).toBeUndefined()
   })
 
-  it('ignores empty and malformed shared config without throwing', () => {
+  it('ignores empty and malformed shared config without throwing', async () => {
     const config = baseConfig()
     config.repositories = {
       web: { path: '/local/web', keywords: ['web'], languages: { commit: 'fr' } },
     }
-    seed(config)
+    await seed(config)
 
     expect(() => mergeOrgSharedConfig({})).not.toThrow()
-    // Malformed input (wrong shapes) is defensively ignored.
     const result = mergeOrgSharedConfig({
       languages: 'nope' as unknown as OrgSharedConfig['languages'],
       repoKeywords: { web: 'nope' as unknown as string[] },

--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -1,10 +1,9 @@
-import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import type { Config, RepositoryConfig, LaunchMode, OrgSharedConfig } from '../../types'
-import { validateConfig, hasCriticalErrors } from './schema-validator'
 import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig } from './defaults'
 import { expandPath } from './validation'
+import { getStore, reportWriteError } from '../store/Store'
 
 /** Settings input where each field can be its normal type, 'default', or null (to reset) */
 type SettingsInput<T> = {
@@ -64,95 +63,71 @@ export function filterValidRepositories(repositories: string[]): string[] {
   return repositories.filter(repo => !isExcludedRepositoryPath(repo))
 }
 
-export function readConfig(): Config {
-  try {
-    if (!fs.existsSync(CONFIG_FILE)) {
-      const defaultConfig: Config = {
-        version: 'unknown',
-        repositories: {},
-        splitEnabled: false,
-        splitActive: false,
-      }
-      writeConfig(defaultConfig)
-      return defaultConfig
-    }
-    const content = fs.readFileSync(CONFIG_FILE, 'utf8')
-    const config: Config = JSON.parse(content)
-
-    // Migration: ensure config fields have default values
-    let needsWrite = false
-
-    if (config.splitEnabled === undefined) {
-      config.splitEnabled = false
-      needsWrite = true
-    }
-
-    if (config.splitActive === undefined) {
-      config.splitActive = false
-      needsWrite = true
-    }
-
-    if (!config.integrations) {
-      config.integrations = { github: true, atlassian: true }
-      needsWrite = true
-    }
-
-    if (!isValidSpotlightConfig(config.spotlight)) {
-      config.spotlight = { ...DEFAULT_SPOTLIGHT, ...(typeof config.spotlight === 'object' && config.spotlight !== null ? config.spotlight : {}) }
-      // Re-validate after merge; if still invalid, reset to pure defaults
-      if (!isValidSpotlightConfig(config.spotlight)) {
-        config.spotlight = { ...DEFAULT_SPOTLIGHT }
-      }
-      needsWrite = true
-    }
-
-    if (needsWrite) {
-      writeConfig(config)
-    }
-
-    // Validate config against JSON Schema
-    try {
-      const validation = validateConfig(config)
-      if (!validation.valid) {
-        if (hasCriticalErrors(validation.errors)) {
-          console.error('Critical config validation errors:', validation.errors)
-          throw new Error(`Invalid config: ${validation.errors.join('; ')}`)
-        }
-        // Non-critical errors: warn but continue (graceful degradation)
-        for (const err of validation.errors) {
-          console.warn(`Config validation warning: ${err}`)
-        }
-      }
-    } catch (validationError) {
-      // Re-throw critical errors, but don't crash on schema loading failures
-      if (validationError instanceof Error && validationError.message.startsWith('Invalid config:')) {
-        throw validationError
-      }
-      console.warn('Config schema validation skipped:', validationError)
-    }
-
-    return config
-  } catch (error) {
-    console.error('Error reading config:', error)
-    return {
-      version: 'unknown',
-      repositories: {},
-      splitEnabled: false,
-      splitActive: false,
-    }
+function defaultConfig(): Config {
+  return {
+    version: 'unknown',
+    repositories: {},
+    splitEnabled: false,
+    splitActive: false,
   }
 }
 
-export function writeConfig(config: Config): void {
-  try {
-    if (!fs.existsSync(CONFIG_DIR)) {
-      fs.mkdirSync(CONFIG_DIR, { recursive: true })
+/**
+ * Fill in missing default fields on a config loaded from the store. Mirrors the
+ * defaulting the old file-based reader performed on first load.
+ */
+function withDefaults(config: Config): Config {
+  config.repositories = config.repositories || {}
+  if (config.splitEnabled === undefined) config.splitEnabled = false
+  if (config.splitActive === undefined) config.splitActive = false
+  if (!config.integrations) config.integrations = { github: true, atlassian: true }
+  if (!isValidSpotlightConfig(config.spotlight)) {
+    config.spotlight = { ...DEFAULT_SPOTLIGHT, ...(typeof config.spotlight === 'object' && config.spotlight !== null ? config.spotlight : {}) }
+    if (!isValidSpotlightConfig(config.spotlight)) {
+      config.spotlight = { ...DEFAULT_SPOTLIGHT }
     }
-    fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2))
-  } catch (error) {
-    console.error('Error writing config:', error)
-    throw error
   }
+  return config
+}
+
+// ---------------------------------------------------------------------------
+// In-memory config cache. The Supabase database is the SINGLE source of truth
+// (see store/CloudStore.ts); there is no local config.json. readConfig() serves
+// the cache synchronously, writeConfig() updates it and writes through to the
+// store asynchronously, and hydrateConfig() loads it from the store.
+// ---------------------------------------------------------------------------
+
+let configCache: Config | null = null
+
+/** Load the config from the store into the cache. Call after auth is established. */
+export async function hydrateConfig(): Promise<Config> {
+  try {
+    const loaded = await getStore().loadConfig()
+    configCache = withDefaults(loaded ?? defaultConfig())
+  } catch (error) {
+    console.error('Error hydrating config:', error)
+    configCache = withDefaults(defaultConfig())
+  }
+  return configCache
+}
+
+/** Drop the cached config (on sign-out) so a different user never sees stale data. */
+export function resetConfigCache(): void {
+  configCache = null
+}
+
+export function readConfig(): Config {
+  return configCache ?? defaultConfig()
+}
+
+export function writeConfig(config: Config): void {
+  configCache = config
+  void getStore()
+    .saveConfig(config)
+    .catch((error) => {
+      console.error('Error persisting config:', error)
+      reportWriteError('config', error)
+    })
 }
 
 export function addRepository(name: string, repoPath: string, keywords: string[] = []): Config {
@@ -413,6 +388,8 @@ export function setCurrentOrgId(orgId: string | undefined): Config {
   } else {
     delete config.currentOrgId
   }
+  // Point the store at the active org so subsequent reads/writes target it.
+  getStore().setActiveOrgId(orgId)
   writeConfig(config)
   return config
 }

--- a/desktop/src/main/config/migrate.test.ts
+++ b/desktop/src/main/config/migrate.test.ts
@@ -1,61 +1,36 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import * as fs from 'fs'
-import * as path from 'path'
-import * as os from 'os'
+import { describe, it, expect } from 'vitest'
+import type { Config } from '../../types'
+import type { Store } from '../store/Store'
+import { setStore, NOOP_STORE } from '../store/Store'
+import { readConfig, hydrateConfig } from './config'
+import { migrateConfig } from './migrate'
 
-let tmpDir: string
-let configFile: string
-let agentsFile: string
+// There is NO data migration from legacy local JSON files: migrateConfig only
+// normalizes the in-memory config hydrated from the store (fills default repo
+// fields, sanitizes launchMode, syncs the version). These tests seed a fake
+// store, hydrate, then assert on the normalized cache.
 
-beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-test-'))
-  configFile = path.join(tmpDir, 'config.json')
-  agentsFile = path.join(tmpDir, 'agents.json')
-})
+let saved: Config | null = null
 
-afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true })
-  vi.restoreAllMocks()
-})
-
-function writeConfigFile(data: unknown): void {
-  fs.writeFileSync(configFile, JSON.stringify(data, null, 2))
+function fakeStore(initial: Config): Store {
+  saved = structuredClone(initial)
+  return {
+    ...NOOP_STORE,
+    loadConfig: async () => (saved ? structuredClone(saved) : null),
+    saveConfig: async (c) => { saved = structuredClone(c) },
+  }
 }
 
-function readConfigFile(): unknown {
-  return JSON.parse(fs.readFileSync(configFile, 'utf8'))
+async function seed(config: Config): Promise<void> {
+  setStore(fakeStore(config))
+  await hydrateConfig()
 }
 
-function writeAgentsJsonFile(data: unknown): void {
-  fs.writeFileSync(agentsFile, JSON.stringify(data, null, 2))
-}
-
-function readAgentsJsonFile(): unknown {
-  return JSON.parse(fs.readFileSync(agentsFile, 'utf8'))
-}
-
-/**
- * A minimal valid config for migration tests.
- */
-function minimalConfig(overrides: Record<string, unknown> = {}) {
+function minimalConfig(overrides: Partial<Config> = {}): Config {
   return {
     version: '0.32.0',
     repositories: {
-      'test-repo': {
-        path: '/home/user/test-repo',
-        keywords: ['test'],
-        color: '#3B82F6',
-        languages: { commit: 'en', pullRequest: 'en', jiraComment: 'en', discussion: 'en' },
-        commit: { style: 'single-line', format: 'angular', coAuthor: true, includeTicketId: true },
-        resolve: {
-          commitMode: 'new', format: 'angular', style: 'single-line',
-          useCommitConfig: true, replyToComments: true, replyLanguage: 'en',
-        },
-        pullRequest: { autoLinkTickets: true },
-        issues: { commentOnPR: true, jiraUrl: '', githubIssuesUrl: '' },
-        branches: { development: '' },
-        worktreeFiles: [],
-      },
+      'test-repo': { path: '/home/user/test-repo', keywords: ['test'] },
     },
     splitEnabled: false,
     splitActive: false,
@@ -63,277 +38,54 @@ function minimalConfig(overrides: Record<string, unknown> = {}) {
   }
 }
 
-describe('migrateConfig — agents migration', () => {
-  let migrateConfig: typeof import('./migrate').migrateConfig
-
-  beforeEach(async () => {
-    // Mock config module to point to our temp dir
-    vi.doMock('./config', () => ({
-      CONFIG_DIR: tmpDir,
-      CONFIG_FILE: configFile,
-      readConfig: () => {
-        try {
-          return JSON.parse(fs.readFileSync(configFile, 'utf8'))
-        } catch {
-          return { version: 'unknown', repositories: {}, splitEnabled: false, splitActive: false }
-        }
-      },
-      writeConfig: (config: unknown) => {
-        fs.writeFileSync(configFile, JSON.stringify(config, null, 2))
-      },
-      filterValidRepositories: (repos: string[]) => repos,
-    }))
-
-    // Mock agents module to use our temp dir
-    vi.doMock('./agents', () => ({
-      writeAgents: (agents: unknown[]) => {
-        fs.writeFileSync(agentsFile, JSON.stringify(agents, null, 2))
-      },
-      AGENTS_FILE: agentsFile,
-    }))
-
-    // Mock schema-validator to always pass
-    vi.doMock('./schema-validator', () => ({
-      validateConfig: () => ({ valid: true, errors: [] }),
-      hasCriticalErrors: () => false,
-    }))
-
-    // Mock defaults
-    const VALID_SHORTCUTS = [
-      'Control+Space', 'Control+Shift+Space', 'Alt+Space', 'Alt+Shift+Space',
-      'Control+M', 'Control+Shift+M', 'Alt+M', 'Alt+Shift+M',
-    ]
-    const VALID_LAUNCH_MODES = ['plan', 'default', 'acceptEdits', 'auto', 'bypassPermissions']
-    const mockDefaultSpotlight = { enabled: true, shortcut: 'Control+Space' }
-    vi.doMock('./defaults', () => ({
-      DEFAULT_REPOSITORY_FIELDS: {
-        color: '#3B82F6',
-        languages: { commit: 'en', pullRequest: 'en', jiraComment: 'en', discussion: 'en' },
-        commit: { style: 'single-line', format: 'angular', coAuthor: true, includeTicketId: true },
-        resolve: {
-          commitMode: 'new', format: 'angular', style: 'single-line',
-          useCommitConfig: true, replyToComments: true, replyLanguage: 'en',
-        },
-        pullRequest: { autoLinkTickets: true },
-        issues: { commentOnPR: true, jiraUrl: '', githubIssuesUrl: '' },
-        branches: { development: '' },
-        worktreeFiles: [],
-      },
-      DEFAULT_SPOTLIGHT: mockDefaultSpotlight,
-      VALID_SPOTLIGHT_SHORTCUTS: VALID_SHORTCUTS,
-      isValidSpotlightShortcut: (value: unknown) =>
-        typeof value === 'string' && VALID_SHORTCUTS.includes(value),
-      isValidSpotlightConfig: (obj: unknown) => {
-        if (typeof obj !== 'object' || obj === null) return false
-        const record = obj as Record<string, unknown>
-        return typeof record.enabled === 'boolean' &&
-          typeof record.shortcut === 'string' &&
-          VALID_SHORTCUTS.includes(record.shortcut)
-      },
-      isValidLaunchMode: (value: unknown) =>
-        typeof value === 'string' && VALID_LAUNCH_MODES.includes(value),
-    }))
-
-    vi.resetModules()
-    const mod = await import('./migrate')
-    migrateConfig = mod.migrateConfig
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('should migrate agents from config.json to agents.json and remove agents key', () => {
-    const agents = [
-      { id: 'a1', name: 'Agent 1', repositories: ['/repo1'], tsCreate: 1000 },
-      { id: 'a2', name: 'Agent 2', repositories: [], tsCreate: 2000 },
-    ]
-    writeConfigFile(minimalConfig({ agents }))
-
+describe('migrateConfig — repository defaults', () => {
+  it('fills missing default repository fields', async () => {
+    await seed(minimalConfig())
     migrateConfig('1.0.0')
-
-    // agents.json should be created with the agents
-    expect(fs.existsSync(agentsFile)).toBe(true)
-    const writtenAgents = readAgentsJsonFile()
-    expect(writtenAgents).toEqual(agents)
-
-    // config.json should no longer have the agents key
-    const config = readConfigFile() as Record<string, unknown>
-    expect(config).not.toHaveProperty('agents')
+    const repo = readConfig().repositories['test-repo']
+    expect(repo.color).toBe('#3B82F6')
+    expect(repo.languages).toEqual({ commit: 'en', pullRequest: 'en', jiraComment: 'en', discussion: 'en' })
+    expect(repo.commit).toMatchObject({ style: 'single-line', format: 'angular' })
+    // Existing fields are preserved.
+    expect(repo.path).toBe('/home/user/test-repo')
+    expect(repo.keywords).toEqual(['test'])
   })
 
-  it('should not overwrite agents.json if it already exists, but should remove agents key from config', () => {
-    const existingAgents = [
-      { id: 'existing1', name: 'Existing Agent', repositories: [], tsCreate: 500 },
-    ]
-    writeAgentsJsonFile(existingAgents)
-
-    const configAgents = [
-      { id: 'a1', name: 'Config Agent', repositories: [], tsCreate: 1000 },
-    ]
-    writeConfigFile(minimalConfig({ agents: configAgents }))
-
+  it('syncs the version with the app version', async () => {
+    await seed(minimalConfig())
     migrateConfig('1.0.0')
-
-    // agents.json should still contain the pre-existing agents (not overwritten)
-    const writtenAgents = readAgentsJsonFile() as unknown[]
-    expect(writtenAgents).toEqual(existingAgents)
-
-    // config.json should no longer have the agents key
-    const config = readConfigFile() as Record<string, unknown>
-    expect(config).not.toHaveProperty('agents')
+    expect(readConfig().version).toBe('1.0.0')
   })
 
-  it('should not create agents.json when config has no agents key', () => {
-    writeConfigFile(minimalConfig())
-
+  it('defaults integrations when missing', async () => {
+    await seed(minimalConfig())
     migrateConfig('1.0.0')
-
-    expect(fs.existsSync(agentsFile)).toBe(false)
-  })
-
-  it('should not crash on fresh install (no config.json)', () => {
-    // No config.json exists at all
-    expect(() => migrateConfig('1.0.0')).not.toThrow()
-    expect(fs.existsSync(agentsFile)).toBe(false)
-  })
-
-  it('should remove agents key even when agents array is empty', () => {
-    writeConfigFile(minimalConfig({ agents: [] }))
-
-    migrateConfig('1.0.0')
-
-    // agents key was present (empty array) — should be removed
-    const config = readConfigFile() as Record<string, unknown>
-    expect(config).not.toHaveProperty('agents')
-
-    // agents.json should NOT be created (empty array, nothing to migrate)
-    expect(fs.existsSync(agentsFile)).toBe(false)
-  })
-
-  it('should handle config with agents key set to non-array', () => {
-    writeConfigFile(minimalConfig({ agents: 'invalid' }))
-
-    migrateConfig('1.0.0')
-
-    // agents key should still be removed
-    const config = readConfigFile() as Record<string, unknown>
-    expect(config).not.toHaveProperty('agents')
-
-    // agents.json should NOT be created (not a valid array)
-    expect(fs.existsSync(agentsFile)).toBe(false)
+    expect(readConfig().integrations).toEqual({ github: true, atlassian: true })
   })
 })
 
 describe('migrateConfig — launchMode sanitization', () => {
-  let migrateConfig: typeof import('./migrate').migrateConfig
-
-  beforeEach(async () => {
-    vi.doMock('./config', () => ({
-      CONFIG_DIR: tmpDir,
-      CONFIG_FILE: configFile,
-      readConfig: () => {
-        try {
-          return JSON.parse(fs.readFileSync(configFile, 'utf8'))
-        } catch {
-          return { version: 'unknown', repositories: {}, splitEnabled: false, splitActive: false }
-        }
-      },
-      writeConfig: (config: unknown) => {
-        fs.writeFileSync(configFile, JSON.stringify(config, null, 2))
-      },
-      filterValidRepositories: (repos: string[]) => repos,
-    }))
-
-    vi.doMock('./agents', () => ({
-      writeAgents: (agents: unknown[]) => {
-        fs.writeFileSync(agentsFile, JSON.stringify(agents, null, 2))
-      },
-      AGENTS_FILE: agentsFile,
-    }))
-
-    vi.doMock('./schema-validator', () => ({
-      validateConfig: () => ({ valid: true, errors: [] }),
-      hasCriticalErrors: () => false,
-    }))
-
-    const VALID_SHORTCUTS = [
-      'Control+Space', 'Control+Shift+Space', 'Alt+Space', 'Alt+Shift+Space',
-      'Control+M', 'Control+Shift+M', 'Alt+M', 'Alt+Shift+M',
-    ]
-    const VALID_LAUNCH_MODES = ['plan', 'default', 'acceptEdits', 'auto', 'bypassPermissions']
-    const mockDefaultSpotlight = { enabled: true, shortcut: 'Control+Space' }
-    vi.doMock('./defaults', () => ({
-      DEFAULT_REPOSITORY_FIELDS: {
-        color: '#3B82F6',
-        languages: { commit: 'en', pullRequest: 'en', jiraComment: 'en', discussion: 'en' },
-        commit: { style: 'single-line', format: 'angular', coAuthor: true, includeTicketId: true },
-        resolve: {
-          commitMode: 'new', format: 'angular', style: 'single-line',
-          useCommitConfig: true, replyToComments: true, replyLanguage: 'en',
-        },
-        pullRequest: { autoLinkTickets: true },
-        issues: { commentOnPR: true, jiraUrl: '', githubIssuesUrl: '' },
-        branches: { development: '' },
-        worktreeFiles: [],
-      },
-      DEFAULT_SPOTLIGHT: mockDefaultSpotlight,
-      VALID_SPOTLIGHT_SHORTCUTS: VALID_SHORTCUTS,
-      isValidSpotlightShortcut: (value: unknown) =>
-        typeof value === 'string' && VALID_SHORTCUTS.includes(value),
-      isValidSpotlightConfig: (obj: unknown) => {
-        if (typeof obj !== 'object' || obj === null) return false
-        const record = obj as Record<string, unknown>
-        return typeof record.enabled === 'boolean' &&
-          typeof record.shortcut === 'string' &&
-          VALID_SHORTCUTS.includes(record.shortcut)
-      },
-      isValidLaunchMode: (value: unknown) =>
-        typeof value === 'string' && VALID_LAUNCH_MODES.includes(value),
-    }))
-
-    vi.resetModules()
-    const mod = await import('./migrate')
-    migrateConfig = mod.migrateConfig
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('should reset an invalid launchMode to undefined', () => {
-    writeConfigFile(minimalConfig({ launchMode: 'turbo' }))
-
+  it('resets an invalid launchMode', async () => {
+    await seed(minimalConfig({ launchMode: 'turbo' as never }))
     migrateConfig('1.0.0')
-
-    const config = readConfigFile() as Record<string, unknown>
-    expect(config).not.toHaveProperty('launchMode')
+    expect(readConfig().launchMode).toBeUndefined()
   })
 
-  it('should preserve a valid launchMode during migration', () => {
-    writeConfigFile(minimalConfig({ launchMode: 'auto' }))
-
+  it('preserves a valid launchMode', async () => {
+    await seed(minimalConfig({ launchMode: 'auto' }))
     migrateConfig('1.0.0')
-
-    const config = readConfigFile() as Record<string, unknown>
-    expect(config.launchMode).toBe('auto')
+    expect(readConfig().launchMode).toBe('auto')
   })
 
-  it('should not add launchMode when it is absent from config', () => {
-    writeConfigFile(minimalConfig())
-
+  it('does not add launchMode when absent', async () => {
+    await seed(minimalConfig())
     migrateConfig('1.0.0')
-
-    const config = readConfigFile() as Record<string, unknown>
-    expect(config).not.toHaveProperty('launchMode')
+    expect(readConfig().launchMode).toBeUndefined()
   })
 
-  it('should reset launchMode when it is a non-string value', () => {
-    writeConfigFile(minimalConfig({ launchMode: 123 }))
-
+  it('resets a non-string launchMode', async () => {
+    await seed(minimalConfig({ launchMode: 123 as never }))
     migrateConfig('1.0.0')
-
-    const config = readConfigFile() as Record<string, unknown>
-    expect(config).not.toHaveProperty('launchMode')
+    expect(readConfig().launchMode).toBeUndefined()
   })
 })

--- a/desktop/src/main/config/migrate.ts
+++ b/desktop/src/main/config/migrate.ts
@@ -1,12 +1,12 @@
-import * as fs from 'fs'
-import * as path from 'path'
-import { readConfig, writeConfig, CONFIG_DIR, CONFIG_FILE } from './config'
-import { writeAgents, AGENTS_FILE } from './agents'
-import { validateConfig } from './schema-validator'
+import { readConfig, writeConfig } from './config'
 import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig, isValidLaunchMode } from './defaults'
 import type { RepositoryConfig } from '../../types'
 
-const CONFIG_BACKUP = path.join(CONFIG_DIR, 'config.json.bak')
+// NOTE: There is deliberately NO data migration from the legacy local JSON files
+// (config.json / agents.json / history.json). The Supabase database is the single
+// source of truth and users start from scratch. These functions only normalize
+// the in-memory config that was hydrated from the store (fill default repository
+// fields, keep enums valid, sync the version) — they never touch the filesystem.
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -27,107 +27,26 @@ function deepMergeDefaults(defaults: Record<string, unknown>, existing: Record<s
 }
 
 /**
- * Creates a backup of the current config file before migration.
- * Only creates a backup if the config file exists.
+ * Normalize the hydrated config: fill missing default repository fields, keep the
+ * spotlight/launchMode/integrations values valid, and sync the version. Writes
+ * through to the store only when something actually changed.
  */
-function createBackup(): boolean {
-  try {
-    if (fs.existsSync(CONFIG_FILE)) {
-      fs.copyFileSync(CONFIG_FILE, CONFIG_BACKUP)
-      return true
-    }
-  } catch (error) {
-    console.warn('Failed to create config backup:', error)
-  }
-  return false
-}
-
 export function migrateConfig(appVersion?: string): boolean {
+  const config = readConfig()
   let changed = false
 
-  // Migrate agents from config.json to agents.json
-  const rawConfig = (() => {
-    try {
-      if (fs.existsSync(CONFIG_FILE)) {
-        return JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'))
-      }
-    } catch { /* ignore */ }
-    return null
-  })()
-
-  if (rawConfig && Array.isArray(rawConfig.agents) && rawConfig.agents.length > 0 && !fs.existsSync(AGENTS_FILE)) {
-    // agents.json doesn't exist yet — migrate agents from config.json
-    writeAgents(rawConfig.agents)
-  }
-
-  if (rawConfig) {
-    // Strip orphaned keys from config.json:
-    // - `agents` (migrated to agents.json)
-    // - `schedulerEnabled` / `schedulerDefaultTime` (scheduled events feature removed)
-    let rawChanged = false
-    for (const key of ['agents', 'schedulerEnabled', 'schedulerDefaultTime']) {
-      if (key in rawConfig) {
-        delete rawConfig[key]
-        rawChanged = true
-      }
-    }
-    if (rawChanged) {
-      try {
-        if (!fs.existsSync(CONFIG_DIR)) {
-          fs.mkdirSync(CONFIG_DIR, { recursive: true })
-        }
-        fs.writeFileSync(CONFIG_FILE, JSON.stringify(rawConfig, null, 2))
-      } catch (error) {
-        console.error('Error removing orphaned keys from config.json:', error)
-      }
-      changed = true
-    }
-  }
-
-  // Clean up agents.json after removing the scheduled events feature:
-  // - Drop agents that were enabled scheduled-only records. They were never
-  //   interactive sessions (they stayed idle until their configured time and
-  //   were excluded from restoreAgents), so keeping them would now wrongly
-  //   launch an interactive terminal on the first startup after upgrade.
-  // - Strip the orphaned `schedule` field from any remaining agent.
-  try {
-    if (fs.existsSync(AGENTS_FILE)) {
-      const rawAgents = JSON.parse(fs.readFileSync(AGENTS_FILE, 'utf8'))
-      if (Array.isArray(rawAgents)) {
-        const cleaned = rawAgents.filter(
-          (agent) => !(agent && typeof agent === 'object' && agent.schedule?.enabled === true)
-        )
-        let agentsChanged = cleaned.length !== rawAgents.length
-        for (const agent of cleaned) {
-          if (agent && typeof agent === 'object' && 'schedule' in agent) {
-            delete agent.schedule
-            agentsChanged = true
-          }
-        }
-        if (agentsChanged) {
-          writeAgents(cleaned)
-          changed = true
-        }
-      }
-    }
-  } catch (error) {
-    console.error('Error cleaning agents.json:', error)
-  }
-
-  // Read config AFTER agents migration to avoid re-introducing agents key
-  const config = readConfig()
-
-  // Sync config version with app version
   if (appVersion && config.version !== appVersion) {
     config.version = appVersion
     changed = true
   }
 
-  // Migrate repositories
   if (config.repositories) {
     for (const name of Object.keys(config.repositories)) {
       const repo = config.repositories[name]
-      const merged = deepMergeDefaults(DEFAULT_REPOSITORY_FIELDS as unknown as Record<string, unknown>, repo as unknown as Record<string, unknown>) as unknown as RepositoryConfig
+      const merged = deepMergeDefaults(
+        DEFAULT_REPOSITORY_FIELDS as unknown as Record<string, unknown>,
+        repo as unknown as Record<string, unknown>,
+      ) as unknown as RepositoryConfig
       if (JSON.stringify(merged) !== JSON.stringify(repo)) {
         config.repositories[name] = merged
         changed = true
@@ -135,7 +54,6 @@ export function migrateConfig(appVersion?: string): boolean {
     }
   }
 
-  // Migrate integrations (default: both enabled for backward compatibility)
   if (!config.integrations) {
     config.integrations = { github: true, atlassian: true }
     changed = true
@@ -143,7 +61,6 @@ export function migrateConfig(appVersion?: string): boolean {
 
   if (!isValidSpotlightConfig(config.spotlight)) {
     config.spotlight = { ...DEFAULT_SPOTLIGHT, ...(typeof config.spotlight === 'object' && config.spotlight !== null ? config.spotlight : {}) }
-    // Re-validate after merge; if still invalid, reset to pure defaults
     if (!isValidSpotlightConfig(config.spotlight)) {
       config.spotlight = { ...DEFAULT_SPOTLIGHT }
     }
@@ -151,29 +68,19 @@ export function migrateConfig(appVersion?: string): boolean {
   }
 
   if (config.launchMode !== undefined && !isValidLaunchMode(config.launchMode)) {
-    config.launchMode = undefined
+    delete config.launchMode
     changed = true
   }
 
   if (changed) {
-    // Create backup before writing migrated config
-    createBackup()
     writeConfig(config)
-
-    // Validate post-migration
-    const validation = validateConfig(config)
-    if (!validation.valid) {
-      for (const err of validation.errors) {
-        console.warn(`Post-migration validation warning: ${err}`)
-      }
-    }
   }
 
   return changed
 }
 
 export function repairConfig(): { repaired: boolean; fixes: string[] } {
-  // First, run migration to fill in missing fields
+  // First, normalize to fill in missing fields.
   migrateConfig()
 
   const config = readConfig()
@@ -254,7 +161,6 @@ export function repairConfig(): { repaired: boolean; fixes: string[] } {
   }
 
   if (repaired) {
-    createBackup()
     writeConfig(config)
   }
 

--- a/desktop/src/main/config/repo-validation.ts
+++ b/desktop/src/main/config/repo-validation.ts
@@ -1,0 +1,32 @@
+import { readConfig } from './config'
+import { isGitRepository } from './validation'
+
+export type InvalidRepoReason = 'missing' | 'not-git'
+
+export interface InvalidRepo {
+  name: string
+  path: string
+  reason: InvalidRepoReason
+}
+
+/**
+ * Strict repo-path check: the directory must exist AND contain a `.git` entry.
+ * Built on isGitRepository (not the lenient validateRepoPath, which only warns).
+ */
+export function checkRepoPath(repoPath: string): { valid: boolean; reason?: InvalidRepoReason } {
+  const res = isGitRepository(repoPath)
+  if (!res.exists) return { valid: false, reason: 'missing' }
+  if (!res.isGit) return { valid: false, reason: 'not-git' }
+  return { valid: true }
+}
+
+/** Every configured repository whose path is missing or is not a git repository. */
+export function validateAllRepoPaths(): InvalidRepo[] {
+  const config = readConfig()
+  const invalid: InvalidRepo[] = []
+  for (const [name, repo] of Object.entries(config.repositories ?? {})) {
+    const { valid, reason } = checkRepoPath(repo.path)
+    if (!valid && reason) invalid.push({ name, path: repo.path, reason })
+  }
+  return invalid
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, Notification, ipcMain, dialog, Menu, shell, globalShortcut, powerMonitor } from 'electron'
 import { join } from 'path'
 import { setupConfigHandlers } from './ipc/config-handlers'
-import { setupTerminalHandlers, cleanupTerminals, restoreAgents } from './ipc/terminal-handlers'
+import { setupTerminalHandlers, cleanupTerminals } from './ipc/terminal-handlers'
 import { startStatusServer, stopStatusServer, setStateCallback, setMetadataCallback, setCommandStartCallback, setCommandEndCallback, setRepositoriesCallback, setUsageCallback } from './hooks/status-server'
 import { installShellIntegration } from './hooks/shell-integration'
 import { configureClaudeHooks, configureStatusLine } from './hooks/claude-hooks-config'
@@ -12,7 +12,9 @@ import { updateSkills } from './skills-updater'
 import { setupSkillsHandlers } from './ipc/skills-handlers'
 import { setupScriptHandlers } from './ipc/script-handlers'
 import { registerActivityHistoryHandlers } from './ipc/activity-history-handlers'
-import { migrateConfig } from './config/migrate'
+import { setupConnectivityHandlers } from './ipc/connectivity-handlers'
+import { setStore } from './store/Store'
+import { CloudStore } from './store/CloudStore'
 import { readConfig, writeConfig } from './config/config'
 import { TrayManager } from './tray/tray-manager'
 import { AgentStateAggregator } from './tray/agent-state-aggregator'
@@ -191,10 +193,11 @@ function setupHandlers() {
   registerActivityHistoryHandlers()
   setupProfileHandlers()
   setupUsageHandlers()
-  // Cloud (optional): auth + organization. Handlers degrade gracefully when the
-  // Supabase env is missing — they never block boot.
+  // Cloud is MANDATORY: auth + organization + connectivity gate. The renderer
+  // blocks the whole app behind these until the backend reports 'ok'.
   setupAuthHandlers(() => mainWindow)
   setupOrgHandlers()
+  setupConnectivityHandlers(() => mainWindow)
   // Notification callback - only show when window is not focused
   const notificationCallback = (title: string, body: string) => {
     if (Notification.isSupported() && mainWindow && !mainWindow.isFocused()) {
@@ -352,8 +355,10 @@ function setupQuickLaunchHandlers() {
 }
 
 app.whenReady().then(async () => {
-  // Migrate config to ensure all repositories have complete fields
-  migrateConfig(app.getVersion())
+  // Wire the single source of truth (Supabase). Config, agents and history are
+  // hydrated from the DB after auth + connectivity are established (via the
+  // connectivity gate). Nothing is persisted locally.
+  setStore(new CloudStore())
 
   // Create custom menu (removes Cmd+W close window behavior)
   createMenu()
@@ -419,8 +424,8 @@ app.whenReady().then(async () => {
       if (mainWindow) {
         setUpdaterMainWindow(mainWindow)
       }
-      // Restore terminal sessions when window is reopened on Mac
-      restoreAgents()
+      // Terminal sessions are restored by the connectivity gate once the backend
+      // is reachable + hydrated (see connectivity-handlers.ts), not here.
     }
   })
 })
@@ -513,8 +518,9 @@ async function initializeHooksAndSessions() {
 
     console.log(`Magic Slash hooks configured on port ${port}`)
 
-    // Restore terminal sessions after hooks are ready
-    restoreAgents()
+    // NOTE: terminal sessions are NOT restored here. Under the hydrate-first
+    // model the agents cache is empty until the backend is reachable + hydrated,
+    // so restoration runs once behind the connectivity gate (connectivity-handlers.ts).
 
     // Start PR review watcher (default ON unless explicitly disabled)
     if (prReviewWatcher) {

--- a/desktop/src/main/ipc/activity-history-handlers.ts
+++ b/desktop/src/main/ipc/activity-history-handlers.ts
@@ -1,11 +1,14 @@
 import { ipcMain } from 'electron'
-import { readHistory, addHistoryEntry, clearHistory } from '../config/activity-history'
+import { readHistory, addHistoryEntry } from '../config/activity-history'
+import { ensureHydrated } from '../store/hydrate'
 
 export function registerActivityHistoryHandlers(): void {
-  ipcMain.handle('activityHistory:getAll', async () => readHistory())
+  ipcMain.handle('activityHistory:getAll', async () => {
+    await ensureHydrated()
+    return readHistory()
+  })
   ipcMain.handle('activityHistory:add', async (_event, params) => {
     if (typeof params?.agentId !== 'string' || typeof params?.agentName !== 'string' || typeof params?.action !== 'string') return
     return addHistoryEntry(params)
   })
-  ipcMain.handle('activityHistory:clear', async () => clearHistory())
 }

--- a/desktop/src/main/ipc/auth-handlers.ts
+++ b/desktop/src/main/ipc/auth-handlers.ts
@@ -12,6 +12,7 @@ import {
   confirmEmailChange,
   deleteAccount,
 } from '../cloud/auth'
+import { resetHydration } from '../store/hydrate'
 
 interface LoginArgs { email: string; password: string }
 interface SignUpArgs { email: string; password: string; orgName?: string; invitationToken?: string }
@@ -42,6 +43,8 @@ export function setupAuthHandlers(getMainWindow: () => BrowserWindow | null): vo
 
   ipcMain.handle('auth:logout', async (): Promise<AuthStatus> => {
     const status = await signOut()
+    // Clear cached config/agents/history so the next user starts clean.
+    resetHydration()
     emit(status)
     return status
   })
@@ -74,6 +77,7 @@ export function setupAuthHandlers(getMainWindow: () => BrowserWindow | null): vo
   // Account deletion (GDPR) — signs the user out; emit the logged-out transition.
   ipcMain.handle('auth:deleteAccount', async (): Promise<AuthStatus> => {
     const status = await deleteAccount()
+    resetHydration()
     emit(status)
     return status
   })

--- a/desktop/src/main/ipc/config-handlers.ts
+++ b/desktop/src/main/ipc/config-handlers.ts
@@ -48,6 +48,7 @@ import {
   findBestMatch,
   getLastCommand
 } from '../config/command-history'
+import { ensureHydrated } from '../store/hydrate'
 
 interface ParsedDiff {
   addedNewLines: Set<number>
@@ -130,6 +131,7 @@ const MIME_MAP: Record<string, string> = {
 export function setupConfigHandlers(getMainWindow: () => BrowserWindow | null) {
   // Get config (also validates and notifies renderer of any errors)
   ipcMain.handle('config:get', async () => {
+    await ensureHydrated()
     const config = readConfig()
     try {
       const validation = validateConfig(config)

--- a/desktop/src/main/ipc/connectivity-handlers.ts
+++ b/desktop/src/main/ipc/connectivity-handlers.ts
@@ -1,0 +1,69 @@
+import { app, ipcMain, type BrowserWindow } from 'electron'
+import type { ConnectivityStatus, StoreWriteKind } from '../store/Store'
+import { getStore, setWriteErrorHandler } from '../store/Store'
+import { ensureHydrated, rehydrate, resetHydration } from '../store/hydrate'
+import { migrateConfig } from '../config/migrate'
+import { validateAllRepoPaths } from '../config/repo-validation'
+import { restoreAgents } from './terminal-handlers'
+
+let restoredOnce = false
+
+/**
+ * Connectivity + hydration gate for the main process. The renderer polls
+ * `connectivity:check` (on an interval, on window focus, and before mutating
+ * calls); the whole app is blocked in the renderer until this reports 'ok'.
+ *
+ *  - 'ok'           → hydrate caches from the store, normalize config, restore
+ *                     agents once, and surface any invalid repo paths.
+ *  - 'unauthorized' → reset caches + hydration so the next user starts clean.
+ *  - 'unreachable'/'disabled' → the renderer shows the corresponding block.
+ */
+export function setupConnectivityHandlers(getMainWindow: () => BrowserWindow | null): void {
+  const emitInvalidRepos = () => {
+    const invalid = validateAllRepoPaths()
+    getMainWindow()?.webContents.send('repos:invalid', invalid)
+  }
+
+  const check = async (): Promise<ConnectivityStatus> => {
+    const status = await getStore().ping()
+
+    if (status === 'ok') {
+      try {
+        await ensureHydrated()
+        // migrateConfig only ever changes data on the first post-upgrade pass;
+        // run it (and restoreAgents) once rather than on every 20s poll/focus.
+        if (!restoredOnce) {
+          restoredOnce = true
+          migrateConfig(app.getVersion())
+          restoreAgents()
+        }
+        emitInvalidRepos()
+      } catch (error) {
+        console.error('[connectivity] hydration failed:', error)
+      }
+    } else if (status === 'unauthorized') {
+      restoredOnce = false
+      resetHydration()
+    }
+
+    getMainWindow()?.webContents.send('connectivity:statusChanged', status)
+    return status
+  }
+
+  ipcMain.handle('connectivity:check', async (): Promise<ConnectivityStatus> => check())
+
+  // Report configured repositories whose path is missing or not a git repo.
+  ipcMain.handle('repos:getInvalid', async () => validateAllRepoPaths())
+
+  // A write-through to the store failed: the in-memory cache may have diverged
+  // from the DB. Tell the renderer (toast) and re-sync the caches from the DB so
+  // they converge back rather than staying diverged (the failed change is lost —
+  // the user is told so they can retry).
+  setWriteErrorHandler((kind: StoreWriteKind, error: unknown) => {
+    getMainWindow()?.webContents.send('store:writeError', { kind })
+    void rehydrate()
+      .then(() => emitInvalidRepos())
+      .catch((rehydrateError) => console.error('[connectivity] rehydrate after write error failed:', rehydrateError))
+    console.error(`[connectivity] store write failed (${kind}):`, error)
+  })
+}

--- a/desktop/src/main/ipc/org-handlers.ts
+++ b/desktop/src/main/ipc/org-handlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron'
 import type { AcceptInvitationResult } from '../cloud/org'
-import type { Config, Invitation, Member, MembershipRole, Org } from '../../types'
+import type { Config, Invitation, Member, MembershipRole, Org, OrgSharedConfig } from '../../types'
 import {
   getCurrentOrg,
   listMembers,
@@ -8,6 +8,7 @@ import {
   createInvitation,
   acceptInvitation,
   applySharedConfig,
+  setOrgSharedConfig,
   listOrgs,
   removeMember,
   leaveOrg,
@@ -21,6 +22,7 @@ interface AcceptArgs { token: string }
 interface OrgIdArgs { orgId: string }
 interface MemberArgs { orgId: string; userId: string }
 interface RoleArgs { orgId: string; userId: string; role: MembershipRole }
+interface SetSharedArgs { shared: OrgSharedConfig; orgId?: string }
 
 export function setupOrgHandlers(): void {
   ipcMain.handle('org:current', async (): Promise<Org | null> => getCurrentOrg())
@@ -40,6 +42,13 @@ export function setupOrgHandlers(): void {
   )
 
   ipcMain.handle('org:applyShared', async (): Promise<Config> => applySharedConfig())
+
+  ipcMain.handle('org:setShared', async (_event, { shared, orgId }: SetSharedArgs): Promise<void> => {
+    if (typeof shared !== 'object' || shared === null) {
+      throw new Error('org:setShared: "shared" must be a non-null object')
+    }
+    return setOrgSharedConfig(shared, orgId)
+  })
 
   ipcMain.handle('org:removeMember', async (_event, { orgId, userId }: MemberArgs): Promise<void> =>
     removeMember(orgId, userId),

--- a/desktop/src/main/ipc/terminal-handlers.ts
+++ b/desktop/src/main/ipc/terminal-handlers.ts
@@ -22,7 +22,33 @@ import {
   updateAgentSplitPane,
 } from '../config/agents'
 import { addHistoryEntry } from '../config/activity-history'
+import { readConfig } from '../config/config'
+import { expandPath } from '../config/validation'
+import { checkRepoPath } from '../config/repo-validation'
+import { ensureHydrated } from '../store/hydrate'
 import type { HistoryAction } from '../../types'
+
+/**
+ * Strict repo-path guard used on agent creation (⌘N). When the launch cwd maps
+ * to a configured repository, that repository must be a valid git repo (folder
+ * exists AND has .git). Throws a descriptive error otherwise so the renderer can
+ * prompt the user to re-point the folder instead of creating a broken agent.
+ */
+function assertLaunchTargetValid(cwd: unknown): void {
+  if (typeof cwd !== 'string' || cwd.length === 0) return
+  const expanded = expandPath(cwd)
+  const config = readConfig()
+  const match = Object.entries(config.repositories ?? {}).find(
+    ([, repo]) => expandPath(repo.path) === expanded,
+  )
+  if (!match) return
+  const [name, repo] = match
+  const { valid, reason } = checkRepoPath(repo.path)
+  if (!valid) {
+    const detail = reason === 'missing' ? 'the folder no longer exists' : 'it is not a git repository'
+    throw new Error(`Repository "${name}" is invalid: ${detail}. Re-point the folder in Settings before launching an agent.`)
+  }
+}
 
 let getMainWindow: () => BrowserWindow | null
 let showNotification: (title: string, body: string) => void
@@ -267,6 +293,11 @@ export function setupTerminalHandlers(
     if (typeof id !== 'string' || typeof name !== 'string') {
       throw new Error('terminal:launchClaude requires id (string) and name (string)')
     }
+    // The DB is the source of truth; make sure agents/config are loaded before we
+    // save a new agent (so we never clobber the hydrated cache).
+    await ensureHydrated()
+    // Strict repo-path validation on ⌘N.
+    assertLaunchTargetValid(cwd)
     const callbacks = createTerminalCallbacks(id, name)
     const terminal = launchClaude(
       id,
@@ -361,6 +392,7 @@ export function setupTerminalHandlers(
 
   // Get all terminals
   ipcMain.handle('terminal:getAll', async () => {
+    await ensureHydrated()
     const savedAgents = readAgents()
     const agentMap = new Map(savedAgents.map(a => [a.id, a]))
     return getAllTerminals().map(t => ({
@@ -383,6 +415,7 @@ export function setupTerminalHandlers(
   })
 
   const handleGetAgents = async () => {
+    await ensureHydrated()
     return readAgents()
   }
   ipcMain.handle('terminal:getSessions', handleGetAgents) // legacy alias

--- a/desktop/src/main/store/CloudStore.ts
+++ b/desktop/src/main/store/CloudStore.ts
@@ -1,0 +1,326 @@
+import { randomUUID } from 'crypto'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Agent, Config, HistoryEntry, OrgSharedConfig, TerminalMetadata } from '../../types'
+import { getAuthedClient } from '../cloud/auth'
+import { loadSession } from '../cloud/session-store'
+import { isCloudEnabled } from '../cloud/supabase-client'
+import type { ConnectivityStatus, Store } from './Store'
+
+// ---------------------------------------------------------------------------
+// DB row shapes (no generated database.types.ts exists — declared inline, in the
+// same spirit as the OrgRow/MembershipRow shapes in cloud/org.ts).
+// ---------------------------------------------------------------------------
+
+interface ConfigRow {
+  data: Config & Partial<Record<'languages' | 'commit' | 'pullRequest' | 'repoKeywords', unknown>>
+}
+
+interface AgentRow {
+  id: string
+  org_id: string
+  owner_id: string | null
+  name: string
+  ticket_id: string | null
+  description: string | null
+  branch_name: string | null
+  base_branch: string | null
+  status: string | null
+  repositories: string[]
+  metadata: TerminalMetadata & { __app?: { id: string; tsCreate?: number; splitPane?: 'left' | 'right' } }
+}
+
+interface ActivityEventRow {
+  id: string
+  agent_id: string | null
+  action: string
+  ticket_id: string | null
+  description: string | null
+  repositories: string[]
+  occurred_at: string
+}
+
+/** The four shareable keys, projected to the TOP LEVEL of the config blob so the
+ *  get_org_shared_config SECURITY DEFINER function keeps returning them. */
+function projectSharedFields(config: Config): Record<string, unknown> {
+  const repos = Object.values(config.repositories ?? {})
+  const named = Object.entries(config.repositories ?? {})
+
+  const firstWith = <K extends keyof (typeof repos)[number]>(key: K) =>
+    repos.find((r) => r[key] !== undefined)?.[key]
+
+  const repoKeywords: Record<string, string[]> = {}
+  for (const [name, repo] of named) {
+    if (Array.isArray(repo.keywords) && repo.keywords.length > 0) repoKeywords[name] = repo.keywords
+  }
+
+  const shared: Record<string, unknown> = {}
+  const languages = firstWith('languages')
+  const commit = firstWith('commit')
+  const pullRequest = firstWith('pullRequest')
+  if (languages) shared.languages = languages
+  if (commit) shared.commit = commit
+  if (pullRequest) shared.pullRequest = pullRequest
+  if (Object.keys(repoKeywords).length > 0) shared.repoKeywords = repoKeywords
+  return shared
+}
+
+const SHARED_KEYS = ['languages', 'commit', 'pullRequest', 'repoKeywords'] as const
+
+/**
+ * Single Supabase-backed Store implementation. Config, agents and history all
+ * live in the database — nothing is persisted locally. Reads/writes are scoped
+ * to the current user's active organization.
+ */
+export class CloudStore implements Store {
+  private activeOrgId: string | undefined
+  /** app agent id ("claude-…") → agents.id (uuid). Rebuilt on every loadAgents. */
+  private agentIdMap = new Map<string, string>()
+  /** agents.id (uuid) → display name, for reconstructing history entries. */
+  private agentNameByUuid = new Map<string, string>()
+
+  setActiveOrgId(orgId: string | undefined): void {
+    this.activeOrgId = orgId
+  }
+
+  private async context(): Promise<{ client: SupabaseClient; uid: string; orgId: string } | null> {
+    const client = await getAuthedClient()
+    if (!client) return null
+    const uid = loadSession()?.user?.id
+    if (!uid) return null
+    const orgId = await this.resolveOrgId(client, uid)
+    if (!orgId) return null
+    return { client, uid, orgId }
+  }
+
+  private async resolveOrgId(client: SupabaseClient, uid: string): Promise<string | null> {
+    const { data, error } = await client
+      .from('memberships')
+      .select('org_id')
+      .eq('user_id', uid)
+      .order('created_at', { ascending: true })
+    if (error || !data || data.length === 0) return null
+    const ids = data.map((r) => (r as { org_id: string }).org_id)
+    if (this.activeOrgId && ids.includes(this.activeOrgId)) return this.activeOrgId
+    this.activeOrgId = ids[0]
+    return ids[0]
+  }
+
+  // -------------------------------------------------------------------------
+  // Config
+  // -------------------------------------------------------------------------
+
+  async loadConfig(): Promise<Config | null> {
+    const ctx = await this.context()
+    if (!ctx) return null
+
+    const { data, error } = await ctx.client
+      .from('configs')
+      .select('data')
+      .eq('org_id', ctx.orgId)
+      .eq('user_id', ctx.uid)
+      .maybeSingle()
+
+    if (error || !data) return null
+
+    const blob = { ...(data as ConfigRow).data } as Record<string, unknown>
+    // Drop the top-level shared projection — it is a mirror, not part of Config.
+    for (const key of SHARED_KEYS) delete blob[key]
+    const config = blob as unknown as Config
+    // Keep the remembered org id in sync with what we actually loaded.
+    if (typeof config.currentOrgId === 'string') {
+      this.activeOrgId = config.currentOrgId
+    }
+    return config
+  }
+
+  async saveConfig(config: Config): Promise<void> {
+    const ctx = await this.context()
+    if (!ctx) return
+
+    // Store the full Config blob AND mirror the shareable keys at top level so
+    // get_org_shared_config keeps working for org admins.
+    const data = { ...config, ...projectSharedFields(config) }
+
+    const { error } = await ctx.client
+      .from('configs')
+      .upsert({ org_id: ctx.orgId, user_id: ctx.uid, data }, { onConflict: 'org_id,user_id' })
+    if (error) throw new Error(`saveConfig failed: ${error.message}`)
+  }
+
+  // -------------------------------------------------------------------------
+  // Agents
+  // -------------------------------------------------------------------------
+
+  private toAgentRow(agent: Agent, id: string, orgId: string, uid: string): Record<string, unknown> {
+    const meta = agent.metadata
+    return {
+      id,
+      org_id: orgId,
+      owner_id: uid,
+      name: agent.name,
+      ticket_id: meta?.ticketId ?? null,
+      description: meta?.description ?? null,
+      branch_name: meta?.branchName ?? null,
+      base_branch: meta?.baseBranch ?? null,
+      status: meta?.status ?? null,
+      repositories: agent.repositories ?? [],
+      metadata: { ...(meta ?? {}), __app: { id: agent.id, tsCreate: agent.tsCreate, splitPane: agent.splitPane } },
+    }
+  }
+
+  private fromAgentRow(row: AgentRow): Agent {
+    const app = row.metadata?.__app
+    const metadata = { ...(row.metadata ?? {}) } as AgentRow['metadata']
+    delete metadata.__app
+    return {
+      id: app?.id ?? row.id,
+      name: row.name,
+      repositories: Array.isArray(row.repositories) ? row.repositories : [],
+      tsCreate: app?.tsCreate,
+      metadata: metadata as TerminalMetadata,
+      splitPane: app?.splitPane,
+    }
+  }
+
+  async loadAgents(): Promise<Agent[]> {
+    const ctx = await this.context()
+    if (!ctx) return []
+
+    const { data, error } = await ctx.client
+      .from('agents')
+      .select('id, org_id, owner_id, name, ticket_id, description, branch_name, base_branch, status, repositories, metadata')
+      .eq('org_id', ctx.orgId)
+
+    if (error || !data) return []
+
+    this.agentIdMap.clear()
+    this.agentNameByUuid.clear()
+    const agents: Agent[] = []
+    for (const raw of data as AgentRow[]) {
+      const agent = this.fromAgentRow(raw)
+      this.agentIdMap.set(agent.id, raw.id)
+      this.agentNameByUuid.set(raw.id, agent.name)
+      agents.push(agent)
+    }
+    return agents
+  }
+
+  async saveAgents(agents: Agent[]): Promise<void> {
+    const ctx = await this.context()
+    if (!ctx) return
+
+    const desired = new Set(agents.map((a) => a.id))
+
+    // Delete rows whose app agent id no longer exists locally.
+    for (const [appId, uuid] of [...this.agentIdMap.entries()]) {
+      if (!desired.has(appId)) {
+        const { error } = await ctx.client.from('agents').delete().eq('org_id', ctx.orgId).eq('id', uuid)
+        if (error) throw new Error(`saveAgents (delete) failed: ${error.message}`)
+        this.agentIdMap.delete(appId)
+        this.agentNameByUuid.delete(uuid)
+      }
+    }
+
+    // Upsert the desired set.
+    const rows = agents.map((a) => {
+      const uuid = this.agentIdMap.get(a.id) ?? randomUUID()
+      this.agentIdMap.set(a.id, uuid)
+      this.agentNameByUuid.set(uuid, a.name)
+      return this.toAgentRow(a, uuid, ctx.orgId, ctx.uid)
+    })
+    if (rows.length === 0) return
+
+    const { error } = await ctx.client.from('agents').upsert(rows, { onConflict: 'id' })
+    if (error) throw new Error(`saveAgents failed: ${error.message}`)
+  }
+
+  // -------------------------------------------------------------------------
+  // History (activity_events — append-only, read-limited)
+  // -------------------------------------------------------------------------
+
+  async loadHistory(limit: number): Promise<HistoryEntry[]> {
+    const ctx = await this.context()
+    if (!ctx) return []
+
+    const { data, error } = await ctx.client
+      .from('activity_events')
+      .select('id, agent_id, action, ticket_id, description, repositories, occurred_at')
+      .eq('org_id', ctx.orgId)
+      .order('occurred_at', { ascending: false })
+      .limit(limit)
+
+    if (error || !data) return []
+
+    // Reverse to oldest-first to match the legacy read order.
+    return (data as ActivityEventRow[]).reverse().map((row) => ({
+      id: row.id,
+      agentId: row.agent_id ?? '',
+      agentName: (row.agent_id ? this.agentNameByUuid.get(row.agent_id) : undefined) ?? '',
+      action: row.action as HistoryEntry['action'],
+      ticketId: row.ticket_id ?? undefined,
+      description: row.description ?? undefined,
+      repositories: Array.isArray(row.repositories) ? row.repositories : [],
+      timestamp: Date.parse(row.occurred_at) || Date.now(),
+    }))
+  }
+
+  async appendHistory(entry: HistoryEntry): Promise<void> {
+    const ctx = await this.context()
+    if (!ctx) return
+
+    const agentUuid = this.agentIdMap.get(entry.agentId) ?? null
+
+    const { error } = await ctx.client.from('activity_events').insert({
+      org_id: ctx.orgId,
+      user_id: ctx.uid,
+      agent_id: agentUuid,
+      action: entry.action,
+      ticket_id: entry.ticketId ?? null,
+      description: entry.description ?? null,
+      repositories: entry.repositories ?? [],
+      occurred_at: new Date(entry.timestamp).toISOString(),
+    })
+    if (error) throw new Error(`appendHistory failed: ${error.message}`)
+  }
+
+  // -------------------------------------------------------------------------
+  // Org shared config (admin write path)
+  // -------------------------------------------------------------------------
+
+  async setOrgSharedConfig(orgId: string, shared: OrgSharedConfig): Promise<void> {
+    const client = await getAuthedClient()
+    if (!client) throw new Error('Cloud features are not available')
+    const { error } = await client.rpc('set_org_shared_config', { p_org_id: orgId, p_shared: shared })
+    if (error) throw new Error(error.message)
+  }
+
+  // -------------------------------------------------------------------------
+  // Connectivity
+  // -------------------------------------------------------------------------
+
+  async ping(): Promise<ConnectivityStatus> {
+    if (!isCloudEnabled()) return 'disabled'
+    const stored = loadSession()
+    if (!stored) return 'unauthorized'
+
+    // Applying the session refreshes the token when needed. getAuthedClient
+    // clears the session ONLY on a genuine refresh-token rejection (→ null with
+    // no session left) and keeps it on a transient/offline error (→ null with
+    // the session still present), which lets us tell the two apart.
+    const client = await getAuthedClient()
+    if (!client) return loadSession() ? 'unreachable' : 'unauthorized'
+
+    try {
+      const { error } = await client
+        .from('memberships')
+        .select('org_id', { count: 'exact', head: true })
+        .limit(1)
+      if (!error) return 'ok'
+      const status = (error as { status?: number }).status
+      if (status === 401 || status === 403) return 'unauthorized'
+      return 'unreachable'
+    } catch {
+      return 'unreachable'
+    }
+  }
+}

--- a/desktop/src/main/store/Store.ts
+++ b/desktop/src/main/store/Store.ts
@@ -1,0 +1,100 @@
+import type { Config, Agent, HistoryEntry, OrgSharedConfig } from '../../types'
+
+/**
+ * Result of a backend reachability probe.
+ *  - 'ok'           reachable + authenticated.
+ *  - 'unauthorized' no valid session (logged out, or the refresh token was
+ *                   rejected) — the app must fall back to the auth wall.
+ *  - 'unreachable'  the backend could not be reached (offline / network error) —
+ *                   the app must block with a "connection lost" screen. No grace
+ *                   period, no offline mode.
+ *  - 'disabled'     Supabase is not configured (isCloudEnabled() === false) —
+ *                   the app must show the "cloud not configured" blocking screen.
+ */
+export type ConnectivityStatus = 'ok' | 'unauthorized' | 'unreachable' | 'disabled'
+
+/**
+ * The single persistence contract for config, agents and history. The Supabase
+ * database is the single source of truth — there is deliberately NO local JSON
+ * persistence behind any implementation of this interface. Callers keep an
+ * in-memory cache (hydrated via the load methods) and write through via the
+ * save/append methods.
+ */
+export interface Store {
+  loadConfig(): Promise<Config | null>
+  saveConfig(config: Config): Promise<void>
+
+  loadAgents(): Promise<Agent[]>
+  saveAgents(agents: Agent[]): Promise<void>
+
+  /** Most-recent `limit` history entries, oldest-first (matches the legacy read order). */
+  loadHistory(limit: number): Promise<HistoryEntry[]>
+  appendHistory(entry: HistoryEntry): Promise<void>
+
+  /** Admin-only: push the org's shared config (languages/commit/pullRequest/repoKeywords). */
+  setOrgSharedConfig(orgId: string, shared: OrgSharedConfig): Promise<void>
+
+  /** Lightweight authed reachability probe used by the connectivity gate. */
+  ping(): Promise<ConnectivityStatus>
+
+  /** Remember which org subsequent reads/writes target (set on org switch). */
+  setActiveOrgId(orgId: string | undefined): void
+}
+
+// ---------------------------------------------------------------------------
+// Active store registry (dependency injection point)
+// ---------------------------------------------------------------------------
+
+/**
+ * A do-nothing store used before the real store is wired and in unit tests. It
+ * keeps every persistence call a safe no-op and reports the backend as
+ * unauthorized so nothing accidentally believes it is connected.
+ */
+export const NOOP_STORE: Store = {
+  async loadConfig() { return null },
+  async saveConfig() { /* no-op */ },
+  async loadAgents() { return [] },
+  async saveAgents() { /* no-op */ },
+  async loadHistory() { return [] },
+  async appendHistory() { /* no-op */ },
+  async setOrgSharedConfig() { /* no-op */ },
+  async ping() { return 'unauthorized' },
+  setActiveOrgId() { /* no-op */ },
+}
+
+let activeStore: Store = NOOP_STORE
+
+/** Wire the concrete store (CloudStore in production; a fake in tests). */
+export function setStore(store: Store): void {
+  activeStore = store
+}
+
+/** The currently active store. Falls back to a safe no-op store. */
+export function getStore(): Store {
+  return activeStore
+}
+
+// ---------------------------------------------------------------------------
+// Write-through failure reporting
+// ---------------------------------------------------------------------------
+// The cache modules (config/agents/activity-history) write through to the store
+// asynchronously and keep a synchronous read API. When a write-through fails the
+// in-memory cache would silently diverge from the DB, so we surface the failure
+// through a handler wired in the main process (emits an IPC event + re-hydrates).
+
+/** Which cache write failed to persist to the DB. */
+export type StoreWriteKind = 'config' | 'agents' | 'history'
+
+type WriteErrorHandler = (kind: StoreWriteKind, error: unknown) => void
+
+let writeErrorHandler: WriteErrorHandler | null = null
+
+/** Wire the handler invoked whenever a write-through to the store fails. */
+export function setWriteErrorHandler(handler: WriteErrorHandler | null): void {
+  writeErrorHandler = handler
+}
+
+/** Report a write-through failure to the wired handler (no-op if none). */
+export function reportWriteError(kind: StoreWriteKind, error: unknown): void {
+  writeErrorHandler?.(kind, error)
+}

--- a/desktop/src/main/store/hydrate.ts
+++ b/desktop/src/main/store/hydrate.ts
@@ -1,0 +1,58 @@
+import { hydrateConfig, resetConfigCache } from '../config/config'
+import { hydrateAgents, resetAgentsCache } from '../config/agents'
+import { hydrateHistory, resetHistoryCache } from '../config/activity-history'
+
+// Coordinates a one-time hydration of the in-memory caches (config, agents,
+// history) from the store once auth + connectivity are established. Every mutating
+// IPC path awaits ensureHydrated() so it never reads a cold (empty) cache.
+
+let hydrationPromise: Promise<void> | null = null
+
+/**
+ * Hydrate config, agents and history from the store exactly once. Subsequent
+ * calls return the same in-flight/settled promise. Agents must be hydrated
+ * before history so history entries can resolve their agent names.
+ */
+export function ensureHydrated(): Promise<void> {
+  if (!hydrationPromise) {
+    hydrationPromise = (async () => {
+      await hydrateConfig()
+      await hydrateAgents()
+      await hydrateHistory()
+    })().catch((error) => {
+      // Allow a later retry if hydration failed.
+      hydrationPromise = null
+      throw error
+    })
+  }
+  return hydrationPromise
+}
+
+/**
+ * Force a fresh reload of all caches from the store, replacing the hydration
+ * guard with the new load. Used to re-sync after a write-through failure so the
+ * in-memory caches converge back to the DB rather than staying diverged.
+ */
+export function rehydrate(): Promise<void> {
+  hydrationPromise = (async () => {
+    await hydrateConfig()
+    await hydrateAgents()
+    await hydrateHistory()
+  })().catch((error) => {
+    hydrationPromise = null
+    throw error
+  })
+  return hydrationPromise
+}
+
+/**
+ * Reset all caches and the hydration guard (on sign-out or when the backend
+ * reports the session is no longer authorized), so the next authenticated user
+ * re-hydrates cleanly and never sees stale data.
+ */
+export function resetHydration(): void {
+  hydrationPromise = null
+  resetConfigCache()
+  resetAgentsCache()
+  resetHistoryCache()
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
-import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole } from '../types'
+import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole, OrgSharedConfig } from '../types'
 
 export type TerminalState = 'idle' | 'working' | 'waiting' | 'completed' | 'error'
 
@@ -78,6 +78,15 @@ const configApi = {
 
   validatePath: (path: string) =>
     ipcRenderer.invoke('config:validatePath', { path }),
+
+  // Configured repositories whose path is missing or is not a git repository.
+  getInvalidRepos: (): Promise<InvalidRepo[]> => ipcRenderer.invoke('repos:getInvalid'),
+
+  onInvalidRepos: (callback: (repos: InvalidRepo[]) => void) => {
+    const listener = (_event: IpcRendererEvent, repos: InvalidRepo[]) => callback(repos)
+    ipcRenderer.on('repos:invalid', listener)
+    return () => ipcRenderer.removeListener('repos:invalid', listener)
+  },
 
   hasGitHubRemote: (path: string) =>
     ipcRenderer.invoke('config:hasGitHubRemote', { path }),
@@ -232,12 +241,39 @@ const historyApi = {
     ipcRenderer.invoke('history:getLast', { repoPath }),
 }
 
-// Activity History API
+// Activity History API (append-only — no clear: activity_events is append-only)
 const activityHistoryApi = {
   getAll: () => ipcRenderer.invoke('activityHistory:getAll'),
   add: (params: { agentId: string; agentName: string; action: string; ticketId?: string; description?: string; repositories: string[] }) =>
     ipcRenderer.invoke('activityHistory:add', params),
-  clear: () => ipcRenderer.invoke('activityHistory:clear'),
+}
+
+// Connectivity API (cloud is mandatory: the renderer blocks the whole app until
+// the backend reports 'ok'). See main/ipc/connectivity-handlers.ts.
+export type ConnectivityStatus = 'ok' | 'unauthorized' | 'unreachable' | 'disabled'
+
+export type StoreWriteKind = 'config' | 'agents' | 'history'
+
+export interface InvalidRepo {
+  name: string
+  path: string
+  reason: 'missing' | 'not-git'
+}
+
+const connectivityApi = {
+  check: (): Promise<ConnectivityStatus> => ipcRenderer.invoke('connectivity:check'),
+  onStatusChanged: (callback: (status: ConnectivityStatus) => void) => {
+    const listener = (_event: IpcRendererEvent, status: ConnectivityStatus) => callback(status)
+    ipcRenderer.on('connectivity:statusChanged', listener)
+    return () => ipcRenderer.removeListener('connectivity:statusChanged', listener)
+  },
+  // A write-through to the cloud failed; the local cache was re-synced from the
+  // DB (the failed change may be lost). Carries which write failed.
+  onWriteError: (callback: (data: { kind: StoreWriteKind }) => void) => {
+    const listener = (_event: IpcRendererEvent, data: { kind: StoreWriteKind }) => callback(data)
+    ipcRenderer.on('store:writeError', listener)
+    return () => ipcRenderer.removeListener('store:writeError', listener)
+  },
 }
 
 // Window API
@@ -424,6 +460,8 @@ const orgApi = {
   accept: (token: string): Promise<{ orgId: string; config: Config }> =>
     ipcRenderer.invoke('org:accept', { token }),
   applySharedConfig: (): Promise<Config> => ipcRenderer.invoke('org:applyShared'),
+  setSharedConfig: (shared: OrgSharedConfig, orgId?: string): Promise<void> =>
+    ipcRenderer.invoke('org:setShared', { shared, orgId }),
   removeMember: (orgId: string, userId: string): Promise<void> =>
     ipcRenderer.invoke('org:removeMember', { orgId, userId }),
   leave: (orgId: string): Promise<void> => ipcRenderer.invoke('org:leave', { orgId }),
@@ -452,6 +490,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   usage: usageApi,
   auth: authApi,
   org: orgApi,
+  connectivity: connectivityApi,
 })
 
 // Type definitions for the renderer
@@ -475,6 +514,7 @@ declare global {
       usage: typeof usageApi
       auth: typeof authApi
       org: typeof orgApi
+      connectivity: typeof connectivityApi
     }
   }
 

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useCallback, useRef, useMemo, useState } from 'react'
-import { AlertTriangle, RotateCcw } from 'lucide-react'
+import { AlertTriangle, RotateCcw, FolderOpen } from 'lucide-react'
+import type { InvalidRepo } from '../preload'
 import { useStore } from './store'
 import { useConfig } from './hooks/useConfig'
 import { useTerminals } from './hooks/useTerminals'
@@ -202,6 +203,66 @@ export function App() {
           ],
         }
       )
+    })
+    return () => { unsubscribe() }
+  }, [loadConfig])
+
+  // Surface configured repositories whose folder is missing or is not a git repo,
+  // with a one-click "re-point folder" action. Runs on launch (initial fetch +
+  // the main-process 'repos:invalid' event) so invalid paths are caught early.
+  useEffect(() => {
+    const shownRef = new Set<string>()
+
+    const repointFolder = async (name: string) => {
+      const folder = await window.electronAPI.dialog.openFolder()
+      if (!folder) return
+      try {
+        await window.electronAPI.config.updateRepository(name, { path: folder })
+        loadConfig()
+        showToast(`Re-pointed "${name}"`, 'success')
+      } catch (err) {
+        showToast(err instanceof Error ? err.message : `Failed to re-point "${name}"`, 'error')
+      }
+    }
+
+    const surface = (repos: InvalidRepo[]) => {
+      for (const repo of repos) {
+        if (shownRef.has(repo.name)) continue
+        shownRef.add(repo.name)
+        const why = repo.reason === 'missing' ? 'folder is missing' : 'is not a git repository'
+        showToast(`Repository "${repo.name}" ${why} (${repo.path})`, 'error', {
+          persistent: true,
+          actions: [
+            {
+              label: 'Re-point folder',
+              icon: <FolderOpen className="w-3.5 h-3.5" />,
+              onClick: () => repointFolder(repo.name),
+            },
+          ],
+        })
+      }
+    }
+
+    window.electronAPI.config.getInvalidRepos().then(surface).catch(() => {})
+    const unsubscribe = window.electronAPI.config.onInvalidRepos(surface)
+    return () => { unsubscribe() }
+  }, [loadConfig])
+
+  // A write-through to the cloud failed: the main process already re-synced the
+  // caches from the DB, so the latest change may not have been saved. Tell the
+  // user, and refresh the local config view so it reflects the re-synced state.
+  useEffect(() => {
+    const LABELS: Record<'config' | 'agents' | 'history', string> = {
+      config: 'settings',
+      agents: 'agents',
+      history: 'activity history',
+    }
+    const unsubscribe = window.electronAPI.connectivity.onWriteError(({ kind }) => {
+      showToast(
+        `Failed to save your ${LABELS[kind]} to the cloud. Your latest change may not have been saved — reloaded from the server.`,
+        'error',
+      )
+      if (kind === 'config') loadConfig()
     })
     return () => { unsubscribe() }
   }, [loadConfig])

--- a/desktop/src/renderer/components/AppGate.tsx
+++ b/desktop/src/renderer/components/AppGate.tsx
@@ -1,0 +1,87 @@
+import { CloudOff, WifiOff, Loader2, RotateCcw } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useConnectivity } from '../hooks/useConnectivity'
+import { LoginScreen } from './LoginScreen'
+
+function FullScreen({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center justify-center h-screen bg-transparent text-white">
+      <div className="flex flex-col items-center gap-4 text-center max-w-sm px-6">{children}</div>
+    </div>
+  )
+}
+
+function Checking() {
+  return (
+    <FullScreen>
+      <Loader2 className="w-8 h-8 animate-spin text-accent" />
+      <p className="text-white/60">Connecting…</p>
+    </FullScreen>
+  )
+}
+
+function CloudNotConfigured() {
+  return (
+    <FullScreen>
+      <div className="p-3 bg-red/10 rounded-xl">
+        <CloudOff className="w-7 h-7 text-red" />
+      </div>
+      <h2 className="text-lg font-semibold">Cloud not configured</h2>
+      <p className="text-sm text-text-secondary">
+        Magic Slash requires its cloud backend, but it isn’t configured in this build. Please
+        reinstall an official build or set the Supabase environment before launching.
+      </p>
+    </FullScreen>
+  )
+}
+
+function ConnectionLost({ onRetry }: { onRetry: () => void }) {
+  return (
+    <FullScreen>
+      <div className="p-3 bg-yellow/10 rounded-xl">
+        <WifiOff className="w-7 h-7 text-yellow" />
+      </div>
+      <h2 className="text-lg font-semibold">Connection lost</h2>
+      <p className="text-sm text-text-secondary">
+        Magic Slash can’t reach its backend. Check your internet connection — the app stays
+        locked until the connection is restored.
+      </p>
+      <button
+        onClick={onRetry}
+        className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-hover text-white rounded-lg text-sm font-medium transition-colors"
+      >
+        <RotateCcw className="w-4 h-4" />
+        Retry
+      </button>
+    </FullScreen>
+  )
+}
+
+/**
+ * Mandatory cloud gate wrapping the entire app. Children (the real App) render
+ * ONLY when the backend is reachable AND the user is authenticated. Every other
+ * state is a hard block — no offline mode, no grace period.
+ */
+export function AppGate({ children }: { children: ReactNode }) {
+  const { status, recheck } = useConnectivity()
+
+  switch (status) {
+    case 'ok':
+      return <>{children}</>
+    case 'checking':
+      return <Checking />
+    case 'disabled':
+      return <CloudNotConfigured />
+    case 'unreachable':
+      return <ConnectionLost onRetry={recheck} />
+    case 'unauthorized':
+    default:
+      // Blocking auth wall: the modal cannot be dismissed (there is nothing
+      // behind it). On sign-in we re-probe connectivity to unlock the app.
+      return (
+        <div className="h-screen bg-transparent">
+          <LoginScreen isOpen onClose={() => {}} onSignedIn={recheck} />
+        </div>
+      )
+  }
+}

--- a/desktop/src/renderer/components/LoginScreen.tsx
+++ b/desktop/src/renderer/components/LoginScreen.tsx
@@ -150,7 +150,7 @@ export function LoginScreen({ isOpen, onClose, onSignedIn }: LoginScreenProps) {
           <p className="text-xs text-text-secondary/60">
             {mode === 'reset'
               ? 'Reset your password with a 6-digit code sent to your email — no link to click.'
-              : 'Cloud sign-in is optional — Magic Slash works fully without an account. Sign in to manage your organization and invite teammates.'}
+              : 'Sign in to continue. Magic Slash keeps your config, agents and history in your organization’s cloud.'}
           </p>
 
           <div className="space-y-2">

--- a/desktop/src/renderer/hooks/useActivityHistory.ts
+++ b/desktop/src/renderer/hooks/useActivityHistory.ts
@@ -120,14 +120,5 @@ export function useActivityHistory() {
     })
   }, [entries])
 
-  const clear = useCallback(async () => {
-    try {
-      await window.electronAPI.activityHistory.clear()
-      setEntries([])
-    } catch (err) {
-      console.error('Error clearing activity history:', err)
-    }
-  }, [])
-
-  return { entries, groups, loading, error, refresh: loadHistory, clear }
+  return { entries, groups, loading, error, refresh: loadHistory }
 }

--- a/desktop/src/renderer/hooks/useConnectivity.ts
+++ b/desktop/src/renderer/hooks/useConnectivity.ts
@@ -1,0 +1,56 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import type { ConnectivityStatus } from '../../preload'
+
+export type GateStatus = ConnectivityStatus | 'checking'
+
+const RECHECK_INTERVAL_MS = 20_000
+
+/**
+ * Drives the mandatory cloud gate. Polls the backend reachability probe on an
+ * interval AND on window focus, and subscribes to push updates from the main
+ * process. The whole app stays blocked until this reports 'ok':
+ *  - 'checking'     initial probe in flight → loading.
+ *  - 'ok'           reachable + authed → app is allowed to render.
+ *  - 'unauthorized' logged out / rejected session → auth wall.
+ *  - 'unreachable'  backend down / offline → "connection lost" block (no grace).
+ *  - 'disabled'     Supabase not configured → "cloud not configured" block.
+ */
+export function useConnectivity() {
+  const [status, setStatus] = useState<GateStatus>('checking')
+  const inFlight = useRef(false)
+
+  const recheck = useCallback(async () => {
+    if (inFlight.current) return
+    inFlight.current = true
+    try {
+      const next = await window.electronAPI.connectivity.check()
+      setStatus(next)
+    } catch {
+      setStatus('unreachable')
+    } finally {
+      inFlight.current = false
+    }
+  }, [])
+
+  // Initial probe + interval.
+  useEffect(() => {
+    recheck()
+    const timer = window.setInterval(recheck, RECHECK_INTERVAL_MS)
+    return () => window.clearInterval(timer)
+  }, [recheck])
+
+  // Re-check when the window regains focus.
+  useEffect(() => {
+    const onFocus = () => recheck()
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [recheck])
+
+  // Push updates from the main process (e.g. after login/logout).
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.connectivity.onStatusChanged(setStatus)
+    return () => { unsubscribe() }
+  }, [])
+
+  return { status, recheck }
+}

--- a/desktop/src/renderer/main.tsx
+++ b/desktop/src/renderer/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from './App'
+import { AppGate } from './components/AppGate'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <AppGate>
+      <App />
+    </AppGate>
   </React.StrictMode>
 )

--- a/desktop/src/renderer/pages/History/index.tsx
+++ b/desktop/src/renderer/pages/History/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { Clock, Trash2, ChevronRight, ChevronLeft } from 'lucide-react'
+import { Clock, ChevronRight, ChevronLeft } from 'lucide-react'
 import { useActivityHistory } from '../../hooks/useActivityHistory'
 import { useHistoryAnalytics } from '../../hooks/useHistoryAnalytics'
 import { ActivityHeatmap } from './ActivityHeatmap'
@@ -75,10 +75,9 @@ function SingleEntryRow({ entry, isDimmed }: { entry: HistoryEntry; isDimmed: bo
 }
 
 export function HistoryPage() {
-  const { entries, groups, loading, clear } = useActivityHistory()
+  const { entries, groups, loading } = useActivityHistory()
   const { heatmapData } = useHistoryAnalytics(entries)
   const hasEntries = groups.some(g => g.entries.length > 0)
-  const [showConfirm, setShowConfirm] = useState(false)
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
   const [closingGroups, setClosingGroups] = useState<Set<string>>(new Set())
   const [dayIndex, setDayIndex] = useState(0)
@@ -125,11 +124,6 @@ export function HistoryPage() {
     document.addEventListener('mousedown', handleClick)
     return () => document.removeEventListener('mousedown', handleClick)
   }, [expandedGroups, collapseGroup])
-
-  const handleClear = useCallback(async () => {
-    await clear()
-    setShowConfirm(false)
-  }, [clear])
 
   const goToPrevDay = useCallback(() => {
     setDayIndex(i => Math.min(i + 1, groups.length - 1))
@@ -180,30 +174,6 @@ export function HistoryPage() {
               <h1 className="text-2xl font-semibold">History</h1>
               <p className="text-sm text-text-secondary mt-1">Track your agents' activity across all repositories.</p>
             </div>
-            {!showConfirm ? (
-              <button
-                onClick={() => setShowConfirm(true)}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/[0.08] rounded-lg hover:bg-white/[0.04] hover:text-white transition-all"
-              >
-                <Trash2 className="w-3.5 h-3.5" />
-                <span>Clear</span>
-              </button>
-            ) : (
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => setShowConfirm(false)}
-                  className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/[0.08] rounded-lg hover:bg-white/[0.04] hover:text-white transition-all"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleClear}
-                  className="px-3 py-1.5 text-xs font-medium text-red border border-red/20 rounded-lg hover:bg-red/10 transition-all"
-                >
-                  Confirm clear
-                </button>
-              </div>
-            )}
           </div>
 
           {/* Analytics dashboard */}

--- a/desktop/src/renderer/pages/Terminals/index.tsx
+++ b/desktop/src/renderer/pages/Terminals/index.tsx
@@ -23,6 +23,26 @@ export function TerminalsPage() {
     return `Claude ${count}`
   }
 
+  // Strict repo-path guard on ⌘N: if any configured repository points at a
+  // missing folder or a non-git directory, block creation and send the user to
+  // Settings to re-point it (instead of launching a broken agent).
+  const blockOnInvalidRepos = async (): Promise<boolean> => {
+    try {
+      const invalid = await window.electronAPI.config.getInvalidRepos()
+      if (invalid.length > 0) {
+        showToast(
+          `${invalid.length} repository path${invalid.length > 1 ? 's are' : ' is'} invalid. Re-point ${invalid.length > 1 ? 'them' : 'it'} in Settings before launching an agent.`,
+          'error',
+          { actions: [{ label: 'Open settings', onClick: () => setCurrentPage('config') }] },
+        )
+        return true
+      }
+    } catch {
+      // If the check itself fails, don't block creation.
+    }
+    return false
+  }
+
   const handleCreateTerminal = async () => {
     if (isCreating) return
 
@@ -31,6 +51,8 @@ export function TerminalsPage() {
       showToast(`Maximum of ${MAX_AGENTS} agents reached`, 'error')
       return
     }
+
+    if (await blockOnInvalidRepos()) return
 
     setIsCreating(true)
     try {
@@ -50,6 +72,7 @@ export function TerminalsPage() {
       showToast(`Maximum of ${MAX_AGENTS} agents reached`, 'error')
       return
     }
+    if (await blockOnInvalidRepos()) return
     setIsCreating(true)
     try {
       const name = getNextTerminalName()

--- a/supabase/migrations/20260724090000_set_org_shared_config.sql
+++ b/supabase/migrations/20260724090000_set_org_shared_config.sql
@@ -1,0 +1,74 @@
+-- Migration: set_org_shared_config
+-- The admin WRITE counterpart to get_org_shared_config (migration
+-- 20260723100000). Lets an org admin persist the shared config fields that new
+-- invitees inherit — languages, commit/PR format, and shared repo keywords.
+--
+-- Mirrors the established RPC pattern (get_org_shared_config, remove_member,
+-- ...): SECURITY DEFINER with a locked search_path, an auth.uid() guard, and a
+-- defense-in-depth is_org_admin() check on top of RLS (which SECURITY DEFINER
+-- bypasses). Grants are revoked from PUBLIC and granted to authenticated only.
+--
+-- Why it writes into the ORG CREATOR's config row
+-- ---------------------------------------------------------------------------
+-- configs is per-user (unique (org_id, user_id)); there is no org-level config
+-- row. get_org_shared_config sources the "org shared config" from the org
+-- creator/admin's row — it reads organizations.created_by into admin_uid and
+-- returns the shared fields from configs where (org_id, user_id) = (org,
+-- admin_uid). To stay consistent, the write MUST target that same row, so a
+-- subsequent get_org_shared_config reads back exactly what was written. We
+-- therefore upsert into (org_id = p_org_id, user_id = created_by), regardless of
+-- which admin performs the call.
+--
+-- Only the shared fields are persisted: p_shared is projected down to
+-- languages/commit/pullRequest/repoKeywords (unknown/extra keys ignored, nulls
+-- dropped) exactly as get_org_shared_config projects on read, then merged into
+-- the creator's existing data jsonb so any other (local/per-user) keys already
+-- there are preserved.
+create or replace function public.set_org_shared_config(p_org_id uuid, p_shared jsonb)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  creator_uid uuid;
+  shared_subset jsonb;
+begin
+  if auth.uid() is null then
+    raise exception 'set_org_shared_config requires an authenticated user';
+  end if;
+
+  if not public.is_org_admin(p_org_id) then
+    raise exception 'not an admin of this organization';
+  end if;
+
+  select created_by into creator_uid
+  from public.organizations
+  where id = p_org_id;
+
+  if creator_uid is null then
+    raise exception 'organization has no creator to store shared config';
+  end if;
+
+  -- Project p_shared down to just the shared fields (ignore unknown/extra keys),
+  -- stripping nulls so absent keys are simply omitted — mirroring how
+  -- get_org_shared_config projects on read.
+  shared_subset := jsonb_strip_nulls(jsonb_build_object(
+    'languages',    p_shared -> 'languages',
+    'commit',       p_shared -> 'commit',
+    'pullRequest',  p_shared -> 'pullRequest',
+    'repoKeywords', p_shared -> 'repoKeywords'
+  ));
+
+  -- Upsert into the creator's config row. On insert the shared subset is the
+  -- whole data blob; on conflict we merge (data || subset) so any pre-existing
+  -- non-shared keys in the creator's data are preserved.
+  insert into public.configs (org_id, user_id, data)
+  values (p_org_id, creator_uid, shared_subset)
+  on conflict (org_id, user_id)
+  do update set data = public.configs.data || excluded.data;
+end;
+$$;
+
+revoke execute on function public.set_org_shared_config(uuid, jsonb) from public;
+grant execute on function public.set_org_shared_config(uuid, jsonb) to authenticated;

--- a/supabase/tests/set_org_shared_config.test.sql
+++ b/supabase/tests/set_org_shared_config.test.sql
@@ -1,0 +1,127 @@
+-- pgTAP: prove set_org_shared_config behaves correctly and round-trips through
+-- get_org_shared_config.
+--
+-- Like accept_invitation.test.sql, we impersonate authenticated end users by
+-- setting:
+--   set local role authenticated;
+--   set local request.jwt.claims = '{"sub":"<uuid>","email":"<email>"}';
+-- The RPCs are SECURITY DEFINER: they run as the owner but read auth.uid() from
+-- the "sub" claim above. We `reset role;` to seed data and to read results back
+-- bypassing RLS.
+
+begin;
+select plan(6);
+
+-- ---------------------------------------------------------------------------
+-- Seed as the table owner (RLS bypassed).
+--   Org One (aaaa): u1 = admin/creator, u2 = plain member. No config yet — used
+--                   for the write + round-trip and the non-admin rejection.
+--   Org Two (bbbb): u3 = admin/creator, with a pre-existing config row carrying
+--                   a non-shared key (repoPaths) — used to prove the merge
+--                   preserves pre-existing keys.
+-- ---------------------------------------------------------------------------
+insert into auth.users (instance_id, id, aud, role, email, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000', '11111111-1111-1111-1111-111111111111', 'authenticated', 'authenticated', 'u1@example.com', now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '22222222-2222-2222-2222-222222222222', 'authenticated', 'authenticated', 'u2@example.com', now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '33333333-3333-3333-3333-333333333333', 'authenticated', 'authenticated', 'u3@example.com', now(), now());
+
+insert into public.organizations (id, name, created_by)
+values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Org One', '11111111-1111-1111-1111-111111111111'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Org Two', '33333333-3333-3333-3333-333333333333');
+
+insert into public.memberships (org_id, user_id, role)
+values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', 'admin'),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', 'user'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '33333333-3333-3333-3333-333333333333', 'admin');
+
+-- Org Two's creator already has a config row with a non-shared, local-only key
+-- (repoPaths) that the merge must preserve.
+insert into public.configs (org_id, user_id, data)
+values (
+  'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  '33333333-3333-3333-3333-333333333333',
+  '{"repoPaths":{"api":"/local"}}'::jsonb
+);
+
+-- ===========================================================================
+-- Org One: an admin writes the shared config, which round-trips through
+-- get_org_shared_config.
+-- ===========================================================================
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111","email":"u1@example.com"}';  -- u1, admin/creator
+
+-- 1. The admin sets the shared config. The extra repoPaths key is non-shared and
+--    must be dropped by the projection (proved by the round-trip in #2).
+select lives_ok(
+  $sql$ select public.set_org_shared_config(
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    '{"languages":{"commit":"en"},"commit":{"format":"conventional"},"pullRequest":{"autoLinkTickets":true},"repoKeywords":{"api":["api","backend"]},"repoPaths":{"api":"/should-be-ignored"}}'::jsonb
+  ) $sql$,
+  'set_org_shared_config succeeds for an admin'
+);
+
+-- 2. get_org_shared_config returns exactly the shared fields just written
+--    (repoPaths dropped) — full round-trip.
+select is(
+  public.get_org_shared_config('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+  '{"commit":{"format":"conventional"},"languages":{"commit":"en"},"pullRequest":{"autoLinkTickets":true},"repoKeywords":{"api":["api","backend"]}}'::jsonb,
+  'set_org_shared_config round-trips through get_org_shared_config'
+);
+
+-- ===========================================================================
+-- Org One: a non-admin member is rejected.
+-- ===========================================================================
+reset role;
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222","email":"u2@example.com"}';  -- u2, plain member
+
+-- 3. A non-admin member cannot set the shared config.
+select throws_ok(
+  $sql$ select public.set_org_shared_config(
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    '{"languages":{"commit":"fr"}}'::jsonb
+  ) $sql$,
+  'not an admin of this organization',
+  'set_org_shared_config rejects a non-admin member'
+);
+
+-- ===========================================================================
+-- Org Two: merging preserves pre-existing non-shared keys in the creator's row.
+-- ===========================================================================
+reset role;
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"33333333-3333-3333-3333-333333333333","email":"u3@example.com"}';  -- u3, admin/creator
+
+-- 4. The admin sets the shared config on top of the pre-existing config row.
+select lives_ok(
+  $sql$ select public.set_org_shared_config(
+    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    '{"languages":{"commit":"fr"}}'::jsonb
+  ) $sql$,
+  'set_org_shared_config succeeds on an existing config row'
+);
+
+-- 5. The pre-existing non-shared key (repoPaths) is preserved by the merge.
+reset role;  -- read back as owner (bypass RLS)
+select is(
+  (select data -> 'repoPaths' from public.configs
+   where org_id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+     and user_id = '33333333-3333-3333-3333-333333333333'),
+  '{"api":"/local"}'::jsonb,
+  'set_org_shared_config preserves pre-existing non-shared keys (merge)'
+);
+
+-- 6. The shared field was added and is visible through get_org_shared_config.
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"33333333-3333-3333-3333-333333333333","email":"u3@example.com"}';
+select is(
+  public.get_org_shared_config('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+  '{"languages":{"commit":"fr"}}'::jsonb,
+  'set_org_shared_config adds the shared field alongside existing keys'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Description

Make the Supabase database the **single source of truth** for config, agents and history via a new `Store` interface + a single `CloudStore` implementation, removing all local JSON persistence. Authentication becomes **mandatory**: the whole app is blocked behind an auth wall when logged out and blocked immediately when the backend is unreachable (no offline mode, no grace period). Adds strict repo-path validation on launch and on new-agent creation (⌘N). **No data migration** — users start from scratch (existing local `config.json` / `agents.json` / `history.json` are abandoned, not imported).

Part of the epic #121. Depends on PR 1 (Supabase client) + PR 2 (auth/org), both already merged.

## Related Issue

Closes #125

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **Storage abstraction**: new `Store` interface + single `CloudStore` (Supabase-backed). Removed all `fs` JSON I/O from `config.ts` / `agents.ts` / `activity-history.ts`; the synchronous read API is preserved via write-through in-memory caches hydrated from the DB (`store/hydrate.ts`).
- **Auth + connectivity gate**: `AppGate` + `useConnectivity` block the entire app when logged out, when the backend is unreachable, or when cloud is not configured — interval + focus + push rechecks, no grace period, no offline path.
- **Repo path validation**: strict check (directory exists **and** `.git` present) surfaced on launch (`repos:invalid` event → re-point toast) and enforced on ⌘N in both the renderer and the main process before agent creation.
- **Org-shared config**: new admin-only `set_org_shared_config` RPC (SECURITY DEFINER, `is_org_admin` guarded, `REVOKE PUBLIC`) + pgTAP test; shared keys are projected at the top level of the config blob so `get_org_shared_config` keeps working.
- **History**: dropped the "clear history" feature (`activity_events` is append-only); `MAX_ENTRIES = 500` is now a read-side limit.
- **Write-failure feedback**: write-through failures now emit `store:writeError`, show a toast, and trigger a re-hydrate so the cache re-syncs from the DB.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

Automated: `npm run lint` → 0 errors, `npm run typecheck` → clean, `npm test` → 201 tests passing.

### Test Steps

1. Launch **without** `MAGIC_SLASH_SUPABASE_URL` / `MAGIC_SLASH_SUPABASE_ANON_KEY` → the app shows the "cloud not configured" blocking screen. Set both env vars and relaunch → the auth wall (`LoginScreen`) is shown and no feature is accessible.
2. Sign in → the app loads with **empty** config/agents/history (no migration). Create an agent (⌘N) and add a repo → confirm rows appear in Supabase `configs` / `agents` / `activity_events`, and that **nothing** is written to `~/.config/magic-slash/config.json`.
3. Stop the Supabase backend (or kill the network) → the app blocks **immediately** with the connection-lost screen (no grace period); restore connectivity → the app unblocks.
4. Point a repository at a non-existent or non-git folder → it is flagged on launch with a "re-point folder" action, and ⌘N agent creation is blocked until the path is re-pointed.
5. As an org admin, exercise the shared-config write path (`org.setSharedConfig`) → verify `get_org_shared_config` reflects the change for a member of the org.

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

- **No data migration by design** — users start from scratch; existing local JSON files are abandoned.
- **Cloud is now mandatory**: dev/CI builds must inject `MAGIC_SLASH_SUPABASE_URL` / `MAGIC_SLASH_SUPABASE_ANON_KEY`, otherwise the app shows the blocking screen.
- The encrypted session file (`cloud-session.enc`), `profile.md` and `command-history` **remain local** (only config/agents/history moved to the cloud).
- **Known limitation**: repo `path` now lives in the DB, so it may be wrong on another machine or for an invited teammate — mitigated by the launch / ⌘N path validation above.
- Follow-up worth considering: unit tests for `CloudStore` / `repo-validation` / `hydrate` (currently covered indirectly).