### PR TITLE
[#126] Realtime — team agents + dashboard

### DIFF
--- a/desktop/src/main/cloud/org.ts
+++ b/desktop/src/main/cloud/org.ts
@@ -1,9 +1,10 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Config, Invitation, InvitationStatus, Member, MembershipRole, Org, OrgSharedConfig } from '../../types'
+import type { Config, Invitation, InvitationStatus, Member, MembershipRole, Org, OrgAgent, OrgSharedConfig } from '../../types'
 import { getAuthedClient } from './auth'
 import { loadSession } from './session-store'
 import { readConfig, writeConfig, hydrateConfig, mergeOrgSharedConfig, setCurrentOrgId } from '../config/config'
 import { getStore } from '../store/Store'
+import { startOrgAgentsRealtime } from './realtime'
 
 interface OrgRow {
   id: string
@@ -96,6 +97,15 @@ export async function listOrgs(): Promise<Org[]> {
     })
   }
   return orgs
+}
+
+/**
+ * Org-wide agents roster (all members) for the team dashboard "who is working
+ * on what". Delegates to the store (org-scoped by RLS). Degrades to [] when
+ * cloud is off or the user is logged out.
+ */
+export async function listOrgAgents(): Promise<OrgAgent[]> {
+  return getStore().loadOrgAgents()
 }
 
 /** Run a void-returning RPC through the authed client, surfacing failures as thrown errors. */
@@ -254,6 +264,13 @@ export async function switchOrg(orgId: string): Promise<Config> {
   const config = await hydrateConfig()
   config.currentOrgId = orgId
   writeConfig(config)
+
+  // Re-point the realtime subscription at the newly-active org so the team
+  // dashboard streams the right org's agents (best-effort — never fail the
+  // switch over it).
+  void startOrgAgentsRealtime(orgId).catch((error) =>
+    console.error('[cloud] failed to resubscribe realtime after org switch:', error),
+  )
   return config
 }
 

--- a/desktop/src/main/cloud/realtime.test.ts
+++ b/desktop/src/main/cloud/realtime.test.ts
@@ -91,6 +91,19 @@ describe('startOrgAgentsRealtime', () => {
     expect(h.state.client.channel).toHaveBeenCalledTimes(1)
   })
 
+  it('serializes concurrent starts so no channel is orphaned', async () => {
+    // Both switchOrg and the connectivity poller can fire a start at once.
+    // Without serialization they interleave across the getAuthedClient await
+    // and each opens a channel, leaking the first. The lock must collapse these
+    // into a single subscription.
+    await Promise.all([
+      startOrgAgentsRealtime('org-1'),
+      startOrgAgentsRealtime('org-1'),
+    ])
+    expect(h.state.client.channel).toHaveBeenCalledTimes(1)
+    expect(getActiveRealtimeOrgId()).toBe('org-1')
+  })
+
   it('does nothing when there is no session token', async () => {
     h.state.token = undefined
     await startOrgAgentsRealtime('org-1')

--- a/desktop/src/main/cloud/realtime.test.ts
+++ b/desktop/src/main/cloud/realtime.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the authed client + session store so the realtime module exercises only
+// its own lifecycle logic (no network, no socket). vi.hoisted shares mutable
+// state the factories (hoisted above imports) can read per test.
+const h = vi.hoisted(() => {
+  const channel = {
+    on: vi.fn(),
+    subscribe: vi.fn(),
+  }
+  // `on` and `subscribe` return the channel for chaining.
+  channel.on.mockReturnValue(channel)
+  channel.subscribe.mockReturnValue(channel)
+
+  const authSubscription = { unsubscribe: vi.fn() }
+  const client = {
+    channel: vi.fn(() => channel),
+    removeChannel: vi.fn().mockResolvedValue(undefined),
+    realtime: { setAuth: vi.fn() },
+    auth: {
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: authSubscription } })),
+    },
+  }
+  const state = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client: client as any,
+    token: 'access-token' as string | undefined,
+  }
+  return { channel, authSubscription, client, state }
+})
+
+vi.mock('./auth', () => ({
+  getAuthedClient: vi.fn(async () => h.state.client),
+}))
+
+vi.mock('./session-store', () => ({
+  loadSession: () => (h.state.token ? { access_token: h.state.token } : null),
+}))
+
+import {
+  startOrgAgentsRealtime,
+  stopOrgAgentsRealtime,
+  getActiveRealtimeOrgId,
+  setRealtimeEmitters,
+  mapOrgAgentRow,
+} from './realtime'
+
+let changes: unknown[]
+let statuses: unknown[]
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  h.channel.on.mockReturnValue(h.channel)
+  h.channel.subscribe.mockReturnValue(h.channel)
+  h.state.client = {
+    channel: vi.fn(() => h.channel),
+    removeChannel: vi.fn().mockResolvedValue(undefined),
+    realtime: { setAuth: vi.fn() },
+    auth: { onAuthStateChange: vi.fn(() => ({ data: { subscription: h.authSubscription } })) },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+  h.state.token = 'access-token'
+  changes = []
+  statuses = []
+  setRealtimeEmitters(
+    (c) => changes.push(c),
+    (s) => statuses.push(s),
+  )
+  // Ensure a clean channel between tests.
+  await stopOrgAgentsRealtime()
+})
+
+describe('startOrgAgentsRealtime', () => {
+  it('authorizes the socket then subscribes with an org-scoped filter', async () => {
+    await startOrgAgentsRealtime('org-1')
+
+    expect(h.state.client.realtime.setAuth).toHaveBeenCalledWith('access-token')
+    expect(h.state.client.channel).toHaveBeenCalledWith('org-agents')
+    expect(h.channel.on).toHaveBeenCalledWith(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'agents', filter: 'org_id=eq.org-1' },
+      expect.any(Function),
+    )
+    expect(h.channel.subscribe).toHaveBeenCalled()
+    expect(getActiveRealtimeOrgId()).toBe('org-1')
+  })
+
+  it('is a no-op when already subscribed to the same org', async () => {
+    await startOrgAgentsRealtime('org-1')
+    await startOrgAgentsRealtime('org-1')
+    expect(h.state.client.channel).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when there is no session token', async () => {
+    h.state.token = undefined
+    await startOrgAgentsRealtime('org-1')
+    expect(h.state.client.channel).not.toHaveBeenCalled()
+    expect(getActiveRealtimeOrgId()).toBeNull()
+  })
+
+  it('maps channel status to live / reconnecting', async () => {
+    await startOrgAgentsRealtime('org-1')
+    const statusCb = h.channel.subscribe.mock.calls[0][0] as (s: string) => void
+    statusCb('SUBSCRIBED')
+    statusCb('CHANNEL_ERROR')
+    statusCb('TIMED_OUT')
+    expect(statuses).toEqual(['live', 'reconnecting', 'reconnecting'])
+  })
+
+  it('forwards INSERT/UPDATE with a mapped agent and DELETE with the row id', async () => {
+    await startOrgAgentsRealtime('org-1')
+    const changeCb = h.channel.on.mock.calls[0][2] as (payload: unknown) => void
+
+    changeCb({
+      eventType: 'INSERT',
+      new: { id: 'uuid-1', owner_id: 'u1', name: 'Agent A', ticket_id: 'T-1', status: 'in progress', repositories: ['/repo'], updated_at: '2026-07-24T00:00:00Z' },
+    })
+    changeCb({ eventType: 'DELETE', old: { id: 'uuid-1' } })
+
+    expect(changes).toEqual([
+      {
+        eventType: 'INSERT',
+        id: 'uuid-1',
+        agent: {
+          id: 'uuid-1',
+          ownerId: 'u1',
+          name: 'Agent A',
+          ticketId: 'T-1',
+          status: 'in progress',
+          repositories: ['/repo'],
+          updatedAt: '2026-07-24T00:00:00Z',
+        },
+      },
+      { eventType: 'DELETE', id: 'uuid-1' },
+    ])
+  })
+
+  it('resubscribes on org switch (tears down old channel, opens a new one)', async () => {
+    await startOrgAgentsRealtime('org-1')
+    await startOrgAgentsRealtime('org-2')
+
+    expect(h.state.client.removeChannel).toHaveBeenCalledTimes(1)
+    expect(h.channel.on).toHaveBeenLastCalledWith(
+      'postgres_changes',
+      expect.objectContaining({ filter: 'org_id=eq.org-2' }),
+      expect.any(Function),
+    )
+    expect(getActiveRealtimeOrgId()).toBe('org-2')
+  })
+})
+
+describe('stopOrgAgentsRealtime', () => {
+  it('removes the channel, unsubscribes the auth listener, and clears the active org', async () => {
+    await startOrgAgentsRealtime('org-1')
+    await stopOrgAgentsRealtime()
+
+    expect(h.state.client.removeChannel).toHaveBeenCalledWith(h.channel)
+    expect(h.authSubscription.unsubscribe).toHaveBeenCalled()
+    expect(getActiveRealtimeOrgId()).toBeNull()
+  })
+
+  it('is safe to call when nothing is subscribed', async () => {
+    await expect(stopOrgAgentsRealtime()).resolves.toBeUndefined()
+  })
+})
+
+describe('mapOrgAgentRow', () => {
+  it('prefers top-level columns and falls back to metadata for ticket/status', () => {
+    expect(
+      mapOrgAgentRow({
+        id: 'uuid-2',
+        owner_id: null,
+        name: 'B',
+        ticket_id: null,
+        status: null,
+        repositories: 'not-an-array' as unknown as string[],
+        metadata: { ticketId: 'T-9', status: 'committed' },
+        updated_at: null,
+      }),
+    ).toEqual({
+      id: 'uuid-2',
+      ownerId: null,
+      name: 'B',
+      ticketId: 'T-9',
+      status: 'committed',
+      repositories: [],
+      updatedAt: undefined,
+    })
+  })
+})

--- a/desktop/src/main/cloud/realtime.ts
+++ b/desktop/src/main/cloud/realtime.ts
@@ -117,12 +117,32 @@ function ensureTokenReapply(client: SupabaseClient): void {
   }
 }
 
+// Serialize all start/stop operations. Both `switchOrg` and the connectivity
+// poller can trigger a start, and each start awaits (getAuthedClient, teardown)
+// — without serialization two of them could interleave across an await and
+// orphan a WebSocket channel (the second `channel = client.channel(...)` would
+// overwrite the first without removing it). Chaining every entrypoint onto the
+// previous op means the idempotency guard below always sees a settled state.
+let opLock: Promise<void> = Promise.resolve()
+
+function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = opLock.then(fn, fn)
+  // Keep the chain alive and non-rejecting so one failed op can't wedge the lock.
+  opLock = run.then(() => undefined, () => undefined)
+  return run
+}
+
 /**
  * Subscribe to org-scoped agent changes. Idempotent for the same org (a repeat
  * call while already subscribed is a no-op). Switching orgs tears down the old
  * channel first. Degrades to a no-op when cloud is unavailable / logged out.
+ * Serialized against every other start/stop call (see withLock).
  */
-export async function startOrgAgentsRealtime(orgId: string): Promise<void> {
+export function startOrgAgentsRealtime(orgId: string): Promise<void> {
+  return withLock(() => startInternal(orgId))
+}
+
+async function startInternal(orgId: string): Promise<void> {
   if (channel && subscribedOrgId === orgId) return
 
   const client = await getAuthedClient()
@@ -131,7 +151,8 @@ export async function startOrgAgentsRealtime(orgId: string): Promise<void> {
   if (!token) return
 
   // Switching org (or a stale channel) → tear down before re-subscribing.
-  await stopOrgAgentsRealtime()
+  // Internal (unlocked) teardown: we already hold the lock.
+  await stopInternal()
 
   // CRITICAL for RLS: authorize the socket with the user's JWT before subscribe.
   client.realtime.setAuth(token)
@@ -154,11 +175,21 @@ export async function startOrgAgentsRealtime(orgId: string): Promise<void> {
 
 /**
  * Tear down the org-agents channel (sign-out / unauthorized / org switch).
- * Never throws.
+ * Never throws. Serialized against every other start/stop call (see withLock).
  */
-export async function stopOrgAgentsRealtime(): Promise<void> {
+export function stopOrgAgentsRealtime(): Promise<void> {
+  return withLock(stopInternal)
+}
+
+async function stopInternal(): Promise<void> {
   subscribedOrgId = null
-  lastStatus = 'reconnecting'
+  if (lastStatus !== 'reconnecting') {
+    lastStatus = 'reconnecting'
+    // Notify the renderer so a mounted LiveIndicator flips to "Reconnecting…"
+    // immediately, rather than lingering on "Live" through the teardown/
+    // resubscribe window (or indefinitely if the next channel never subscribes).
+    statusEmitter?.(lastStatus)
+  }
   if (authListenerUnsub) {
     authListenerUnsub()
     authListenerUnsub = null

--- a/desktop/src/main/cloud/realtime.ts
+++ b/desktop/src/main/cloud/realtime.ts
@@ -1,0 +1,175 @@
+import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js'
+import type { OrgAgent, OrgAgentChange, RealtimeStatus } from '../../types'
+import { getAuthedClient } from './auth'
+import { loadSession } from './session-store'
+
+// ---------------------------------------------------------------------------
+// Org-agents Realtime subscription (main process).
+//
+// Subscribes to postgres_changes on public.agents, org-scoped via a
+// `org_id=eq.<orgId>` filter AND the table's org-scoped RLS. The socket is
+// authorized with the user's JWT (realtime.setAuth) so the SAME RLS the REST
+// path enforces also gates the stream — a member of org A never receives org
+// B's events (AC#3). Events are forwarded to the renderer via injected emitters
+// (wired in connectivity-handlers to webContents.send). This module NEVER
+// mutates the local config/agents cache — teammates' agents are read-only.
+// ---------------------------------------------------------------------------
+
+/** DB row shape for `agents` as delivered by REST select and Realtime payloads. */
+export interface OrgAgentRow {
+  id: string
+  owner_id: string | null
+  name: string
+  ticket_id: string | null
+  status: string | null
+  repositories: unknown
+  metadata?: { __app?: unknown; ticketId?: string; status?: string } & Record<string, unknown>
+  updated_at?: string | null
+}
+
+/** Map a raw `agents` DB row (REST or Realtime) to the roster-facing OrgAgent. */
+export function mapOrgAgentRow(row: OrgAgentRow): OrgAgent {
+  const meta = row.metadata ?? {}
+  return {
+    id: row.id,
+    ownerId: row.owner_id ?? null,
+    name: row.name,
+    ticketId: row.ticket_id ?? meta.ticketId ?? undefined,
+    status: row.status ?? meta.status ?? undefined,
+    repositories: Array.isArray(row.repositories) ? (row.repositories as string[]) : [],
+    updatedAt: row.updated_at ?? undefined,
+  }
+}
+
+type ChangeEmitter = (change: OrgAgentChange) => void
+type StatusEmitter = (status: RealtimeStatus) => void
+
+let changeEmitter: ChangeEmitter | null = null
+let statusEmitter: StatusEmitter | null = null
+
+/**
+ * Wire the emitters that forward realtime events + channel health to the
+ * renderer. Pass (null, null) to clear (e.g. on teardown).
+ */
+export function setRealtimeEmitters(change: ChangeEmitter | null, status: StatusEmitter | null): void {
+  changeEmitter = change
+  statusEmitter = status
+}
+
+let channel: RealtimeChannel | null = null
+let activeClient: SupabaseClient | null = null
+let subscribedOrgId: string | null = null
+let authListenerUnsub: (() => void) | null = null
+let lastStatus: RealtimeStatus = 'reconnecting'
+
+/** The org id the channel is currently subscribed to, or null when inactive. */
+export function getActiveRealtimeOrgId(): string | null {
+  return subscribedOrgId
+}
+
+/**
+ * Last known channel health. Lets a late-mounting renderer (e.g. opening the
+ * dashboard after the channel already fired SUBSCRIBED) seed its indicator
+ * instead of waiting for the next push, which may never come.
+ */
+export function getRealtimeStatus(): RealtimeStatus {
+  return lastStatus
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function handleChange(payload: any): void {
+  if (!changeEmitter) return
+  const eventType = payload?.eventType as OrgAgentChange['eventType']
+  if (eventType === 'DELETE') {
+    const id = (payload.old as OrgAgentRow | undefined)?.id
+    if (id) changeEmitter({ eventType, id })
+    return
+  }
+  const row = payload?.new as OrgAgentRow | undefined
+  if (!row?.id) return
+  changeEmitter({ eventType, id: row.id, agent: mapOrgAgentRow(row) })
+}
+
+function mapChannelStatus(status: string): RealtimeStatus {
+  // 'SUBSCRIBED' means the socket is live and RLS-authorized. Every other status
+  // ('CHANNEL_ERROR', 'TIMED_OUT', 'CLOSED') is a transient loss → reconnecting.
+  return status === 'SUBSCRIBED' ? 'live' : 'reconnecting'
+}
+
+/**
+ * Re-apply the access token to the realtime socket whenever the SDK refreshes
+ * it, so a long-lived channel never falls back to the anon key and breaks RLS.
+ * Registered once per active channel; torn down in stopOrgAgentsRealtime.
+ */
+function ensureTokenReapply(client: SupabaseClient): void {
+  if (authListenerUnsub) return
+  const { data } = client.auth.onAuthStateChange((_event, session) => {
+    if (session?.access_token && channel) {
+      client.realtime.setAuth(session.access_token)
+    }
+  })
+  authListenerUnsub = () => {
+    try {
+      data.subscription.unsubscribe()
+    } catch (error) {
+      console.error('[realtime] failed to unsubscribe auth listener:', error)
+    }
+  }
+}
+
+/**
+ * Subscribe to org-scoped agent changes. Idempotent for the same org (a repeat
+ * call while already subscribed is a no-op). Switching orgs tears down the old
+ * channel first. Degrades to a no-op when cloud is unavailable / logged out.
+ */
+export async function startOrgAgentsRealtime(orgId: string): Promise<void> {
+  if (channel && subscribedOrgId === orgId) return
+
+  const client = await getAuthedClient()
+  if (!client) return
+  const token = loadSession()?.access_token
+  if (!token) return
+
+  // Switching org (or a stale channel) → tear down before re-subscribing.
+  await stopOrgAgentsRealtime()
+
+  // CRITICAL for RLS: authorize the socket with the user's JWT before subscribe.
+  client.realtime.setAuth(token)
+  ensureTokenReapply(client)
+
+  activeClient = client
+  subscribedOrgId = orgId
+  channel = client
+    .channel('org-agents')
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'agents', filter: `org_id=eq.${orgId}` },
+      handleChange,
+    )
+    .subscribe((status: string) => {
+      lastStatus = mapChannelStatus(status)
+      statusEmitter?.(lastStatus)
+    })
+}
+
+/**
+ * Tear down the org-agents channel (sign-out / unauthorized / org switch).
+ * Never throws.
+ */
+export async function stopOrgAgentsRealtime(): Promise<void> {
+  subscribedOrgId = null
+  lastStatus = 'reconnecting'
+  if (authListenerUnsub) {
+    authListenerUnsub()
+    authListenerUnsub = null
+  }
+  if (channel && activeClient) {
+    try {
+      await activeClient.removeChannel(channel)
+    } catch (error) {
+      console.error('[realtime] failed to remove channel:', error)
+    }
+  }
+  channel = null
+  activeClient = null
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -25,6 +25,7 @@ import { setupProfileHandlers } from './ipc/profile-handlers'
 import { setupUsageHandlers } from './ipc/usage-handlers'
 import { setupAuthHandlers } from './ipc/auth-handlers'
 import { setupOrgHandlers } from './ipc/org-handlers'
+import { stopOrgAgentsRealtime } from './cloud/realtime'
 import { PRReviewWatcher } from './pr-review-watcher/watcher'
 import { setupPRReviewHandlers } from './ipc/pr-review-handlers'
 
@@ -568,6 +569,9 @@ app.on('before-quit', async (event) => {
     prReviewWatcher.stop()
     prReviewWatcher = null
   }
+
+  // Tear down the org-agents realtime channel
+  void stopOrgAgentsRealtime()
 
   // Cleanup global shortcuts
   globalShortcut.unregisterAll()

--- a/desktop/src/main/ipc/connectivity-handlers.ts
+++ b/desktop/src/main/ipc/connectivity-handlers.ts
@@ -5,6 +5,13 @@ import { ensureHydrated, rehydrate, resetHydration } from '../store/hydrate'
 import { migrateConfig } from '../config/migrate'
 import { validateAllRepoPaths } from '../config/repo-validation'
 import { restoreAgents } from './terminal-handlers'
+import { getCurrentOrg } from '../cloud/org'
+import {
+  startOrgAgentsRealtime,
+  stopOrgAgentsRealtime,
+  getActiveRealtimeOrgId,
+  setRealtimeEmitters,
+} from '../cloud/realtime'
 
 let restoredOnce = false
 
@@ -24,6 +31,14 @@ export function setupConnectivityHandlers(getMainWindow: () => BrowserWindow | n
     getMainWindow()?.webContents.send('repos:invalid', invalid)
   }
 
+  // Forward org-agents realtime events + channel health to the renderer (team
+  // dashboard + live indicator). Wired once; the realtime module holds the
+  // channel lifecycle.
+  setRealtimeEmitters(
+    (change) => getMainWindow()?.webContents.send('org:agentsChanged', change),
+    (status) => getMainWindow()?.webContents.send('org:realtimeStatus', status),
+  )
+
   const check = async (): Promise<ConnectivityStatus> => {
     const status = await getStore().ping()
 
@@ -38,12 +53,25 @@ export function setupConnectivityHandlers(getMainWindow: () => BrowserWindow | n
           restoreAgents()
         }
         emitInvalidRepos()
+        // Start the org-agents realtime subscription once the backend is
+        // reachable + authed. Idempotent per org; resolve the org only until a
+        // channel is live to avoid an extra query on every poll.
+        if (!getActiveRealtimeOrgId()) {
+          const org = await getCurrentOrg()
+          if (org) {
+            void startOrgAgentsRealtime(org.id).catch((error) =>
+              console.error('[connectivity] failed to start realtime:', error),
+            )
+          }
+        }
       } catch (error) {
         console.error('[connectivity] hydration failed:', error)
       }
     } else if (status === 'unauthorized') {
       restoredOnce = false
       resetHydration()
+      // Session gone → tear down the realtime channel so the next user starts clean.
+      void stopOrgAgentsRealtime()
     }
 
     getMainWindow()?.webContents.send('connectivity:statusChanged', status)

--- a/desktop/src/main/ipc/connectivity-handlers.ts
+++ b/desktop/src/main/ipc/connectivity-handlers.ts
@@ -36,7 +36,7 @@ export function setupConnectivityHandlers(getMainWindow: () => BrowserWindow | n
   // channel lifecycle.
   setRealtimeEmitters(
     (change) => getMainWindow()?.webContents.send('org:agentsChanged', change),
-    (status) => getMainWindow()?.webContents.send('org:realtimeStatus', status),
+    (status) => getMainWindow()?.webContents.send('org:realtimeStatusChanged', status),
   )
 
   const check = async (): Promise<ConnectivityStatus> => {

--- a/desktop/src/main/ipc/org-handlers.ts
+++ b/desktop/src/main/ipc/org-handlers.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron'
 import type { AcceptInvitationResult } from '../cloud/org'
-import type { Config, Invitation, Member, MembershipRole, Org, OrgSharedConfig } from '../../types'
+import type { Config, Invitation, Member, MembershipRole, Org, OrgAgent, OrgSharedConfig, RealtimeStatus } from '../../types'
+import { getRealtimeStatus } from '../cloud/realtime'
 import {
   getCurrentOrg,
   listMembers,
@@ -10,6 +11,7 @@ import {
   applySharedConfig,
   setOrgSharedConfig,
   listOrgs,
+  listOrgAgents,
   removeMember,
   leaveOrg,
   updateMemberRole,
@@ -30,6 +32,10 @@ export function setupOrgHandlers(): void {
   ipcMain.handle('org:members', async (): Promise<Member[]> => listMembers())
 
   ipcMain.handle('org:list', async (): Promise<Org[]> => listOrgs())
+
+  ipcMain.handle('org:listAgents', async (): Promise<OrgAgent[]> => listOrgAgents())
+
+  ipcMain.handle('org:realtimeStatus', async (): Promise<RealtimeStatus> => getRealtimeStatus())
 
   ipcMain.handle('org:invitations', async (): Promise<Invitation[]> => listInvitations())
 

--- a/desktop/src/main/store/CloudStore.ts
+++ b/desktop/src/main/store/CloudStore.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'crypto'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Agent, Config, HistoryEntry, OrgSharedConfig, TerminalMetadata } from '../../types'
+import type { Agent, Config, HistoryEntry, OrgAgent, OrgSharedConfig, TerminalMetadata } from '../../types'
 import { getAuthedClient } from '../cloud/auth'
 import { loadSession } from '../cloud/session-store'
 import { isCloudEnabled } from '../cloud/supabase-client'
+import { mapOrgAgentRow, type OrgAgentRow } from '../cloud/realtime'
 import type { ConnectivityStatus, Store } from './Store'
 
 // ---------------------------------------------------------------------------
@@ -188,7 +189,7 @@ export class CloudStore implements Store {
 
     const { data, error } = await ctx.client
       .from('agents')
-      .select('id, org_id, owner_id, name, ticket_id, description, branch_name, base_branch, status, repositories, metadata')
+      .select('id, org_id, owner_id, name, ticket_id, description, branch_name, base_branch, status, repositories, metadata, updated_at')
       .eq('org_id', ctx.orgId)
 
     if (error || !data) return []
@@ -232,6 +233,25 @@ export class CloudStore implements Store {
 
     const { error } = await ctx.client.from('agents').upsert(rows, { onConflict: 'id' })
     if (error) throw new Error(`saveAgents failed: ${error.message}`)
+  }
+
+  /**
+   * Org-wide agents roster for the team dashboard. Unlike loadAgents (which maps
+   * to the LOCAL Agent shape and drives terminal restoration), this preserves
+   * owner_id + updated_at so the dashboard can group by member and show recency.
+   * Read-only: never touches the local agents cache. RLS scopes it to the org.
+   */
+  async loadOrgAgents(): Promise<OrgAgent[]> {
+    const ctx = await this.context()
+    if (!ctx) return []
+
+    const { data, error } = await ctx.client
+      .from('agents')
+      .select('id, owner_id, name, ticket_id, status, repositories, metadata, updated_at')
+      .eq('org_id', ctx.orgId)
+
+    if (error || !data) return []
+    return (data as OrgAgentRow[]).map(mapOrgAgentRow)
   }
 
   // -------------------------------------------------------------------------

--- a/desktop/src/main/store/Store.ts
+++ b/desktop/src/main/store/Store.ts
@@ -1,4 +1,4 @@
-import type { Config, Agent, HistoryEntry, OrgSharedConfig } from '../../types'
+import type { Config, Agent, HistoryEntry, OrgSharedConfig, OrgAgent } from '../../types'
 
 /**
  * Result of a backend reachability probe.
@@ -26,6 +26,9 @@ export interface Store {
 
   loadAgents(): Promise<Agent[]>
   saveAgents(agents: Agent[]): Promise<void>
+
+  /** Org-wide agents roster (all members) for the team dashboard. Read-only. */
+  loadOrgAgents(): Promise<OrgAgent[]>
 
   /** Most-recent `limit` history entries, oldest-first (matches the legacy read order). */
   loadHistory(limit: number): Promise<HistoryEntry[]>
@@ -55,6 +58,7 @@ export const NOOP_STORE: Store = {
   async saveConfig() { /* no-op */ },
   async loadAgents() { return [] },
   async saveAgents() { /* no-op */ },
+  async loadOrgAgents() { return [] },
   async loadHistory() { return [] },
   async appendHistory() { /* no-op */ },
   async setOrgSharedConfig() { /* no-op */ },

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -464,8 +464,8 @@ const orgApi = {
   },
   onRealtimeStatus: (callback: (status: RealtimeStatus) => void) => {
     const listener = (_event: IpcRendererEvent, status: RealtimeStatus) => callback(status)
-    ipcRenderer.on('org:realtimeStatus', listener)
-    return () => ipcRenderer.removeListener('org:realtimeStatus', listener)
+    ipcRenderer.on('org:realtimeStatusChanged', listener)
+    return () => ipcRenderer.removeListener('org:realtimeStatusChanged', listener)
   },
   invitations: (): Promise<Invitation[]> => ipcRenderer.invoke('org:invitations'),
   invite: (email: string, role?: MembershipRole): Promise<Invitation> =>

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
-import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole, OrgSharedConfig } from '../types'
+import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole, OrgSharedConfig, OrgAgent, OrgAgentChange, RealtimeStatus } from '../types'
 
 export type TerminalState = 'idle' | 'working' | 'waiting' | 'completed' | 'error'
 
@@ -454,6 +454,19 @@ const orgApi = {
   current: (): Promise<Org | null> => ipcRenderer.invoke('org:current'),
   members: (): Promise<Member[]> => ipcRenderer.invoke('org:members'),
   list: (): Promise<Org[]> => ipcRenderer.invoke('org:list'),
+  // Team dashboard: org-wide agents roster + live realtime propagation.
+  listAgents: (): Promise<OrgAgent[]> => ipcRenderer.invoke('org:listAgents'),
+  getRealtimeStatus: (): Promise<RealtimeStatus> => ipcRenderer.invoke('org:realtimeStatus'),
+  onAgentsChanged: (callback: (change: OrgAgentChange) => void) => {
+    const listener = (_event: IpcRendererEvent, change: OrgAgentChange) => callback(change)
+    ipcRenderer.on('org:agentsChanged', listener)
+    return () => ipcRenderer.removeListener('org:agentsChanged', listener)
+  },
+  onRealtimeStatus: (callback: (status: RealtimeStatus) => void) => {
+    const listener = (_event: IpcRendererEvent, status: RealtimeStatus) => callback(status)
+    ipcRenderer.on('org:realtimeStatus', listener)
+    return () => ipcRenderer.removeListener('org:realtimeStatus', listener)
+  },
   invitations: (): Promise<Invitation[]> => ipcRenderer.invoke('org:invitations'),
   invite: (email: string, role?: MembershipRole): Promise<Invitation> =>
     ipcRenderer.invoke('org:invite', { email, role }),

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import { ConfigPage } from './pages/Config'
 import { TerminalsPage } from './pages/Terminals'
 import { SkillsPage } from './pages/Skills'
 import { HistoryPage } from './pages/History'
+import { DashboardPage } from './pages/Dashboard'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { ProfileOnboardingWizard } from './components/ProfileOnboardingWizard'
 import { useWindowSplitMode } from './hooks/useWindowSplitMode'
@@ -333,6 +334,13 @@ export function App() {
           <div className={`absolute inset-0 overflow-auto ${currentPage === 'history' ? 'block' : 'hidden'}`}>
             <div className="max-w-5xl mx-auto p-6 h-full">
               <HistoryPage />
+            </div>
+          </div>
+
+          {/* Team Dashboard Page */}
+          <div className={`absolute inset-0 overflow-auto ${currentPage === 'dashboard' ? 'block' : 'hidden'}`}>
+            <div className="max-w-5xl mx-auto p-6 h-full">
+              <DashboardPage />
             </div>
           </div>
 

--- a/desktop/src/renderer/components/IconSidebar.tsx
+++ b/desktop/src/renderer/components/IconSidebar.tsx
@@ -1,4 +1,4 @@
-import { Bot, Settings, Circle, AlertTriangle, Sparkles, Clock } from 'lucide-react'
+import { Bot, Settings, Circle, AlertTriangle, Sparkles, Clock, Users } from 'lucide-react'
 import { useStore } from '../store'
 import { stateColorsIcon as stateColors, stateBgColorsIcon as stateBgColors } from '../utils/stateColors'
 import { useMemo } from 'react'
@@ -82,6 +82,19 @@ export function IconSidebar() {
           <Clock className="w-5 h-5" />
         </button>
       )}
+
+      {/* Team dashboard button */}
+      <button
+        onClick={() => setCurrentPage('dashboard')}
+        className={`w-10 h-10 flex items-center justify-center rounded-lg transition-colors ${
+          currentPage === 'dashboard'
+            ? 'text-accent bg-accent/20'
+            : 'text-text-secondary hover:text-white hover:bg-bg-tertiary'
+        }`}
+        title="Team"
+      >
+        <Users className="w-5 h-5" />
+      </button>
 
       {/* Spacer to push Configuration to bottom */}
       <div className="flex-1" />

--- a/desktop/src/renderer/components/LiveIndicator.tsx
+++ b/desktop/src/renderer/components/LiveIndicator.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import type { RealtimeStatus } from '../../types'
+import { useConnectivity } from '../hooks/useConnectivity'
+
+/**
+ * Small live / reconnecting hint for the team dashboard. Combines the shared
+ * connectivity gate state (from #125) with the org-agents realtime channel
+ * health: only "live" when the backend is reachable AND the channel is
+ * SUBSCRIBED. Any loss on either side reads as "Reconnecting…". Deliberately not
+ * a blocking banner — the connectivity gate already owns hard offline states.
+ */
+export function LiveIndicator() {
+  const { status: connectivity } = useConnectivity()
+  const [realtime, setRealtime] = useState<RealtimeStatus>('reconnecting')
+
+  useEffect(() => {
+    // Seed from the current channel health so a dashboard mounted after the
+    // channel already went SUBSCRIBED isn't stuck on "Reconnecting…" until the
+    // next push. Then keep it fresh via the status events.
+    let active = true
+    window.electronAPI.org.getRealtimeStatus().then((status) => {
+      if (active) setRealtime(status)
+    })
+    const unsubscribe = window.electronAPI.org.onRealtimeStatus(setRealtime)
+    return () => {
+      active = false
+      unsubscribe()
+    }
+  }, [])
+
+  const isLive = connectivity === 'ok' && realtime === 'live'
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium ${
+        isLive ? 'bg-green/10 text-green' : 'bg-yellow/10 text-yellow'
+      }`}
+      title={isLive ? 'Real-time updates' : 'Reconnecting to the real-time feed…'}
+    >
+      <span className="relative flex w-2 h-2">
+        {isLive && (
+          <span className="absolute inline-flex w-full h-full rounded-full bg-green opacity-75 animate-ping" />
+        )}
+        <span className={`relative inline-flex w-2 h-2 rounded-full ${isLive ? 'bg-green' : 'bg-yellow'}`} />
+      </span>
+      {isLive ? 'Live' : 'Reconnecting…'}
+    </span>
+  )
+}

--- a/desktop/src/renderer/components/LiveIndicator.tsx
+++ b/desktop/src/renderer/components/LiveIndicator.tsx
@@ -20,7 +20,7 @@ export function LiveIndicator() {
     let active = true
     window.electronAPI.org.getRealtimeStatus().then((status) => {
       if (active) setRealtime(status)
-    })
+    }).catch(() => { /* stays at 'reconnecting' default */ })
     const unsubscribe = window.electronAPI.org.onRealtimeStatus(setRealtime)
     return () => {
       active = false

--- a/desktop/src/renderer/components/Sidebar.tsx
+++ b/desktop/src/renderer/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect, useCallback, memo } from 'react'
-import { Bot, Settings, AlertTriangle, Check, Clock, XCircle, Sparkles, X, Eye, CheckCircle2, Zap } from 'lucide-react'
+import { Bot, Settings, AlertTriangle, Check, Clock, XCircle, Sparkles, X, Eye, CheckCircle2, Zap, Users } from 'lucide-react'
 import { useStore } from '../store'
 import { useTerminals } from '../hooks/useTerminals'
 import { useScriptRunner } from '../hooks/useScriptRunner'
@@ -459,6 +459,22 @@ export function Sidebar() {
           <Clock className="w-3.5 h-3.5" />
           <span>History</span>
           <span className="ml-auto text-xs opacity-50">{historyShortcutKey}</span>
+        </button>
+
+        {/* Team dashboard button */}
+        <button
+          onClick={() => {
+            setCurrentPage('dashboard')
+            setActiveTerminal(null)
+          }}
+          className={`w-full flex items-center justify-center gap-2 px-2 py-2 text-xs font-medium rounded-lg transition-all ${
+            currentPage === 'dashboard'
+              ? 'bg-white/10 text-white'
+              : 'text-text-secondary hover:bg-text-secondary/10 hover:text-white'
+          }`}
+        >
+          <Users className="w-3.5 h-3.5" />
+          <span>Team</span>
         </button>
 
         {/* Settings button */}

--- a/desktop/src/renderer/hooks/useOrgAgents.ts
+++ b/desktop/src/renderer/hooks/useOrgAgents.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { OrgAgent, OrgAgentChange } from '../../types'
+import { useStore } from '../store'
+
+/**
+ * Org-wide agents roster for the team dashboard ("who is working on what").
+ * Initial load via org.listAgents(), then kept live by the org-agents realtime
+ * feed (org.onAgentsChanged). Realtime rows are reconciled by the DB row uuid
+ * (OrgAgent.id) — NOT the app-level metadata id. Reloads on org switch.
+ *
+ * Deliberately kept separate from the local terminals list: these are teammates'
+ * agents (read-only) and must never feed local terminal restoration. Channel
+ * health (live / reconnecting) is surfaced separately by <LiveIndicator />.
+ */
+export function useOrgAgents() {
+  const activeOrgId = useStore((s) => s.activeOrg?.id)
+  const [agents, setAgents] = useState<OrgAgent[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setAgents(await window.electronAPI.org.listAgents())
+    } catch {
+      setAgents([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Initial load + reload whenever the active org changes.
+  useEffect(() => {
+    load()
+  }, [load, activeOrgId])
+
+  // Live realtime propagation — reconcile by DB uuid.
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.org.onAgentsChanged((change: OrgAgentChange) => {
+      setAgents((prev) => {
+        if (change.eventType === 'DELETE') {
+          return prev.filter((a) => a.id !== change.id)
+        }
+        if (!change.agent) return prev
+        const idx = prev.findIndex((a) => a.id === change.agent!.id)
+        if (idx === -1) return [...prev, change.agent]
+        const next = [...prev]
+        next[idx] = change.agent
+        return next
+      })
+    })
+    return () => { unsubscribe() }
+  }, [])
+
+  return { agents, loading }
+}

--- a/desktop/src/renderer/pages/Dashboard/index.tsx
+++ b/desktop/src/renderer/pages/Dashboard/index.tsx
@@ -1,0 +1,154 @@
+import { useMemo } from 'react'
+import { Users, Bot } from 'lucide-react'
+import type { OrgAgent } from '../../../types'
+import { useOrgAgents } from '../../hooks/useOrgAgents'
+import { useOrg } from '../../hooks/useOrg'
+import { LiveIndicator } from '../../components/LiveIndicator'
+
+// Workflow-status → label + badge color. Statuses mirror
+// TerminalMetadata.status; anything unrecognized falls through to a neutral pill.
+const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
+  'in progress':        { label: 'In progress',      className: 'bg-accent/15 text-accent' },
+  committed:            { label: 'Committed',         className: 'bg-yellow/15 text-yellow' },
+  'ready for PR':       { label: 'Ready for PR',      className: 'bg-blue/15 text-blue' },
+  'PR created':         { label: 'PR created',        className: 'bg-blue/15 text-blue' },
+  'in review':          { label: 'In review',         className: 'bg-purple/15 text-purple' },
+  'changes requested':  { label: 'Changes requested', className: 'bg-red/15 text-red' },
+  'Review addressed':   { label: 'Review addressed',  className: 'bg-green/15 text-green' },
+  'PR merged':          { label: 'PR merged',         className: 'bg-green/15 text-green' },
+}
+
+function StatusPill({ status }: { status?: string }) {
+  if (!status) return null
+  const config = STATUS_CONFIG[status]
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded-full flex-shrink-0 ${config?.className ?? 'bg-white/[0.06] text-text-secondary'}`}>
+      {config?.label ?? status}
+    </span>
+  )
+}
+
+function RepoTag({ repo }: { repo: string }) {
+  const name = repo.split('/').pop() ?? repo
+  return (
+    <span className="text-xs text-text-secondary/60 bg-white/[0.04] border border-white/[0.06] px-1.5 py-0.5 rounded font-mono">
+      {name}
+    </span>
+  )
+}
+
+function AgentRow({ agent }: { agent: OrgAgent }) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-white/[0.04] border border-white/[0.08] min-w-0">
+      <Bot className="w-4 h-4 text-text-secondary/60 flex-shrink-0" />
+      <span className="text-sm font-medium text-white truncate min-w-0 flex-1">
+        {agent.name}
+      </span>
+      {agent.ticketId && (
+        <span className="text-xs text-accent/80 bg-accent/10 px-2 py-0.5 rounded flex-shrink-0">
+          {agent.ticketId}
+        </span>
+      )}
+      {agent.repositories.slice(0, 2).map((repo) => (
+        <RepoTag key={repo} repo={repo} />
+      ))}
+      {agent.repositories.length > 2 && (
+        <span className="text-xs text-text-secondary/40 flex-shrink-0">+{agent.repositories.length - 2}</span>
+      )}
+      <StatusPill status={agent.status} />
+    </div>
+  )
+}
+
+interface MemberGroup {
+  key: string
+  label: string
+  agents: OrgAgent[]
+}
+
+export function DashboardPage() {
+  const { agents, loading } = useOrgAgents()
+  const { members } = useOrg()
+
+  // owner_id → email, so agents can be grouped under a readable member label.
+  const emailByOwner = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const m of members) {
+      if (m.email) map.set(m.userId, m.email)
+    }
+    return map
+  }, [members])
+
+  // Group agents by owner (unassigned/unknown owners fall into a trailing group).
+  const groups: MemberGroup[] = useMemo(() => {
+    const byOwner = new Map<string, OrgAgent[]>()
+    for (const agent of agents) {
+      const key = agent.ownerId ?? '__unassigned__'
+      if (!byOwner.has(key)) byOwner.set(key, [])
+      byOwner.get(key)!.push(agent)
+    }
+
+    const result: MemberGroup[] = []
+    for (const [key, list] of byOwner.entries()) {
+      if (key === '__unassigned__') continue
+      result.push({
+        key,
+        label: emailByOwner.get(key) ?? key,
+        agents: list.sort((a, b) => a.name.localeCompare(b.name)),
+      })
+    }
+    result.sort((a, b) => a.label.localeCompare(b.label))
+
+    const unassigned = byOwner.get('__unassigned__')
+    if (unassigned && unassigned.length > 0) {
+      result.push({ key: '__unassigned__', label: 'Unassigned', agents: unassigned })
+    }
+    return result
+  }, [agents, emailByOwner])
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-purple/10 rounded-lg">
+            <Users className="w-5 h-5 text-purple" />
+          </div>
+          <div>
+            <h1 className="text-lg font-semibold text-white">Team</h1>
+            <p className="text-xs text-text-secondary">Who is working on what, in real time</p>
+          </div>
+        </div>
+        <LiveIndicator />
+      </div>
+
+      {/* Body */}
+      {loading && agents.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center text-text-secondary text-sm">
+          Loading…
+        </div>
+      ) : agents.length === 0 ? (
+        <div className="flex-1 flex flex-col items-center justify-center text-text-secondary text-sm gap-2">
+          <Users className="w-8 h-8 opacity-30" />
+          <p>No active agents in the organization yet.</p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-auto flex flex-col gap-6">
+          {groups.map((group) => (
+            <div key={group.key} className="flex flex-col gap-2">
+              <div className="flex items-center gap-2 px-1">
+                <span className="text-sm font-medium text-white truncate">{group.label}</span>
+                <span className="text-xs text-text-secondary/50">{group.agents.length}</span>
+              </div>
+              <div className="flex flex-col gap-2">
+                {group.agents.map((agent) => (
+                  <AgentRow key={agent.id} agent={agent} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/desktop/src/renderer/store/index.ts
+++ b/desktop/src/renderer/store/index.ts
@@ -33,7 +33,7 @@ interface AppState {
   rightPaneTerminalIds: string[]
 
   // UI
-  currentPage: 'config' | 'terminals' | 'skills' | 'history'
+  currentPage: 'config' | 'terminals' | 'skills' | 'history' | 'dashboard'
   // When set, the Config page selects this settings tab on mount, then resets it
   // to null. Lets other views (e.g. the sidebar account menu) deep-link a tab.
   settingsInitialTab: SettingsTab | null
@@ -75,7 +75,7 @@ interface AppState {
   toggleSplitActive: () => void
   moveTerminalToPane: (id: string, pane: 'left' | 'right') => void
 
-  setCurrentPage: (page: 'config' | 'terminals' | 'skills' | 'history') => void
+  setCurrentPage: (page: 'config' | 'terminals' | 'skills' | 'history' | 'dashboard') => void
   setSettingsInitialTab: (tab: SettingsTab | null) => void
   setRightSidebar: (sidebar: 'info' | null) => void
   toggleRightSidebar: (sidebar: 'info') => void

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -210,6 +210,42 @@ export interface Member {
   createdAt?: string
 }
 
+// ---------------------------------------------------------------------------
+// Cloud: org-wide agents roster + realtime (team dashboard "who is working on
+// what"). Distinct from the LOCAL `Agent` shape above: an OrgAgent describes a
+// teammate's agent as seen over the org roster / realtime feed, keyed by the DB
+// row uuid (NOT the app-level metadata.__app.id). It is READ-ONLY — it never
+// feeds the local terminal-restoration cache.
+// ---------------------------------------------------------------------------
+export interface OrgAgent {
+  /** The `agents` table row id (uuid). Reconcile realtime events by this. */
+  id: string
+  /** owner membership user id (auth.users id), or null when ownership was cleared. */
+  ownerId: string | null
+  /** Resolved in the renderer from the org member list (owner_id → email). */
+  ownerEmail?: string
+  name: string
+  ticketId?: string
+  status?: string
+  repositories: string[]
+  /** ISO timestamp of the last write (agents.updated_at). */
+  updatedAt?: string
+}
+
+/** Realtime channel health for the org-agents subscription. */
+export type RealtimeStatus = 'live' | 'reconnecting'
+
+/**
+ * A single org-agents realtime change forwarded to the renderer. `id` is always
+ * the DB row uuid (present for every event, including DELETE) so the renderer
+ * can reconcile by uuid; `agent` carries the mapped row for INSERT/UPDATE only.
+ */
+export interface OrgAgentChange {
+  eventType: 'INSERT' | 'UPDATE' | 'DELETE'
+  id: string
+  agent?: OrgAgent
+}
+
 export interface Invitation {
   id: string
   email: string

--- a/supabase/migrations/20260724100000_realtime_agents.sql
+++ b/supabase/migrations/20260724100000_realtime_agents.sql
@@ -1,0 +1,14 @@
+-- ---------------------------------------------------------------------------
+-- Realtime for org agents
+-- ---------------------------------------------------------------------------
+-- Add public.agents to the supabase_realtime publication so INSERT/UPDATE/DELETE
+-- events stream to subscribed clients. Access is still governed entirely by the
+-- existing org-scoped RLS on the table (agents_select = is_org_member(org_id)):
+-- Realtime enforces the SAME row-level policies on the socket, so a member of
+-- org A never receives change events for org B's agents.
+--
+-- REPLICA IDENTITY FULL makes the previous row values (`old`) available on
+-- UPDATE/DELETE events — required so DELETE payloads carry the row id (and RLS
+-- can be evaluated against the deleted row) rather than only the primary key.
+alter publication supabase_realtime add table public.agents;
+alter table public.agents replica identity full;


### PR DESCRIPTION
## Description

Adds Supabase Realtime propagation for org agents so teammates see each other's work live, a "Team" dashboard listing all org agents (who is working on what), and a live/reconnecting indicator reusing the connectivity state from #125.

Builds on the cloud-only model from #125 (Supabase is the single source of truth). No offline mode, write-queue, conflict resolution, or per-agent visibility flag — those remain out of scope. Skills publishing (cloud→client) is deferred to a follow-up.

## Related Issue

Closes #126

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **DB migration**: add `public.agents` to the `supabase_realtime` publication and set `replica identity full` (so DELETE payloads carry the row for RLS evaluation). RLS unchanged — already org-scoped via `is_org_member(org_id)`.
- **Realtime subscription (main)**: new `cloud/realtime.ts` opens an org-scoped `postgres_changes` channel on the authenticated client. `realtime.setAuth(jwt)` is applied before subscribe and re-applied on token refresh so the socket enforces the org RLS. Idempotent lifecycle: start on connectivity `ok`, stop on `unauthorized`/quit, resubscribe on org switch.
- **Roster + IPC bridge**: `CloudStore.loadOrgAgents()` (reuses the existing org-scoped query, adds `updated_at`); new `org:listAgents` / `org:realtimeStatus` IPC handlers and preload methods (`listAgents`, `onAgentsChanged`, `onRealtimeStatus`, `getRealtimeStatus`).
- **Team dashboard (renderer)**: new `pages/Dashboard` grouping org agents by member (owner → email), showing ticket/status/repos; `useOrgAgents` hook reconciles live changes by DB uuid; new "Team" nav entry.
- **Live indicator**: `LiveIndicator` combines `useConnectivity` (#125) + channel health → "Live" vs "Reconnecting…". Seeded from the current status on mount so a late-mounted dashboard is never stuck.
- **Types**: `OrgAgent`, `OrgAgentChange`, `RealtimeStatus`.

Remote agents are kept strictly separate from the local terminal cache — a teammate's event never mutates local PTY state.

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [x] Tested affected slash commands

### Test Steps

1. Run `npm run desktop` (Node 20) and sign in as a member of a multi-user org.
2. Open the **Team** tab from the icon rail → all org agents appear, grouped by member, with ticket / status / repositories.
3. From another machine/account in the **same** org, start or update an agent (e.g. change status via `/magic:start` or `/magic:commit`) → the row appears/updates in the dashboard **without** a manual refresh.
4. Check the indicator: "Live" (green) when connected and the channel is SUBSCRIBED; cut the network → "Reconnecting…" (yellow); restore → back to "Live".
5. RLS (AC3): a member of org A must never see an agent from org B — verify with two distinct orgs.

Automated: `npm run typecheck` and `npm test` (210 tests, incl. 9 new realtime lifecycle tests) pass.

## Screenshots

_N/A — will attach dashboard screenshots on request._

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

- Realtime re-points the channel via `switchOrg`; an org change through a path that bypasses `switchOrg` would leave the channel on the previous org until logout.
- Renderer reconcile (`useOrgAgents`) and `LiveIndicator` are not yet unit-tested; the main-process lifecycle is well covered.
- Skills publishing (cloud→client) from the epic is intentionally left as a follow-up.