### PR TITLE
[#127] Opt-in usage logs & org stats dashboard

### DIFF
--- a/desktop/src/main/cloud/org.ts
+++ b/desktop/src/main/cloud/org.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Config, Invitation, InvitationStatus, Member, MembershipRole, Org, OrgAgent, OrgSharedConfig } from '../../types'
+import type { Config, Invitation, InvitationStatus, Member, MembershipRole, Org, OrgAgent, OrgSharedConfig, UsageStats } from '../../types'
 import { getAuthedClient } from './auth'
 import { loadSession } from './session-store'
 import { readConfig, writeConfig, hydrateConfig, mergeOrgSharedConfig, setCurrentOrgId } from '../config/config'
@@ -106,6 +106,15 @@ export async function listOrgs(): Promise<Org[]> {
  */
 export async function listOrgAgents(): Promise<OrgAgent[]> {
   return getStore().loadOrgAgents()
+}
+
+/**
+ * Org-wide usage stats for the team dashboard. Delegates to the store (org-scoped
+ * by RLS — any member may read, regardless of their own usage-logs opt-in).
+ * Degrades to empty rows when cloud is off or the user is logged out.
+ */
+export async function listOrgUsageStats(): Promise<UsageStats> {
+  return getStore().loadOrgUsageStats()
 }
 
 /** Run a void-returning RPC through the authed client, surfacing failures as thrown errors. */

--- a/desktop/src/main/config/config.test.ts
+++ b/desktop/src/main/config/config.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setStore, NOOP_STORE } from '../store/Store'
+import { readConfig, updateUsageLogsEnabled } from './config'
+
+// updateUsageLogsEnabled toggles the GDPR opt-in on the in-memory config cache and
+// writes through to the store (NOOP here). readConfig serves the cache back.
+beforeEach(() => {
+  setStore(NOOP_STORE)
+})
+
+describe('updateUsageLogsEnabled', () => {
+  it('is off by default (never set on a fresh config)', () => {
+    expect(readConfig().usageLogsEnabled).toBeUndefined()
+  })
+
+  it('enables the opt-in and reflects it in the returned + cached config', () => {
+    const config = updateUsageLogsEnabled(true)
+    expect(config.usageLogsEnabled).toBe(true)
+    expect(readConfig().usageLogsEnabled).toBe(true)
+  })
+
+  it('disables the opt-in again', () => {
+    updateUsageLogsEnabled(true)
+    const config = updateUsageLogsEnabled(false)
+    expect(config.usageLogsEnabled).toBe(false)
+    expect(readConfig().usageLogsEnabled).toBe(false)
+  })
+})

--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -367,6 +367,18 @@ export function updateLaunchMode(mode: LaunchMode): Config {
 }
 
 /**
+ * Toggle the GDPR usage-logs opt-in. Default OFF: only when this is true does the
+ * app write an aggregated usage snapshot to usage_events at session end. Reading
+ * the org aggregate is unaffected by this flag.
+ */
+export function updateUsageLogsEnabled(enabled: boolean): Config {
+  const config = readConfig()
+  config.usageLogsEnabled = enabled
+  writeConfig(config)
+  return config
+}
+
+/**
  * Toggle an integration flag. github is always true (const true in the schema);
  * only atlassian is user-settable. DISPLAY/detection only — no token is stored.
  */

--- a/desktop/src/main/ipc/config-handlers.test.ts
+++ b/desktop/src/main/ipc/config-handlers.test.ts
@@ -33,6 +33,7 @@ vi.mock('../config/config', () => ({
   updateSplitEnabled: vi.fn(),
   updateSplitActive: vi.fn(),
   updateLaunchMode: vi.fn(),
+  updateUsageLogsEnabled: vi.fn(),
 }))
 
 vi.mock('../config/migrate', () => ({ repairConfig: vi.fn() }))

--- a/desktop/src/main/ipc/config-handlers.ts
+++ b/desktop/src/main/ipc/config-handlers.ts
@@ -21,6 +21,7 @@ import {
   updateSplitEnabled,
   updateSplitActive,
   updateLaunchMode,
+  updateUsageLogsEnabled,
   setIntegration,
 } from '../config/config'
 import { getGitHubAuthStatus } from '../github'
@@ -260,6 +261,12 @@ export function setupConfigHandlers(getMainWindow: () => BrowserWindow | null) {
     const config = readConfig()
     config.usageCardMinimized = minimized
     writeConfig(config)
+    return { config }
+  })
+
+  // GDPR opt-in for writing usage logs (default OFF). Gates WRITING only.
+  ipcMain.handle('config:setUsageLogsEnabled', async (_event, { enabled }: { enabled: boolean }) => {
+    const config = updateUsageLogsEnabled(enabled)
     return { config }
   })
 

--- a/desktop/src/main/ipc/org-handlers.ts
+++ b/desktop/src/main/ipc/org-handlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron'
 import type { AcceptInvitationResult } from '../cloud/org'
-import type { Config, Invitation, Member, MembershipRole, Org, OrgAgent, OrgSharedConfig, RealtimeStatus } from '../../types'
+import type { Config, Invitation, Member, MembershipRole, Org, OrgAgent, OrgSharedConfig, RealtimeStatus, UsageStats } from '../../types'
 import { getRealtimeStatus } from '../cloud/realtime'
 import {
   getCurrentOrg,
@@ -12,6 +12,7 @@ import {
   setOrgSharedConfig,
   listOrgs,
   listOrgAgents,
+  listOrgUsageStats,
   removeMember,
   leaveOrg,
   updateMemberRole,
@@ -34,6 +35,8 @@ export function setupOrgHandlers(): void {
   ipcMain.handle('org:list', async (): Promise<Org[]> => listOrgs())
 
   ipcMain.handle('org:listAgents', async (): Promise<OrgAgent[]> => listOrgAgents())
+
+  ipcMain.handle('org:getUsageStats', async (): Promise<UsageStats> => listOrgUsageStats())
 
   ipcMain.handle('org:realtimeStatus', async (): Promise<RealtimeStatus> => getRealtimeStatus())
 

--- a/desktop/src/main/ipc/terminal-handlers.test.ts
+++ b/desktop/src/main/ipc/terminal-handlers.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// terminal-handlers pulls in Electron + node-pty (native) + the config/store
+// modules transitively. Mock every dependency so we exercise only the session-end
+// dedup logic. Same mock-everything style as config-handlers.test.ts.
+
+// ipcMain.handle registrations are captured so tests can invoke a handler directly.
+const handlers = new Map<string, (event: unknown, arg: unknown) => unknown>()
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (event: unknown, arg: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }),
+  },
+  BrowserWindow: class {},
+}))
+
+// terminal-manager is the source of getTerminal (the in-memory usage gauge) and
+// createTerminal (whose onExit arg we capture to simulate the natural-exit path).
+const term = vi.hoisted(() => ({
+  getTerminal: vi.fn(),
+  createTerminal: vi.fn(),
+  killTerminal: vi.fn(),
+}))
+// Captured onExit callback from the most recent createTerminal call.
+let capturedOnExit: ((code: number) => void) | undefined
+
+vi.mock('../pty/terminal-manager', () => ({
+  createTerminal: (...args: unknown[]) => {
+    capturedOnExit = args[5] as (code: number) => void
+    term.createTerminal(...args)
+    return { id: args[0], name: args[1], state: 'idle', repositories: [], branchName: null }
+  },
+  launchClaude: vi.fn(),
+  writeToTerminal: vi.fn(),
+  resizeTerminal: vi.fn(),
+  killTerminal: (...args: unknown[]) => term.killTerminal(...args),
+  getTerminal: (...args: unknown[]) => term.getTerminal(...args),
+  getTerminalCwd: vi.fn(),
+  getTerminalBuffer: vi.fn(),
+  getAllTerminals: vi.fn(() => []),
+  cleanupAllTerminals: vi.fn(),
+  updateTerminalMetadataFromHook: vi.fn(),
+  updateTerminalRepositoriesFromHook: vi.fn(),
+}))
+
+const removeAgent = vi.fn()
+vi.mock('../config/agents', () => ({
+  saveAgent: vi.fn(),
+  removeAgent: (...args: unknown[]) => removeAgent(...args),
+  readAgents: vi.fn(() => []),
+  updateAgentSplitPane: vi.fn(),
+}))
+
+vi.mock('../config/activity-history', () => ({ addHistoryEntry: vi.fn() }))
+
+const recordUsageSnapshot = vi.fn()
+vi.mock('../usage/usage-events', () => ({
+  recordUsageSnapshot: (...args: unknown[]) => recordUsageSnapshot(...args),
+}))
+
+vi.mock('../config/config', () => ({ readConfig: vi.fn(() => ({ repositories: {} })) }))
+vi.mock('../config/validation', () => ({ expandPath: (p: string) => p }))
+vi.mock('../config/repo-validation', () => ({ checkRepoPath: vi.fn(() => ({ valid: true })) }))
+vi.mock('../store/hydrate', () => ({ ensureHydrated: vi.fn(async () => {}) }))
+
+import { setupTerminalHandlers } from './terminal-handlers'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function invoke(channel: string, arg: unknown): any {
+  const handler = handlers.get(channel)
+  if (!handler) throw new Error(`no handler registered for ${channel}`)
+  return handler({}, arg)
+}
+
+// Register a terminal so its onExit callback is captured (natural-exit path).
+async function createTerminal(id: string, name = 'Agent') {
+  await invoke('terminal:create', { id, name, cwd: '/repo' })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  handlers.clear()
+  capturedOnExit = undefined
+  // getMainWindow returns null so onExit's IPC forwarding is a safe no-op.
+  setupTerminalHandlers(() => null, vi.fn(), vi.fn())
+})
+
+describe('session-end usage flush (terminal:kill)', () => {
+  it('records the in-memory usage snapshot exactly once, before removeAgent', async () => {
+    const id = 'claude-kill-1'
+    term.getTerminal.mockReturnValue({
+      id,
+      name: 'Agent',
+      metadata: {
+        usage: { model: 'Claude Opus', costUsd: 1.23, linesAdded: 10, linesRemoved: 4, durationMs: 5000 },
+      },
+      repositories: [],
+    })
+
+    await invoke('terminal:kill', { id })
+
+    expect(recordUsageSnapshot).toHaveBeenCalledTimes(1)
+    expect(recordUsageSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: id,
+        model: 'Claude Opus',
+        costUsd: 1.23,
+        linesAdded: 10,
+        linesRemoved: 4,
+        durationMs: 5000,
+      }),
+    )
+    expect(removeAgent).toHaveBeenCalledTimes(1)
+    // Flush must happen BEFORE removeAgent so the store can still resolve the uuid.
+    expect(recordUsageSnapshot.mock.invocationCallOrder[0]).toBeLessThan(
+      removeAgent.mock.invocationCallOrder[0],
+    )
+  })
+
+  it('records nothing when the terminal has no usage metadata', async () => {
+    const id = 'claude-kill-2'
+    term.getTerminal.mockReturnValue({ id, name: 'Agent', metadata: {}, repositories: [] })
+
+    await invoke('terminal:kill', { id })
+
+    expect(recordUsageSnapshot).not.toHaveBeenCalled()
+    expect(removeAgent).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes only ONE snapshot when a stray onExit fires during the kill (usageFlushed guard)', async () => {
+    const id = 'claude-kill-3'
+    term.getTerminal.mockReturnValue({
+      id,
+      name: 'Agent',
+      metadata: { usage: { model: 'Claude Opus', costUsd: 1, durationMs: 100 } },
+      repositories: [],
+    })
+
+    // Register the terminal so its onExit callback exists, then make killTerminal
+    // fire that onExit — simulating the pty exiting as part of the kill. The
+    // natural-exit path would call flushUsageSnapshot again; the guard must dedup.
+    await createTerminal(id)
+    expect(capturedOnExit).toBeTypeOf('function')
+    term.killTerminal.mockImplementation(() => capturedOnExit?.(0))
+
+    await invoke('terminal:kill', { id })
+
+    expect(recordUsageSnapshot).toHaveBeenCalledTimes(1)
+  })
+})

--- a/desktop/src/main/ipc/terminal-handlers.ts
+++ b/desktop/src/main/ipc/terminal-handlers.ts
@@ -22,6 +22,7 @@ import {
   updateAgentSplitPane,
 } from '../config/agents'
 import { addHistoryEntry } from '../config/activity-history'
+import { recordUsageSnapshot } from '../usage/usage-events'
 import { readConfig } from '../config/config'
 import { expandPath } from '../config/validation'
 import { checkRepoPath } from '../config/repo-validation'
@@ -58,7 +59,38 @@ let onAgentChange: (() => void) | null = null
 const lastNotificationTime = new Map<string, number>()
 // Track previous metadata status per terminal for history entries
 const previousStatus = new Map<string, string>()
+// Terminals whose end-of-session usage snapshot has already been flushed, so the
+// kill path and the natural-exit path never write two rows for one session.
+const usageFlushed = new Set<string>()
 const NOTIFICATION_COOLDOWN = 30000 // 30 seconds between notifications per terminal
+
+/**
+ * Flush ONE aggregated usage snapshot for a terminal at session end. Reads the
+ * in-memory usage gauge (populated by the statusLine hook) and appends a single
+ * usage_events row via recordUsageSnapshot (itself a GDPR-gated, fire-and-forget
+ * no-op when the opt-in is off). Deduped per terminal id so it can be called from
+ * both the explicit-kill path and the natural-exit path without double-writing.
+ *
+ * MUST be called BEFORE removeAgent(id) so the store's agentIdMap can still map
+ * the app id → agents.id uuid (mirrors how addHistoryEntry resolves the agent).
+ * tokens is intentionally not derived from contextTokens (a point-in-time context
+ * gauge, not cumulative session tokens) — see recordUsageSnapshot/appendUsage.
+ */
+function flushUsageSnapshot(id: string): void {
+  if (usageFlushed.has(id)) return
+  const usage = getTerminal(id)?.metadata?.usage
+  if (!usage) return
+  usageFlushed.add(id)
+  void recordUsageSnapshot({
+    agentId: id,
+    model: usage.model,
+    costUsd: usage.costUsd,
+    linesAdded: usage.linesAdded,
+    linesRemoved: usage.linesRemoved,
+    durationMs: usage.durationMs,
+    occurredAt: Date.now(),
+  })
+}
 
 // Helper to show notification with cooldown and focus check
 function maybeShowNotification(
@@ -163,6 +195,13 @@ function createTerminalCallbacks(id: string, name: string) {
       }
     },
     onExit: (exitCode: number) => {
+      // Best-effort flush for a session that ends WITHOUT an explicit kill (e.g.
+      // Claude Code exited on its own and exhausted its auto-restarts). This
+      // callback is not invoked during auto-restart (terminal-manager only calls
+      // it once restarts are given up), and killTerminal disposes this listener
+      // before pty.kill so an intentional kill never double-fires here; the
+      // usageFlushed guard defends against any overlap regardless.
+      flushUsageSnapshot(id)
       base.onExit(exitCode)
       previousStatus.delete(id)
     },
@@ -365,9 +404,13 @@ export function setupTerminalHandlers(
         repositories: t.repositories || [],
       })
     }
+    // Flush the aggregated usage snapshot BEFORE removeAgent so the store can still
+    // resolve this agent's uuid (one write per session; GDPR-gated inside).
+    flushUsageSnapshot(id)
     killTerminal(id)
     // Remove agent from disk
     removeAgent(id)
+    usageFlushed.delete(id)
   })
 
   // Get terminal info

--- a/desktop/src/main/store/CloudStore.test.ts
+++ b/desktop/src/main/store/CloudStore.test.ts
@@ -218,7 +218,7 @@ describe('loadOrgUsageStats', () => {
     const store = new CloudStore()
     const result = await store.loadOrgUsageStats()
 
-    expect(result).toEqual({ rows: [] })
+    expect(result).toEqual({ rows: [], capped: false })
     expect(from).toHaveBeenCalledWith('usage_events')
     const usageCalls = calls.filter((c) => c.table === 'usage_events')
     expect(usageCalls).toEqual(
@@ -228,6 +228,25 @@ describe('loadOrgUsageStats', () => {
         { table: 'usage_events', method: 'limit', args: [5000] },
       ]),
     )
+  })
+
+  it('flags capped=true when the result reaches the 5000-row limit', async () => {
+    const minimalRow = {
+      user_id: null, agent_id: null, model: null, cost_usd: 0,
+      tokens: null, lines_added: 0, lines_removed: 0, duration_ms: 0,
+      occurred_at: '2026-07-24T00:00:00Z',
+    }
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      usage_events: { data: Array.from({ length: 5000 }, () => minimalRow), error: null },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    const result = await store.loadOrgUsageStats()
+
+    expect(result.capped).toBe(true)
+    expect(result.rows).toHaveLength(5000)
   })
 
   it('maps rows back applying toNumber coercion for string/bigint columns', async () => {
@@ -326,7 +345,7 @@ describe('loadOrgUsageStats', () => {
     h.state.client = null
 
     const store = new CloudStore()
-    await expect(store.loadOrgUsageStats()).resolves.toEqual({ rows: [] })
+    await expect(store.loadOrgUsageStats()).resolves.toEqual({ rows: [], capped: false })
     expect(from).not.toHaveBeenCalled()
     void client
   })
@@ -339,6 +358,6 @@ describe('loadOrgUsageStats', () => {
     h.state.client = client
 
     const store = new CloudStore()
-    await expect(store.loadOrgUsageStats()).resolves.toEqual({ rows: [] })
+    await expect(store.loadOrgUsageStats()).resolves.toEqual({ rows: [], capped: false })
   })
 })

--- a/desktop/src/main/store/CloudStore.test.ts
+++ b/desktop/src/main/store/CloudStore.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Agent } from '../../types'
+
+// Mock the cloud dependencies so CloudStore exercises only its own mapping /
+// query-building logic (no network, no keychain). vi.hoisted shares mutable state
+// the factories (hoisted above imports) read per test — same style as auth.test.ts
+// and realtime.test.ts.
+const h = vi.hoisted(() => {
+  const state = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client: null as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    session: null as any,
+    cloudEnabled: true as boolean,
+  }
+  return { state }
+})
+
+vi.mock('../cloud/auth', () => ({
+  getAuthedClient: vi.fn(async () => h.state.client),
+}))
+
+vi.mock('../cloud/session-store', () => ({
+  loadSession: () => h.state.session,
+}))
+
+vi.mock('../cloud/supabase-client', () => ({
+  isCloudEnabled: () => h.state.cloudEnabled,
+}))
+
+// mapOrgAgentRow is only reached by loadOrgAgents (not under test here); mock it so
+// importing CloudStore does not pull in the realtime module's socket deps.
+vi.mock('../cloud/realtime', () => ({
+  mapOrgAgentRow: vi.fn(),
+}))
+
+import { CloudStore } from './CloudStore'
+
+// ── Supabase client fake ────────────────────────────────────────────────────
+//
+// The real PostgREST builder is a thenable whose chain methods return the builder
+// and which resolves to { data, error } when awaited. We mimic that: every chain
+// method returns the same builder, and awaiting it (at any point in the chain)
+// resolves to the per-table result. Insert payloads and the full call log are
+// recorded so tests can assert what was sent.
+
+type QueryResult = { data?: unknown; error?: unknown }
+
+interface RecordedCall {
+  table: string
+  method: string
+  args: unknown[]
+}
+
+function makeClient(resultsByTable: Record<string, QueryResult>) {
+  const calls: RecordedCall[] = []
+  const inserts: Record<string, unknown[]> = {}
+
+  function builder(table: string) {
+    const result = resultsByTable[table] ?? { data: [], error: null }
+    const record = (method: string, args: unknown[]) => calls.push({ table, method, args })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b: any = {
+      select: (...args: unknown[]) => { record('select', args); return b },
+      eq: (...args: unknown[]) => { record('eq', args); return b },
+      order: (...args: unknown[]) => { record('order', args); return b },
+      limit: (...args: unknown[]) => { record('limit', args); return b },
+      maybeSingle: (...args: unknown[]) => { record('maybeSingle', args); return b },
+      insert: (payload: unknown) => {
+        record('insert', [payload])
+        ;(inserts[table] ??= []).push(payload)
+        return b
+      },
+      then: (resolve: (v: QueryResult) => unknown, reject?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(resolve, reject),
+    }
+    return b
+  }
+
+  const from = vi.fn((table: string) => builder(table))
+  return { client: { from }, calls, inserts, from }
+}
+
+const UID = 'user-1'
+const ORG = 'org-1'
+
+/** Standard memberships result so context()/resolveOrgId settle on ORG. */
+const membershipsOk: QueryResult = { data: [{ org_id: ORG }], error: null }
+
+beforeEach(() => {
+  h.state.session = { user: { id: UID } }
+  h.state.cloudEnabled = true
+  h.state.client = null
+})
+
+// ── appendUsage ─────────────────────────────────────────────────────────────
+
+describe('appendUsage', () => {
+  it('inserts a usage_events row scoped to org/user with mapped fields and null tokens', async () => {
+    const { client, inserts, from } = makeClient({
+      memberships: membershipsOk,
+      usage_events: { error: null },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.appendUsage({
+      agentId: 'claude-1',
+      model: 'Claude Opus',
+      costUsd: 1.23,
+      linesAdded: 10,
+      linesRemoved: 4,
+      durationMs: 5000,
+      occurredAt: 1000,
+    })
+
+    expect(from).toHaveBeenCalledWith('usage_events')
+    expect(inserts.usage_events).toHaveLength(1)
+    const row = inserts.usage_events[0] as Record<string, unknown>
+    expect(row).toMatchObject({
+      org_id: ORG,
+      user_id: UID,
+      agent_id: null, // no agents loaded → unmapped app id resolves to null
+      model: 'Claude Opus',
+      cost_usd: 1.23,
+      tokens: null,
+      lines_added: 10,
+      lines_removed: 4,
+      duration_ms: 5000,
+      occurred_at: new Date(1000).toISOString(),
+    })
+  })
+
+  it('resolves agent_id via agentIdMap once agents are loaded', async () => {
+    const agentRow = {
+      id: 'uuid-agent-1',
+      org_id: ORG,
+      owner_id: UID,
+      name: 'Agent A',
+      ticket_id: null,
+      description: null,
+      branch_name: null,
+      base_branch: null,
+      status: null,
+      repositories: [],
+      metadata: { __app: { id: 'claude-1' } },
+    }
+    const { client, inserts } = makeClient({
+      memberships: membershipsOk,
+      agents: { data: [agentRow], error: null },
+      usage_events: { error: null },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    const agents = await store.loadAgents()
+    expect(agents.map((a: Agent) => a.id)).toContain('claude-1')
+
+    await store.appendUsage({ agentId: 'claude-1', model: 'Claude Opus', occurredAt: 1000 })
+
+    const row = inserts.usage_events[0] as Record<string, unknown>
+    expect(row.agent_id).toBe('uuid-agent-1')
+  })
+
+  it('leaves optional fields null when omitted', async () => {
+    const { client, inserts } = makeClient({
+      memberships: membershipsOk,
+      usage_events: { error: null },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.appendUsage({ agentId: 'claude-1', occurredAt: 1000 })
+
+    const row = inserts.usage_events[0] as Record<string, unknown>
+    expect(row).toMatchObject({
+      model: null,
+      cost_usd: null,
+      tokens: null,
+      lines_added: null,
+      lines_removed: null,
+      duration_ms: null,
+    })
+  })
+
+  it('propagates the insert error (mirrors appendHistory)', async () => {
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      usage_events: { error: { message: 'insert boom' } },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await expect(store.appendUsage({ agentId: 'claude-1' })).rejects.toThrow('appendUsage failed: insert boom')
+  })
+
+  it('is a no-op (no insert) when the client is not authed', async () => {
+    const { client, from } = makeClient({ memberships: membershipsOk, usage_events: { error: null } })
+    h.state.client = null // getAuthedClient() → null → context() bails
+
+    const store = new CloudStore()
+    await expect(store.appendUsage({ agentId: 'claude-1' })).resolves.toBeUndefined()
+    expect(from).not.toHaveBeenCalled()
+    void client
+  })
+})
+
+// ── loadOrgUsageStats ───────────────────────────────────────────────────────
+
+describe('loadOrgUsageStats', () => {
+  it('selects usage_events scoped by org_id, newest-first, with the 5000 limit', async () => {
+    const { client, calls, from } = makeClient({
+      memberships: membershipsOk,
+      usage_events: { data: [], error: null },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    const result = await store.loadOrgUsageStats()
+
+    expect(result).toEqual({ rows: [] })
+    expect(from).toHaveBeenCalledWith('usage_events')
+    const usageCalls = calls.filter((c) => c.table === 'usage_events')
+    expect(usageCalls).toEqual(
+      expect.arrayContaining([
+        { table: 'usage_events', method: 'eq', args: ['org_id', ORG] },
+        { table: 'usage_events', method: 'order', args: ['occurred_at', { ascending: false }] },
+        { table: 'usage_events', method: 'limit', args: [5000] },
+      ]),
+    )
+  })
+
+  it('maps rows back applying toNumber coercion for string/bigint columns', async () => {
+    const rows = [
+      {
+        user_id: UID,
+        agent_id: 'uuid-agent-1',
+        model: 'Claude Opus',
+        cost_usd: '1.23', // PostgREST returns numeric as a string
+        tokens: '4096', // bigint as a string
+        lines_added: 10,
+        lines_removed: 4,
+        duration_ms: '5000',
+        occurred_at: '2026-07-24T00:00:00Z',
+      },
+    ]
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      usage_events: { data: rows, error: null },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    const { rows: mapped } = await store.loadOrgUsageStats()
+
+    expect(mapped).toHaveLength(1)
+    expect(mapped[0]).toEqual({
+      userId: UID,
+      agentId: 'uuid-agent-1',
+      model: 'Claude Opus',
+      costUsd: 1.23,
+      tokens: 4096,
+      linesAdded: 10,
+      linesRemoved: 4,
+      durationMs: 5000,
+      occurredAt: '2026-07-24T00:00:00Z',
+    })
+    // Coerced string columns are real numbers, not strings.
+    expect(typeof mapped[0].costUsd).toBe('number')
+    expect(typeof mapped[0].tokens).toBe('number')
+    expect(typeof mapped[0].durationMs).toBe('number')
+  })
+
+  it('preserves null tokens but coerces null numerics to 0 (toNumber contract)', async () => {
+    const rows = [
+      {
+        user_id: null,
+        agent_id: null,
+        model: null,
+        cost_usd: null, // null numeric → 0
+        tokens: null, // null tokens stay null
+        lines_added: null, // ?? 0
+        lines_removed: null,
+        duration_ms: null, // null numeric → 0
+        occurred_at: '2026-07-24T00:00:00Z',
+      },
+      {
+        user_id: null,
+        agent_id: null,
+        model: null,
+        cost_usd: 'not-a-number', // non-finite string → 0
+        tokens: '10',
+        lines_added: 2,
+        lines_removed: 1,
+        duration_ms: 42,
+        occurred_at: '2026-07-24T01:00:00Z',
+      },
+    ]
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      usage_events: { data: rows, error: null },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    const { rows: mapped } = await store.loadOrgUsageStats()
+
+    expect(mapped[0]).toEqual({
+      userId: null,
+      agentId: null,
+      model: null,
+      costUsd: 0,
+      tokens: null,
+      linesAdded: 0,
+      linesRemoved: 0,
+      durationMs: 0,
+      occurredAt: '2026-07-24T00:00:00Z',
+    })
+    expect(mapped[1].costUsd).toBe(0) // non-finite string coerced to 0
+    expect(mapped[1].tokens).toBe(10)
+    expect(mapped[1].durationMs).toBe(42)
+  })
+
+  it('returns empty rows when the client is not authed / cloud disabled', async () => {
+    const { client, from } = makeClient({ memberships: membershipsOk })
+    h.state.client = null
+
+    const store = new CloudStore()
+    await expect(store.loadOrgUsageStats()).resolves.toEqual({ rows: [] })
+    expect(from).not.toHaveBeenCalled()
+    void client
+  })
+
+  it('returns empty rows when the query errors', async () => {
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      usage_events: { data: null, error: { message: 'select boom' } },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await expect(store.loadOrgUsageStats()).resolves.toEqual({ rows: [] })
+  })
+})

--- a/desktop/src/main/store/CloudStore.ts
+++ b/desktop/src/main/store/CloudStore.ts
@@ -364,17 +364,20 @@ export class CloudStore implements Store {
    */
   async loadOrgUsageStats(): Promise<UsageStats> {
     const ctx = await this.context()
-    if (!ctx) return { rows: [] }
+    if (!ctx) return { rows: [], capped: false }
 
+    const LIMIT = 5000
     const { data, error } = await ctx.client
       .from('usage_events')
       .select('user_id, agent_id, model, cost_usd, tokens, lines_added, lines_removed, duration_ms, occurred_at')
       .eq('org_id', ctx.orgId)
       .order('occurred_at', { ascending: false })
-      .limit(5000)
+      .limit(LIMIT)
 
-    if (error || !data) return { rows: [] }
+    if (error || !data) return { rows: [], capped: false }
 
+    // When the result reaches the cap the aggregated totals are partial; surface it so the UI can warn.
+    const capped = data.length === LIMIT
     const rows = (data as UsageEventRow[]).map((r) => ({
       userId: r.user_id,
       agentId: r.agent_id,
@@ -386,7 +389,7 @@ export class CloudStore implements Store {
       durationMs: toNumber(r.duration_ms),
       occurredAt: r.occurred_at,
     }))
-    return { rows }
+    return { rows, capped }
   }
 
   // -------------------------------------------------------------------------

--- a/desktop/src/main/store/CloudStore.ts
+++ b/desktop/src/main/store/CloudStore.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Agent, Config, HistoryEntry, OrgAgent, OrgSharedConfig, TerminalMetadata } from '../../types'
+import type { Agent, Config, HistoryEntry, OrgAgent, OrgSharedConfig, TerminalMetadata, UsageEventInput, UsageStats } from '../../types'
 import { getAuthedClient } from '../cloud/auth'
 import { loadSession } from '../cloud/session-store'
 import { isCloudEnabled } from '../cloud/supabase-client'
@@ -38,6 +38,29 @@ interface ActivityEventRow {
   description: string | null
   repositories: string[]
   occurred_at: string
+}
+
+// numeric/bigint columns come back from PostgREST as strings — coerced on read.
+interface UsageEventRow {
+  user_id: string | null
+  agent_id: string | null
+  model: string | null
+  cost_usd: string | number | null
+  tokens: string | number | null
+  lines_added: number | null
+  lines_removed: number | null
+  duration_ms: string | number | null
+  occurred_at: string
+}
+
+/** Coerce a numeric/bigint column (string | number | null) to a number, defaulting to 0. */
+function toNumber(value: string | number | null): number {
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') {
+    const n = Number(value)
+    return Number.isFinite(n) ? n : 0
+  }
+  return 0
 }
 
 /** The four shareable keys, projected to the TOP LEVEL of the config blob so the
@@ -301,6 +324,69 @@ export class CloudStore implements Store {
       occurred_at: new Date(entry.timestamp).toISOString(),
     })
     if (error) throw new Error(`appendHistory failed: ${error.message}`)
+  }
+
+  // -------------------------------------------------------------------------
+  // Usage events (usage_events — append-only, opt-in write / open org read)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Append ONE aggregated usage snapshot at session end. Maps the app agent id to
+   * the agents.id uuid via agentIdMap (exactly like appendHistory). tokens is left
+   * null on purpose: TerminalUsage.contextTokens is a point-in-time context gauge,
+   * not a cumulative session-token count, so it must not be mapped into this row.
+   */
+  async appendUsage(event: UsageEventInput): Promise<void> {
+    const ctx = await this.context()
+    if (!ctx) return
+
+    const agentUuid = this.agentIdMap.get(event.agentId) ?? null
+
+    const { error } = await ctx.client.from('usage_events').insert({
+      org_id: ctx.orgId,
+      user_id: ctx.uid,
+      agent_id: agentUuid,
+      model: event.model ?? null,
+      cost_usd: event.costUsd ?? null,
+      tokens: null,
+      lines_added: event.linesAdded ?? null,
+      lines_removed: event.linesRemoved ?? null,
+      duration_ms: event.durationMs ?? null,
+      occurred_at: new Date(event.occurredAt ?? Date.now()).toISOString(),
+    })
+    if (error) throw new Error(`appendUsage failed: ${error.message}`)
+  }
+
+  /**
+   * Org-wide usage rows for the team dashboard, newest-first. RLS scopes the read
+   * to the org (any member may read — the opt-in only gates writing your own data).
+   * Returns the raw rows for client-side aggregation.
+   */
+  async loadOrgUsageStats(): Promise<UsageStats> {
+    const ctx = await this.context()
+    if (!ctx) return { rows: [] }
+
+    const { data, error } = await ctx.client
+      .from('usage_events')
+      .select('user_id, agent_id, model, cost_usd, tokens, lines_added, lines_removed, duration_ms, occurred_at')
+      .eq('org_id', ctx.orgId)
+      .order('occurred_at', { ascending: false })
+      .limit(5000)
+
+    if (error || !data) return { rows: [] }
+
+    const rows = (data as UsageEventRow[]).map((r) => ({
+      userId: r.user_id,
+      agentId: r.agent_id,
+      model: r.model,
+      costUsd: toNumber(r.cost_usd),
+      tokens: r.tokens === null ? null : toNumber(r.tokens),
+      linesAdded: r.lines_added ?? 0,
+      linesRemoved: r.lines_removed ?? 0,
+      durationMs: toNumber(r.duration_ms),
+      occurredAt: r.occurred_at,
+    }))
+    return { rows }
   }
 
   // -------------------------------------------------------------------------

--- a/desktop/src/main/store/Store.ts
+++ b/desktop/src/main/store/Store.ts
@@ -68,7 +68,7 @@ export const NOOP_STORE: Store = {
   async loadHistory() { return [] },
   async appendHistory() { /* no-op */ },
   async appendUsage() { /* no-op */ },
-  async loadOrgUsageStats() { return { rows: [] } },
+  async loadOrgUsageStats() { return { rows: [], capped: false } },
   async setOrgSharedConfig() { /* no-op */ },
   async ping() { return 'unauthorized' },
   setActiveOrgId() { /* no-op */ },

--- a/desktop/src/main/store/Store.ts
+++ b/desktop/src/main/store/Store.ts
@@ -1,4 +1,4 @@
-import type { Config, Agent, HistoryEntry, OrgSharedConfig, OrgAgent } from '../../types'
+import type { Config, Agent, HistoryEntry, OrgSharedConfig, OrgAgent, UsageEventInput, UsageStats } from '../../types'
 
 /**
  * Result of a backend reachability probe.
@@ -34,6 +34,12 @@ export interface Store {
   loadHistory(limit: number): Promise<HistoryEntry[]>
   appendHistory(entry: HistoryEntry): Promise<void>
 
+  /** Append ONE aggregated usage snapshot at session end (append-only, fire-and-forget). */
+  appendUsage(event: UsageEventInput): Promise<void>
+
+  /** Org-wide usage rows (all members) for the dashboard, aggregated client-side. Read-only. */
+  loadOrgUsageStats(): Promise<UsageStats>
+
   /** Admin-only: push the org's shared config (languages/commit/pullRequest/repoKeywords). */
   setOrgSharedConfig(orgId: string, shared: OrgSharedConfig): Promise<void>
 
@@ -61,6 +67,8 @@ export const NOOP_STORE: Store = {
   async loadOrgAgents() { return [] },
   async loadHistory() { return [] },
   async appendHistory() { /* no-op */ },
+  async appendUsage() { /* no-op */ },
+  async loadOrgUsageStats() { return { rows: [] } },
   async setOrgSharedConfig() { /* no-op */ },
   async ping() { return 'unauthorized' },
   setActiveOrgId() { /* no-op */ },

--- a/desktop/src/main/usage/usage-events.test.ts
+++ b/desktop/src/main/usage/usage-events.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { UsageEventInput } from '../../types'
+import type { Store } from '../store/Store'
+import { setStore, NOOP_STORE } from '../store/Store'
+
+// readConfig is mocked so we can flip the GDPR opt-in per test.
+vi.mock('../config/config', () => ({ readConfig: vi.fn() }))
+import { readConfig } from '../config/config'
+import { recordUsageSnapshot } from './usage-events'
+
+let appended: UsageEventInput[] = []
+
+function fakeStore(overrides: Partial<Store> = {}): Store {
+  return {
+    ...NOOP_STORE,
+    appendUsage: async (e) => { appended.push(structuredClone(e)) },
+    ...overrides,
+  }
+}
+
+const sample: UsageEventInput = {
+  agentId: 'claude-1',
+  model: 'Claude Opus',
+  costUsd: 1.23,
+  linesAdded: 10,
+  linesRemoved: 4,
+  durationMs: 5000,
+  occurredAt: 1000,
+}
+
+beforeEach(() => {
+  appended = []
+  setStore(fakeStore())
+  vi.mocked(readConfig).mockReset()
+})
+
+describe('recordUsageSnapshot', () => {
+  it('does nothing when usageLogsEnabled is not set (default OFF)', async () => {
+    vi.mocked(readConfig).mockReturnValue({ version: 'x', repositories: {} })
+    await recordUsageSnapshot(sample)
+    expect(appended).toHaveLength(0)
+  })
+
+  it('does nothing when usageLogsEnabled is explicitly false', async () => {
+    vi.mocked(readConfig).mockReturnValue({ version: 'x', repositories: {}, usageLogsEnabled: false })
+    await recordUsageSnapshot(sample)
+    expect(appended).toHaveLength(0)
+  })
+
+  it('appends the snapshot when usageLogsEnabled is true', async () => {
+    vi.mocked(readConfig).mockReturnValue({ version: 'x', repositories: {}, usageLogsEnabled: true })
+    await recordUsageSnapshot(sample)
+    expect(appended).toHaveLength(1)
+    expect(appended[0]).toEqual(sample)
+  })
+
+  it('swallows store errors (never throws into the caller)', async () => {
+    vi.mocked(readConfig).mockReturnValue({ version: 'x', repositories: {}, usageLogsEnabled: true })
+    setStore(fakeStore({ appendUsage: async () => { throw new Error('boom') } }))
+    await expect(recordUsageSnapshot(sample)).resolves.toBeUndefined()
+  })
+})

--- a/desktop/src/main/usage/usage-events.ts
+++ b/desktop/src/main/usage/usage-events.ts
@@ -1,0 +1,23 @@
+import type { UsageEventInput } from '../../types'
+import { readConfig } from '../config/config'
+import { getStore } from '../store/Store'
+
+/**
+ * Record ONE aggregated usage snapshot at session end.
+ *
+ * GDPR opt-in: writing is gated behind Config.usageLogsEnabled (default OFF). When
+ * the flag is not explicitly true this is a no-op — no data leaves the machine.
+ *
+ * Fire-and-forget: this never throws into the caller. Callers may `void` the
+ * returned promise; any store/network error is swallowed and logged. usage_events
+ * is append-only, so there is no cache to keep consistent (unlike config/agents/
+ * history), hence no reportWriteError wiring here.
+ */
+export async function recordUsageSnapshot(input: UsageEventInput): Promise<void> {
+  if (readConfig().usageLogsEnabled !== true) return
+  try {
+    await getStore().appendUsage(input)
+  } catch (error) {
+    console.error('[usage] Failed to record usage snapshot:', error)
+  }
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
-import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole, OrgSharedConfig, OrgAgent, OrgAgentChange, RealtimeStatus } from '../types'
+import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole, OrgSharedConfig, OrgAgent, OrgAgentChange, RealtimeStatus, UsageStats } from '../types'
 
 export type TerminalState = 'idle' | 'working' | 'waiting' | 'completed' | 'error'
 
@@ -54,6 +54,8 @@ const configApi = {
     ipcRenderer.invoke('config:setUsageCardEnabled', { enabled }),
   setUsageCardMinimized: (minimized: boolean): Promise<{ config: Config }> =>
     ipcRenderer.invoke('config:setUsageCardMinimized', { minimized }),
+  setUsageLogsEnabled: (enabled: boolean): Promise<{ config: Config }> =>
+    ipcRenderer.invoke('config:setUsageLogsEnabled', { enabled }),
 
   updateSplitEnabled: (enabled: boolean) =>
     ipcRenderer.invoke('config:updateSplitEnabled', { enabled }),
@@ -456,6 +458,8 @@ const orgApi = {
   list: (): Promise<Org[]> => ipcRenderer.invoke('org:list'),
   // Team dashboard: org-wide agents roster + live realtime propagation.
   listAgents: (): Promise<OrgAgent[]> => ipcRenderer.invoke('org:listAgents'),
+  // Team dashboard: org-wide usage stats (read is open to any member).
+  getUsageStats: (): Promise<UsageStats> => ipcRenderer.invoke('org:getUsageStats'),
   getRealtimeStatus: (): Promise<RealtimeStatus> => ipcRenderer.invoke('org:realtimeStatus'),
   onAgentsChanged: (callback: (change: OrgAgentChange) => void) => {
     const listener = (_event: IpcRendererEvent, change: OrgAgentChange) => callback(change)

--- a/desktop/src/renderer/hooks/useOrgUsageStats.ts
+++ b/desktop/src/renderer/hooks/useOrgUsageStats.ts
@@ -12,6 +12,7 @@ import { useStore } from '../store'
 export function useOrgUsageStats() {
   const activeOrgId = useStore((s) => s.activeOrg?.id)
   const [rows, setRows] = useState<UsageStatRow[]>([])
+  const [capped, setCapped] = useState(false)
   const [loading, setLoading] = useState(true)
 
   const load = useCallback(async () => {
@@ -19,8 +20,10 @@ export function useOrgUsageStats() {
     try {
       const stats = await window.electronAPI.org.getUsageStats()
       setRows(stats.rows)
+      setCapped(stats.capped)
     } catch {
       setRows([])
+      setCapped(false)
     } finally {
       setLoading(false)
     }
@@ -30,5 +33,5 @@ export function useOrgUsageStats() {
     load()
   }, [load, activeOrgId])
 
-  return { rows, loading }
+  return { rows, capped, loading }
 }

--- a/desktop/src/renderer/hooks/useOrgUsageStats.ts
+++ b/desktop/src/renderer/hooks/useOrgUsageStats.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { UsageStatRow } from '../../types'
+import { useStore } from '../store'
+
+/**
+ * Org-wide usage stats for the team dashboard. Loaded via org.getUsageStats() and
+ * reloaded whenever the active org changes. Reading is open to any org member (RLS
+ * scopes it to the org) — the usage-logs opt-in only gates WRITING your own data,
+ * not viewing the team aggregate. Rows come newest-first and are aggregated by the
+ * consuming component.
+ */
+export function useOrgUsageStats() {
+  const activeOrgId = useStore((s) => s.activeOrg?.id)
+  const [rows, setRows] = useState<UsageStatRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const stats = await window.electronAPI.org.getUsageStats()
+      setRows(stats.rows)
+    } catch {
+      setRows([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load, activeOrgId])
+
+  return { rows, loading }
+}

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, Fragment } from 'react'
-import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, GitPullRequest, History, Gauge, User, Coins } from 'lucide-react'
+import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, GitPullRequest, History, Gauge, User, Coins, BarChart3 } from 'lucide-react'
 import { ProfileSection } from './ProfileSection'
 import { RepoPage } from './RepoPage'
 import { OrgPage } from './OrgPage'
@@ -9,6 +9,7 @@ import { useConfig } from '../../hooks/useConfig'
 import type { SpotlightShortcut, LaunchMode, ClaudeAccount, SpendSummary, SettingsTab } from '../../../types'
 import { showToast } from '../../components/Toast'
 import { getProjectColorMap } from '../../utils/projectColors'
+import { formatUsd } from '../../utils/usageStats'
 
 const SPOTLIGHT_OPTIONS: { label: string; value: string }[] = [
   { label: '\u2303 Space', value: 'Control+Space' },
@@ -47,12 +48,6 @@ function formatTokensCompact(n: number): string {
   return `${n}`
 }
 
-function formatUsd(n: number): string {
-  if (n > 0 && n < 0.01) return '<$0.01'
-  if (n >= 1000) return `$${Math.round(n).toLocaleString('en-US')}`
-  return `$${n.toFixed(2)}`
-}
-
 // Human-readable label for a Claude seat tier / billing type.
 const SEAT_TIER_LABELS: Record<string, string> = {
   team_standard: 'Team',
@@ -88,6 +83,7 @@ function WelcomePage() {
   const [showBypassWarning, setShowBypassWarning] = useState(false)
   const [historyEnabled, setHistoryEnabled] = useState(config?.historyEnabled ?? true)
   const [usageCardEnabled, setUsageCardEnabled] = useState(config?.usageCardEnabled ?? false)
+  const [usageLogsEnabled, setUsageLogsEnabled] = useState(config?.usageLogsEnabled ?? false)
   const [prWatcherEnabled, setPrWatcherEnabled] = useState(config?.prReviews?.enabled ?? true)
   const [prWatcherInterval, setPrWatcherInterval] = useState(config?.prReviews?.pollIntervalMs ?? 60_000)
   const [prWatcherAutoLaunch, setPrWatcherAutoLaunch] = useState(config?.prReviews?.autoLaunchSkills ?? false)
@@ -113,6 +109,11 @@ function WelcomePage() {
   useEffect(() => {
     if (configUsageCardEnabled !== undefined) setUsageCardEnabled(configUsageCardEnabled)
   }, [configUsageCardEnabled])
+
+  const configUsageLogsEnabled = config?.usageLogsEnabled
+  useEffect(() => {
+    if (configUsageLogsEnabled !== undefined) setUsageLogsEnabled(configUsageLogsEnabled)
+  }, [configUsageLogsEnabled])
 
   const configPrWatcherEnabled = config?.prReviews?.enabled
   const configPrWatcherInterval = config?.prReviews?.pollIntervalMs
@@ -543,6 +544,39 @@ function WelcomePage() {
             >
               <div className={`absolute top-[3px] left-[3px] w-4 h-4 rounded-full bg-white transition-transform duration-200 ${
                 usageCardEnabled ? 'translate-x-[18px]' : 'translate-x-0'
+              }`} />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Usage Logs Section (GDPR opt-in — off by default) */}
+      <div>
+        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
+          <BarChart3 className="w-4 h-4" />
+          <span>Usage logs</span>
+        </div>
+        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <div className="text-sm font-medium">Share my usage with my organization</div>
+              <div className="text-xs text-text-secondary/50 mt-0.5">
+                Off by default (GDPR opt-in). When enabled, an aggregated summary (estimated cost, lines added/removed, duration, model) is recorded for your organization at the end of each session, so admins can track team usage. No prompts or code are ever sent. You can turn it off at any time.
+              </div>
+            </div>
+            <button
+              onClick={async () => {
+                const newValue = !usageLogsEnabled
+                setUsageLogsEnabled(newValue)
+                const result = await window.electronAPI.config.setUsageLogsEnabled(newValue)
+                setConfig(result.config)
+              }}
+              className={`relative w-10 h-[22px] rounded-full transition-colors duration-200 flex-shrink-0 ${
+                usageLogsEnabled ? 'bg-accent' : 'bg-white/20'
+              }`}
+            >
+              <div className={`absolute top-[3px] left-[3px] w-4 h-4 rounded-full bg-white transition-transform duration-200 ${
+                usageLogsEnabled ? 'translate-x-[18px]' : 'translate-x-0'
               }`} />
             </button>
           </div>

--- a/desktop/src/renderer/pages/Dashboard/index.tsx
+++ b/desktop/src/renderer/pages/Dashboard/index.tsx
@@ -1,9 +1,107 @@
 import { useMemo } from 'react'
-import { Users, Bot } from 'lucide-react'
+import { Users, Bot, Coins, Plus, Minus, Clock, Activity, BarChart3 } from 'lucide-react'
 import type { OrgAgent } from '../../../types'
 import { useOrgAgents } from '../../hooks/useOrgAgents'
+import { useOrgUsageStats } from '../../hooks/useOrgUsageStats'
 import { useOrg } from '../../hooks/useOrg'
 import { LiveIndicator } from '../../components/LiveIndicator'
+import { ActivityHeatmap } from '../History/ActivityHeatmap'
+import { aggregateUsageTotals, aggregateUsageByMember, computeUsageHeatmap, formatUsd } from '../../utils/usageStats'
+
+function formatDuration(ms: number): string {
+  const totalMin = Math.round(ms / 60000)
+  if (totalMin < 60) return `${totalMin}m`
+  const h = Math.floor(totalMin / 60)
+  const m = totalMin % 60
+  return m === 0 ? `${h}h` : `${h}h ${m}m`
+}
+
+function StatTile({ icon: Icon, label, value }: { icon: typeof Coins; label: string; value: string }) {
+  return (
+    <div className="bg-white/[0.06] border border-white/[0.08] rounded-xl p-4 flex flex-col gap-1.5 min-w-0">
+      <div className="flex items-center gap-1.5 text-xs text-text-secondary">
+        <Icon className="w-3.5 h-3.5 flex-shrink-0" />
+        <span className="truncate">{label}</span>
+      </div>
+      <div className="text-lg font-semibold text-white truncate">{value}</div>
+    </div>
+  )
+}
+
+/**
+ * Org-wide usage stats. Reading is open to any org member (the usage-logs opt-in
+ * only gates WRITING your own data), so this always renders — with a clean empty
+ * state when no member has opted in / produced data yet.
+ */
+function UsageStatsSection() {
+  const { rows, loading } = useOrgUsageStats()
+  const { members } = useOrg()
+
+  const emailByOwner = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const m of members) {
+      if (m.email) map.set(m.userId, m.email)
+    }
+    return map
+  }, [members])
+
+  const totals = useMemo(() => aggregateUsageTotals(rows), [rows])
+  const byMember = useMemo(() => aggregateUsageByMember(rows), [rows])
+  const heatmap = useMemo(() => computeUsageHeatmap(rows), [rows])
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
+        <BarChart3 className="w-4 h-4" />
+        <span>Usage</span>
+      </div>
+
+      {loading && rows.length === 0 ? (
+        <div className="py-10 flex items-center justify-center text-text-secondary text-sm">Loading…</div>
+      ) : rows.length === 0 ? (
+        <div className="py-10 flex flex-col items-center justify-center text-text-secondary text-sm gap-2 bg-white/[0.03] border border-white/[0.06] rounded-xl">
+          <BarChart3 className="w-8 h-8 opacity-30" />
+          <p>No usage recorded yet.</p>
+          <p className="text-xs text-text-secondary/60 max-w-sm text-center">
+            Usage logging is opt-in. Members who enable it in Settings will have an aggregated snapshot recorded at the end of each session.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {/* Summary tiles */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+            <StatTile icon={Coins} label="Total cost" value={formatUsd(totals.costUsd)} />
+            <StatTile icon={Activity} label="Sessions" value={totals.sessions.toLocaleString('en-US')} />
+            <StatTile icon={Plus} label="Lines added" value={totals.linesAdded.toLocaleString('en-US')} />
+            <StatTile icon={Minus} label="Lines removed" value={totals.linesRemoved.toLocaleString('en-US')} />
+            <StatTile icon={Clock} label="Total duration" value={formatDuration(totals.durationMs)} />
+          </div>
+
+          {/* Sessions over time */}
+          <ActivityHeatmap heatmapData={heatmap} />
+
+          {/* Per-member breakdown (always non-empty in this branch — rows.length !== 0) */}
+          <div className="bg-white/[0.06] border border-white/[0.08] rounded-xl p-4 flex flex-col gap-2">
+            <div className="text-xs text-text-secondary mb-1">By member</div>
+            {byMember.map((m) => (
+              <div key={m.userId || '__unassigned__'} className="flex items-center justify-between gap-3 text-sm">
+                <span className="text-white truncate min-w-0">
+                  {m.userId ? emailByOwner.get(m.userId) ?? m.userId : 'Unassigned'}
+                </span>
+                <div className="flex items-center gap-4 flex-shrink-0">
+                  <span className="text-xs text-text-secondary/60">
+                    {m.sessions} {m.sessions === 1 ? 'session' : 'sessions'}
+                  </span>
+                  <span className="text-white/90 font-medium tabular-nums">{formatUsd(m.costUsd)}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
 
 // Workflow-status → label + badge color. Statuses mirror
 // TerminalMetadata.status; anything unrecognized falls through to a neutral pill.
@@ -122,33 +220,45 @@ export function DashboardPage() {
         <LiveIndicator />
       </div>
 
-      {/* Body */}
-      {loading && agents.length === 0 ? (
-        <div className="flex-1 flex items-center justify-center text-text-secondary text-sm">
-          Loading…
-        </div>
-      ) : agents.length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center text-text-secondary text-sm gap-2">
-          <Users className="w-8 h-8 opacity-30" />
-          <p>No active agents in the organization yet.</p>
-        </div>
-      ) : (
-        <div className="flex-1 overflow-auto flex flex-col gap-6">
-          {groups.map((group) => (
-            <div key={group.key} className="flex flex-col gap-2">
-              <div className="flex items-center gap-2 px-1">
-                <span className="text-sm font-medium text-white truncate">{group.label}</span>
-                <span className="text-xs text-text-secondary/50">{group.agents.length}</span>
-              </div>
-              <div className="flex flex-col gap-2">
-                {group.agents.map((agent) => (
-                  <AgentRow key={agent.id} agent={agent} />
-                ))}
-              </div>
+      {/* Body — usage stats + active agents share one scroll container */}
+      <div className="flex-1 overflow-auto flex flex-col gap-8">
+        {/* Org usage stats (read is open to any member) */}
+        <UsageStatsSection />
+
+        {/* Active agents */}
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2 text-sm text-text-secondary">
+            <Bot className="w-4 h-4" />
+            <span>Active agents</span>
+          </div>
+          {loading && agents.length === 0 ? (
+            <div className="py-10 flex items-center justify-center text-text-secondary text-sm">
+              Loading…
             </div>
-          ))}
+          ) : agents.length === 0 ? (
+            <div className="py-10 flex flex-col items-center justify-center text-text-secondary text-sm gap-2 bg-white/[0.03] border border-white/[0.06] rounded-xl">
+              <Users className="w-8 h-8 opacity-30" />
+              <p>No active agents in the organization yet.</p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-6">
+              {groups.map((group) => (
+                <div key={group.key} className="flex flex-col gap-2">
+                  <div className="flex items-center gap-2 px-1">
+                    <span className="text-sm font-medium text-white truncate">{group.label}</span>
+                    <span className="text-xs text-text-secondary/50">{group.agents.length}</span>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    {group.agents.map((agent) => (
+                      <AgentRow key={agent.id} agent={agent} />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/desktop/src/renderer/pages/Dashboard/index.tsx
+++ b/desktop/src/renderer/pages/Dashboard/index.tsx
@@ -34,7 +34,7 @@ function StatTile({ icon: Icon, label, value }: { icon: typeof Coins; label: str
  * state when no member has opted in / produced data yet.
  */
 function UsageStatsSection() {
-  const { rows, loading } = useOrgUsageStats()
+  const { rows, capped, loading } = useOrgUsageStats()
   const { members } = useOrg()
 
   const emailByOwner = useMemo(() => {
@@ -68,6 +68,13 @@ function UsageStatsSection() {
         </div>
       ) : (
         <div className="flex flex-col gap-4">
+          {/* Totals are aggregated from at most the newest 5000 sessions; warn when that cap is hit. */}
+          {capped && (
+            <div className="text-xs text-amber-400/80 bg-amber-400/10 border border-amber-400/20 rounded-lg px-3 py-2">
+              Showing the most recent 5,000 sessions — totals below are partial and under-count older activity.
+            </div>
+          )}
+
           {/* Summary tiles */}
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
             <StatTile icon={Coins} label="Total cost" value={formatUsd(totals.costUsd)} />

--- a/desktop/src/renderer/utils/usageStats.test.ts
+++ b/desktop/src/renderer/utils/usageStats.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import type { UsageStatRow } from '../../types'
+import { aggregateUsageTotals, aggregateUsageByMember, computeUsageHeatmap } from './usageStats'
+
+function row(overrides: Partial<UsageStatRow> = {}): UsageStatRow {
+  return {
+    userId: 'u1',
+    agentId: 'a1',
+    model: 'Claude Opus',
+    costUsd: 1,
+    tokens: null,
+    linesAdded: 5,
+    linesRemoved: 2,
+    durationMs: 60000,
+    occurredAt: new Date(2026, 5, 10, 12, 0, 0).toISOString(),
+    ...overrides,
+  }
+}
+
+describe('aggregateUsageTotals', () => {
+  it('returns zeroed totals for no rows', () => {
+    expect(aggregateUsageTotals([])).toEqual({
+      costUsd: 0, linesAdded: 0, linesRemoved: 0, durationMs: 0, sessions: 0,
+    })
+  })
+
+  it('sums cost, lines and duration across rows', () => {
+    const totals = aggregateUsageTotals([
+      row({ costUsd: 1.5, linesAdded: 10, linesRemoved: 3, durationMs: 1000 }),
+      row({ costUsd: 2.25, linesAdded: 4, linesRemoved: 1, durationMs: 2000 }),
+    ])
+    expect(totals.costUsd).toBeCloseTo(3.75)
+    expect(totals.linesAdded).toBe(14)
+    expect(totals.linesRemoved).toBe(4)
+    expect(totals.durationMs).toBe(3000)
+    expect(totals.sessions).toBe(2)
+  })
+})
+
+describe('aggregateUsageByMember', () => {
+  it('groups by user and sorts by cost descending', () => {
+    const result = aggregateUsageByMember([
+      row({ userId: 'u1', costUsd: 1 }),
+      row({ userId: 'u2', costUsd: 5 }),
+      row({ userId: 'u1', costUsd: 2 }),
+    ])
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ userId: 'u2', costUsd: 5, sessions: 1 })
+    expect(result[1]).toEqual({ userId: 'u1', costUsd: 3, sessions: 2 })
+  })
+
+  it('groups null owners under an empty-string key', () => {
+    const result = aggregateUsageByMember([row({ userId: null, costUsd: 1 })])
+    expect(result[0].userId).toBe('')
+  })
+})
+
+describe('computeUsageHeatmap', () => {
+  it('buckets rows by local calendar day', () => {
+    const map = computeUsageHeatmap([
+      row({ occurredAt: new Date(2026, 5, 10, 9, 0, 0).toISOString() }),
+      row({ occurredAt: new Date(2026, 5, 10, 18, 0, 0).toISOString() }),
+      row({ occurredAt: new Date(2026, 5, 11, 9, 0, 0).toISOString() }),
+    ])
+    expect(map.get('2026-06-10')).toBe(2)
+    expect(map.get('2026-06-11')).toBe(1)
+  })
+
+  it('skips rows with an unparseable timestamp', () => {
+    const map = computeUsageHeatmap([row({ occurredAt: 'not-a-date' })])
+    expect(map.size).toBe(0)
+  })
+})

--- a/desktop/src/renderer/utils/usageStats.ts
+++ b/desktop/src/renderer/utils/usageStats.ts
@@ -1,0 +1,62 @@
+import type { UsageStatRow } from '../../types'
+
+/** Format a USD amount for display: `<$0.01` under a cent, rounded thousands, else two decimals. */
+export function formatUsd(n: number): string {
+  if (n > 0 && n < 0.01) return '<$0.01'
+  if (n >= 1000) return `$${Math.round(n).toLocaleString('en-US')}`
+  return `$${n.toFixed(2)}`
+}
+
+export interface UsageTotals {
+  costUsd: number
+  linesAdded: number
+  linesRemoved: number
+  durationMs: number
+  sessions: number
+}
+
+export interface MemberUsage {
+  userId: string
+  costUsd: number
+  sessions: number
+}
+
+/** Sum the headline totals across all usage rows. */
+export function aggregateUsageTotals(rows: UsageStatRow[]): UsageTotals {
+  const totals: UsageTotals = { costUsd: 0, linesAdded: 0, linesRemoved: 0, durationMs: 0, sessions: rows.length }
+  for (const r of rows) {
+    totals.costUsd += r.costUsd
+    totals.linesAdded += r.linesAdded
+    totals.linesRemoved += r.linesRemoved
+    totals.durationMs += r.durationMs
+  }
+  return totals
+}
+
+/** Per-member cost + session counts, sorted by cost descending. Rows with no owner are grouped under ''. */
+export function aggregateUsageByMember(rows: UsageStatRow[]): MemberUsage[] {
+  const byUser = new Map<string, MemberUsage>()
+  for (const r of rows) {
+    const userId = r.userId ?? ''
+    const entry = byUser.get(userId) ?? { userId, costUsd: 0, sessions: 0 }
+    entry.costUsd += r.costUsd
+    entry.sessions += 1
+    byUser.set(userId, entry)
+  }
+  return [...byUser.values()].sort((a, b) => b.costUsd - a.costUsd)
+}
+
+/**
+ * Session count per calendar day, keyed as YYYY-MM-DD in local time — the exact
+ * key shape ActivityHeatmap expects, so the heatmap can render usage over time.
+ */
+export function computeUsageHeatmap(rows: UsageStatRow[]): Map<string, number> {
+  const map = new Map<string, number>()
+  for (const r of rows) {
+    const d = new Date(r.occurredAt)
+    if (Number.isNaN(d.getTime())) continue
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    map.set(key, (map.get(key) || 0) + 1)
+  }
+  return map
+}

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -153,6 +153,10 @@ export interface Config {
   historyEnabled?: boolean
   usageCardEnabled?: boolean    // show the Claude usage card in the sidebar
   usageCardMinimized?: boolean  // sidebar usage card collapsed to gauges only
+  // GDPR opt-in (default OFF): when true, an aggregated usage snapshot is written
+  // to the org's usage_events table at session end. Gates WRITING your own data
+  // only — reading the org aggregate is open to any member regardless of this flag.
+  usageLogsEnabled?: boolean
   prReviews?: {
     enabled?: boolean
     pollIntervalMs?: number
@@ -244,6 +248,45 @@ export interface OrgAgentChange {
   eventType: 'INSERT' | 'UPDATE' | 'DELETE'
   id: string
   agent?: OrgAgent
+}
+
+// ---------------------------------------------------------------------------
+// Cloud: usage logs & org stats (opt-in). One aggregated snapshot is written per
+// session at session end (never per statusLine event). Writing is GDPR opt-in
+// (Config.usageLogsEnabled, default OFF); reading the org aggregate is open to
+// any org member (RLS scopes it to the org).
+// ---------------------------------------------------------------------------
+
+/** Aggregated end-of-session snapshot to append to the usage_events table. */
+export interface UsageEventInput {
+  /** app agent id ("claude-…"), mapped to the agents.id uuid by the store. */
+  agentId: string
+  model?: string
+  costUsd?: number
+  linesAdded?: number
+  linesRemoved?: number
+  durationMs?: number
+  /** epoch ms; defaults to now when omitted. */
+  occurredAt?: number
+}
+
+/** A single usage_events row, normalized for client-side aggregation. */
+export interface UsageStatRow {
+  userId: string | null
+  agentId: string | null
+  model: string | null
+  costUsd: number
+  tokens: number | null
+  linesAdded: number
+  linesRemoved: number
+  durationMs: number
+  /** ISO timestamp of when the session ended. */
+  occurredAt: string
+}
+
+/** Org-wide usage rows for the dashboard, aggregated client-side by the renderer. */
+export interface UsageStats {
+  rows: UsageStatRow[]
 }
 
 export interface Invitation {

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -287,6 +287,8 @@ export interface UsageStatRow {
 /** Org-wide usage rows for the dashboard, aggregated client-side by the renderer. */
 export interface UsageStats {
   rows: UsageStatRow[]
+  /** True when the query hit its row cap, so the aggregated totals are partial (under-counted). */
+  capped: boolean
 }
 
 export interface Invitation {


### PR DESCRIPTION
## Description

Cloud PR 5 of the Supabase multi-tenant epic (#121). Persists Claude Code usage as **one aggregated snapshot per session** into the existing `usage_events` table, gated behind a **GDPR opt-in disabled by default**, and adds an **org usage-stats section** to the Team Dashboard. No SQL migration is needed — the `usage_events` table, RLS and indexes already exist from PR 1.

The opt-in governs **writing** your own usage; **reading** the org aggregate stays open to any org member (matching the existing `usage_events_select` RLS and the Team Dashboard's org-wide agent roster), so an admin can view team stats regardless of their own opt-in.

## Related Issue

Closes #127

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **Opt-in setting** `usageLogsEnabled` (default OFF): added to `Config` type, `config.ts` updater, `config:setUsageLogsEnabled` IPC handler, preload wrapper, and a GDPR-worded toggle in the Config → Features tab.
- **Usage Store domain**: `appendUsage` / `loadOrgUsageStats` added to the `Store` interface, `NOOP_STORE`, and `CloudStore` (agent id → uuid via `agentIdMap`, org/user scoping, PostgREST `toNumber` coercion; `tokens` left null since `contextTokens` is a point-in-time gauge, not a session cumulative).
- **One-write-per-session flush** at session end: `flushUsageSnapshot` called before `removeAgent` in `terminal:kill` and on the natural `onExit` path, deduped via a `usageFlushed` Set — never per statusLine event.
- **Org stats read path**: `org:getUsageStats` IPC → `listOrgUsageStats` → Store, exposed on `electronAPI.org`, consumed by a new `useOrgUsageStats` hook.
- **Dashboard UI**: org usage section with summary tiles (total cost, lines ±, duration), an over-time heatmap reusing `ActivityHeatmap`, a per-member breakdown, and an empty state.
- **Tests**: new suites for `CloudStore` usage path, the session-end dedup in `terminal-handlers`, `usage-events` opt-in gating, `usageStats` aggregation, and `updateUsageLogsEnabled`.

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

### Test Steps

1. Launch the app, open **Config → Features**: confirm the "Usage logs" toggle is **OFF by default**. Open then close a Claude session → verify **no row** is inserted in `usage_events` (Supabase).
2. Enable the toggle, sign in to an org, run a Claude session (cost/lines accumulate in the sidebar), then **close the session** → verify **exactly one** row appears in `usage_events` with the correct `org_id`/`user_id`, coherent `cost_usd`/`lines_added`/`lines_removed`/`duration_ms`, and `tokens` null.
3. During an active session, confirm **no write** happens while the session is still running, despite frequent statusLine events (anti-spam / one-write-per-session).
4. Open the **Dashboard** → the org usage section shows summary tiles, the heatmap and the per-member breakdown; with no data it shows a clean empty state.
5. Turn the toggle back **OFF** and reopen the Dashboard → previously recorded stats remain **visible** (the opt-in gates writing, not reading).

## Screenshots

<!-- N/A -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

- **No migration**: aggregation is done client-side from a plain `select` over the existing `usage_events` table.
- Known v1-acceptable limitations flagged for follow-up: `loadOrgUsageStats` uses a silent `.limit(5000)` (headline totals under-count beyond that), and `useOrgUsageStats` has no realtime subscription (new snapshots appear on remount / org switch).
- `package-lock.json` was intentionally left out of this PR: local `npm install` rewrote it (version bump + machine-specific `libc` platform entries) unrelated to this feature.
