### PR TITLE
[#128] Team dashboard + re-engagement notifications and daily digest

### DIFF
--- a/desktop/src/main/cloud/org.test.ts
+++ b/desktop/src/main/cloud/org.test.ts
@@ -17,6 +17,16 @@ vi.mock(import('../config/config'), async (importOriginal) => ({
   readConfig: vi.fn(() => ({ repositories: h.repositories }) as unknown as Config),
 }))
 
+// Importing ./org pulls its module graph, which reaches packages that are not
+// resolvable when the suite runs from the repo root (@supabase/supabase-js via
+// ./auth -> ./supabase-client, and electron via ./session-store). Stub every
+// heavy sibling module ./org imports so none of their transitive imports load —
+// pickUpTask depends on none of them (only readConfig + expandPath).
+vi.mock('./auth', () => ({ getAuthedClient: vi.fn() }))
+vi.mock('./session-store', () => ({ loadSession: vi.fn() }))
+vi.mock('./realtime', () => ({ startOrgAgentsRealtime: vi.fn() }))
+vi.mock('../store/Store', () => ({ getStore: vi.fn() }))
+
 import { pickUpTask } from './org'
 
 // Build a repositories map keyed by name from a list of paths.

--- a/desktop/src/main/cloud/org.test.ts
+++ b/desktop/src/main/cloud/org.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as os from 'os'
+import * as path from 'path'
+import type { Config } from '../../types'
+
+// pickUpTask resolves a colleague's absolute repo paths to one of the current
+// user's LOCALLY configured repos. It reads the repo list via readConfig, so we
+// mock the config cache and drive readConfig per test. expandPath (from
+// ../config/validation) stays real — it is a pure ~-expansion helper.
+const h = vi.hoisted(() => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  repositories: {} as Record<string, any>,
+}))
+
+vi.mock(import('../config/config'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  readConfig: vi.fn(() => ({ repositories: h.repositories }) as unknown as Config),
+}))
+
+import { pickUpTask } from './org'
+
+// Build a repositories map keyed by name from a list of paths.
+const repos = (...paths: string[]) =>
+  Object.fromEntries(paths.map((p, i) => [`repo${i}`, { path: p }]))
+
+beforeEach(() => {
+  h.repositories = {}
+})
+
+describe('pickUpTask', () => {
+  it('matches a colleague repo to a local one by basename (different parent dirs)', () => {
+    h.repositories = repos('/Users/xavier/dev/poppins-pex')
+    const result = pickUpTask('PROJ-42', ['/home/alice/work/poppins-pex'])
+    expect(result).toEqual({
+      cwd: '/Users/xavier/dev/poppins-pex',
+      initialPrompt: '/magic:continue PROJ-42',
+    })
+  })
+
+  it('matches by exact expanded path when a ~ path expands to the same place', () => {
+    h.repositories = repos('~/dev/api')
+    const expanded = path.join(os.homedir(), 'dev/api')
+    const result = pickUpTask('T-7', [expanded])
+    expect(result.cwd).toBe(expanded)
+    expect(result.initialPrompt).toBe('/magic:continue T-7')
+  })
+
+  it('returns the expanded local path as cwd, not the raw ~ path', () => {
+    h.repositories = repos('~/dev/web')
+    const result = pickUpTask('T-8', ['/somewhere/else/web'])
+    expect(result.cwd).toBe(path.join(os.homedir(), 'dev/web'))
+  })
+
+  it('ignores trailing slashes on the colleague repo when matching by basename', () => {
+    h.repositories = repos('/Users/xavier/dev/service')
+    const result = pickUpTask('T-9', ['/remote/service/'])
+    expect(result.cwd).toBe('/Users/xavier/dev/service')
+  })
+
+  it('skips empty/non-string colleague entries and matches a later valid one', () => {
+    h.repositories = repos('/Users/xavier/dev/keep')
+    const result = pickUpTask('T-10', [
+      '',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      42 as any,
+      '/remote/keep',
+    ])
+    expect(result.cwd).toBe('/Users/xavier/dev/keep')
+  })
+
+  it('throws a user-facing error when no local repo maps', () => {
+    h.repositories = repos('/Users/xavier/dev/other')
+    expect(() => pickUpTask('T-11', ['/remote/unknown-repo'])).toThrowError(
+      /No matching local repository is configured/,
+    )
+  })
+
+  it('throws when there are no configured repositories at all', () => {
+    h.repositories = {}
+    expect(() => pickUpTask('T-12', ['/remote/anything'])).toThrowError(
+      /No matching local repository is configured/,
+    )
+  })
+
+  it('rejects an empty ticketId before any repo resolution', () => {
+    h.repositories = repos('/Users/xavier/dev/x')
+    expect(() => pickUpTask('   ', ['/remote/x'])).toThrowError(/requires a ticketId/)
+  })
+
+  it('picks the first matching colleague repo when several would map', () => {
+    h.repositories = repos('/Users/xavier/dev/first', '/Users/xavier/dev/second')
+    const result = pickUpTask('T-13', ['/remote/first', '/remote/second'])
+    expect(result.cwd).toBe('/Users/xavier/dev/first')
+  })
+})

--- a/desktop/src/main/cloud/org.ts
+++ b/desktop/src/main/cloud/org.ts
@@ -1,8 +1,10 @@
+import * as path from 'path'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Config, Invitation, InvitationStatus, Member, MembershipRole, Org, OrgAgent, OrgSharedConfig, UsageStats } from '../../types'
 import { getAuthedClient } from './auth'
 import { loadSession } from './session-store'
 import { readConfig, writeConfig, hydrateConfig, mergeOrgSharedConfig, setCurrentOrgId } from '../config/config'
+import { expandPath } from '../config/validation'
 import { getStore } from '../store/Store'
 import { startOrgAgentsRealtime } from './realtime'
 
@@ -115,6 +117,48 @@ export async function listOrgAgents(): Promise<OrgAgent[]> {
  */
 export async function listOrgUsageStats(): Promise<UsageStats> {
   return getStore().loadOrgUsageStats()
+}
+
+export interface PickUpTaskResult {
+  /** Local working directory (an expanded, configured repo path) to launch in. */
+  cwd: string
+  /** Prompt to hand the fresh agent, carrying ticket/branch/state resumption. */
+  initialPrompt: string
+}
+
+/**
+ * Resolve a colleague's task to something the current user can actually launch
+ * locally. A teammate's OrgAgent.repositories are absolute paths on THEIR machine,
+ * so they never match ours directly — we match by repository name (the last path
+ * segment) against the current user's configured repositories, falling back to an
+ * exact expanded-path match. Throws a user-facing error when no local repo maps,
+ * so the renderer can surface it as a toast (the dashboard also hides the action
+ * when nothing maps). On success returns the local cwd + the `/magic:continue`
+ * prompt that resumes the ticket's branch/state.
+ */
+export function pickUpTask(ticketId: string, repositories: string[]): PickUpTaskResult {
+  if (typeof ticketId !== 'string' || ticketId.trim().length === 0) {
+    throw new Error('pickUpTask requires a ticketId')
+  }
+  const localRepos = Object.values(readConfig().repositories ?? {})
+  const baseName = (p: string) => path.basename(p.replace(/[/\\]+$/, ''))
+
+  for (const repo of repositories) {
+    if (typeof repo !== 'string' || repo.length === 0) continue
+    const target = baseName(repo)
+    const expandedRepo = expandPath(repo)
+    const match = localRepos.find((r) => {
+      const local = expandPath(r.path)
+      return baseName(local) === target || local === expandedRepo
+    })
+    if (match) {
+      return { cwd: expandPath(match.path), initialPrompt: `/magic:continue ${ticketId}` }
+    }
+  }
+
+  throw new Error(
+    'No matching local repository is configured for this task. Add the repository in Settings to pick it up.',
+  )
 }
 
 /** Run a void-returning RPC through the authed client, surfacing failures as thrown errors. */

--- a/desktop/src/main/cloud/org.ts
+++ b/desktop/src/main/cloud/org.ts
@@ -140,6 +140,12 @@ export function pickUpTask(ticketId: string, repositories: string[]): PickUpTask
   if (typeof ticketId !== 'string' || ticketId.trim().length === 0) {
     throw new Error('pickUpTask requires a ticketId')
   }
+  // ticketId comes from agents.ticket_id, which any org member can write. It is
+  // embedded in initialPrompt and may later be typed into a PTY, so reject
+  // control characters (newline/CR/NUL) that could inject a second command.
+  if (/[\r\n\0]/.test(ticketId)) {
+    throw new Error('pickUpTask received a ticketId with illegal control characters')
+  }
   const localRepos = Object.values(readConfig().repositories ?? {})
   const baseName = (p: string) => path.basename(p.replace(/[/\\]+$/, ''))
 

--- a/desktop/src/main/cloud/realtime.test.ts
+++ b/desktop/src/main/cloud/realtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { RepositoryMetadata } from '../../types'
 
 // Mock the authed client + session store so the realtime module exercises only
 // its own lifecycle logic (no network, no socket). vi.hoisted shares mutable
@@ -44,6 +45,7 @@ import {
   setRealtimeEmitters,
   mapOrgAgentRow,
 } from './realtime'
+import type { OrgAgentRow } from './realtime'
 
 let changes: unknown[]
 let statuses: unknown[]
@@ -197,7 +199,140 @@ describe('mapOrgAgentRow', () => {
       ticketId: 'T-9',
       status: 'committed',
       repositories: [],
+      prReviews: undefined,
       updatedAt: undefined,
+    })
+  })
+
+  // A minimal, valid row helper so each prReviews case only spells out the
+  // metadata under test.
+  const rowWithMeta = (metadata: OrgAgentRow['metadata']): OrgAgentRow => ({
+    id: 'uuid-pr',
+    owner_id: 'u1',
+    name: 'PR Agent',
+    ticket_id: 'T-1',
+    status: 'in progress',
+    repositories: ['/repo'],
+    metadata,
+    updated_at: '2026-07-24T00:00:00Z',
+  })
+
+  describe('prReviews distilled from metadata.repositoryMetadata', () => {
+    it('distills a repo carrying a PR into a full prReviews entry', () => {
+      const agent = mapOrgAgentRow(
+        rowWithMeta({
+          repositoryMetadata: {
+            '/home/alice/api': {
+              prUrl: 'https://github.com/org/api/pull/7',
+              prReviewStatus: 'changes-requested',
+              prReviewers: ['bob', 'carol'],
+              prMerged: false,
+              prClosed: false,
+            },
+          },
+        }),
+      )
+      expect(agent.prReviews).toEqual([
+        {
+          repo: '/home/alice/api',
+          prUrl: 'https://github.com/org/api/pull/7',
+          status: 'changes-requested',
+          reviewers: ['bob', 'carol'],
+          merged: false,
+          closed: false,
+        },
+      ])
+    })
+
+    it('carries merged/closed flags through for a merged PR', () => {
+      const agent = mapOrgAgentRow(
+        rowWithMeta({
+          repositoryMetadata: {
+            '/home/alice/web': {
+              prUrl: 'https://github.com/org/web/pull/3',
+              prReviewStatus: 'approved',
+              prMerged: true,
+              prClosed: true,
+            },
+          },
+        }),
+      )
+      expect(agent.prReviews).toEqual([
+        {
+          repo: '/home/alice/web',
+          prUrl: 'https://github.com/org/web/pull/3',
+          status: 'approved',
+          reviewers: undefined,
+          merged: true,
+          closed: true,
+        },
+      ])
+    })
+
+    it('includes a repo with a review status but no PR url', () => {
+      const agent = mapOrgAgentRow(
+        rowWithMeta({ repositoryMetadata: { '/repo': { prReviewStatus: 'pending' } } }),
+      )
+      expect(agent.prReviews).toEqual([{ repo: '/repo', status: 'pending' }])
+    })
+
+    it('keeps only PR-carrying repos and drops those with no PR state', () => {
+      const agent = mapOrgAgentRow(
+        rowWithMeta({
+          repositoryMetadata: {
+            '/repo/with-pr': { prUrl: 'https://github.com/org/x/pull/1' },
+            '/repo/no-pr': { prReviewCommentCount: 0 },
+          },
+        }),
+      )
+      expect(agent.prReviews).toEqual([
+        { repo: '/repo/with-pr', prUrl: 'https://github.com/org/x/pull/1' },
+      ])
+    })
+
+    it('yields undefined prReviews when the row has no metadata at all', () => {
+      const agent = mapOrgAgentRow({
+        id: 'x',
+        owner_id: null,
+        name: 'N',
+        ticket_id: null,
+        status: null,
+        repositories: [],
+        updated_at: null,
+      })
+      expect(agent.prReviews).toBeUndefined()
+    })
+
+    it('yields undefined prReviews when metadata has no repositoryMetadata', () => {
+      const agent = mapOrgAgentRow(rowWithMeta({ ticketId: 'T-1' }))
+      expect(agent.prReviews).toBeUndefined()
+    })
+
+    it('yields undefined prReviews for an empty repositoryMetadata object', () => {
+      const agent = mapOrgAgentRow(rowWithMeta({ repositoryMetadata: {} }))
+      expect(agent.prReviews).toBeUndefined()
+    })
+
+    it('yields undefined when every repo lacks PR state', () => {
+      const agent = mapOrgAgentRow(
+        rowWithMeta({ repositoryMetadata: { '/a': {}, '/b': { prReviewCommentCount: 2 } } }),
+      )
+      expect(agent.prReviews).toBeUndefined()
+    })
+
+    it('skips malformed (null / non-object) per-repo metadata entries', () => {
+      const agent = mapOrgAgentRow(
+        rowWithMeta({
+          repositoryMetadata: {
+            '/bad-null': null as unknown as RepositoryMetadata,
+            '/bad-string': 'nope' as unknown as RepositoryMetadata,
+            '/good': { prUrl: 'https://github.com/org/g/pull/9' },
+          },
+        }),
+      )
+      expect(agent.prReviews).toEqual([
+        { repo: '/good', prUrl: 'https://github.com/org/g/pull/9' },
+      ])
     })
   })
 })

--- a/desktop/src/main/cloud/realtime.ts
+++ b/desktop/src/main/cloud/realtime.ts
@@ -1,5 +1,5 @@
 import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js'
-import type { OrgAgent, OrgAgentChange, RealtimeStatus } from '../../types'
+import type { OrgAgent, OrgAgentChange, OrgAgentPRReview, RealtimeStatus, RepositoryMetadata } from '../../types'
 import { getAuthedClient } from './auth'
 import { loadSession } from './session-store'
 
@@ -23,8 +23,37 @@ export interface OrgAgentRow {
   ticket_id: string | null
   status: string | null
   repositories: unknown
-  metadata?: { __app?: unknown; ticketId?: string; status?: string } & Record<string, unknown>
+  metadata?: {
+    __app?: unknown
+    ticketId?: string
+    status?: string
+    repositoryMetadata?: Record<string, RepositoryMetadata>
+  } & Record<string, unknown>
   updated_at?: string | null
+}
+
+/**
+ * Distill the org-wide PR review summary from a row's metadata.repositoryMetadata
+ * (populated org-wide by the PRReviewWatcher). Keeps only repos that carry a PR,
+ * so the dashboard's "awaiting review" / "blocked" widgets have exactly what they
+ * need. Returns undefined when no repo has a PR (keeps the OrgAgent shape lean).
+ */
+function extractPRReviews(repoMeta: Record<string, RepositoryMetadata> | undefined): OrgAgentPRReview[] | undefined {
+  if (!repoMeta || typeof repoMeta !== 'object') return undefined
+  const reviews: OrgAgentPRReview[] = []
+  for (const [repo, meta] of Object.entries(repoMeta)) {
+    if (!meta || typeof meta !== 'object') continue
+    if (!meta.prUrl && !meta.prReviewStatus) continue
+    reviews.push({
+      repo,
+      prUrl: meta.prUrl,
+      status: meta.prReviewStatus,
+      reviewers: meta.prReviewers,
+      merged: meta.prMerged,
+      closed: meta.prClosed,
+    })
+  }
+  return reviews.length > 0 ? reviews : undefined
 }
 
 /** Map a raw `agents` DB row (REST or Realtime) to the roster-facing OrgAgent. */
@@ -37,6 +66,7 @@ export function mapOrgAgentRow(row: OrgAgentRow): OrgAgent {
     ticketId: row.ticket_id ?? meta.ticketId ?? undefined,
     status: row.status ?? meta.status ?? undefined,
     repositories: Array.isArray(row.repositories) ? (row.repositories as string[]) : [],
+    prReviews: extractPRReviews(meta.repositoryMetadata),
     updatedAt: row.updated_at ?? undefined,
   }
 }
@@ -47,6 +77,25 @@ type StatusEmitter = (status: RealtimeStatus) => void
 let changeEmitter: ChangeEmitter | null = null
 let statusEmitter: StatusEmitter | null = null
 
+// Additional in-process subscribers to org-agent changes (e.g. the re-engagement
+// notifier). Kept separate from the single renderer-forwarding `changeEmitter`
+// (wired by connectivity-handlers) so a main-process module can observe the same
+// stream without disturbing that forward. Each listener is isolated from the
+// others: a throw in one never blocks the rest or the renderer forward.
+type ChangeListener = (change: OrgAgentChange) => void
+const changeListeners = new Set<ChangeListener>()
+
+/**
+ * Subscribe a main-process listener to org-agent realtime changes. Returns an
+ * unsubscribe function. Independent of the renderer-forwarding emitter.
+ */
+export function addOrgAgentChangeListener(listener: ChangeListener): () => void {
+  changeListeners.add(listener)
+  return () => {
+    changeListeners.delete(listener)
+  }
+}
+
 /**
  * Wire the emitters that forward realtime events + channel health to the
  * renderer. Pass (null, null) to clear (e.g. on teardown).
@@ -54,6 +103,18 @@ let statusEmitter: StatusEmitter | null = null
 export function setRealtimeEmitters(change: ChangeEmitter | null, status: StatusEmitter | null): void {
   changeEmitter = change
   statusEmitter = status
+}
+
+/** Fan a change out to the renderer forward AND every in-process listener. */
+function dispatchChange(change: OrgAgentChange): void {
+  changeEmitter?.(change)
+  for (const listener of changeListeners) {
+    try {
+      listener(change)
+    } catch (error) {
+      console.error('[realtime] org-agent change listener failed:', error)
+    }
+  }
 }
 
 let channel: RealtimeChannel | null = null
@@ -78,16 +139,15 @@ export function getRealtimeStatus(): RealtimeStatus {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function handleChange(payload: any): void {
-  if (!changeEmitter) return
   const eventType = payload?.eventType as OrgAgentChange['eventType']
   if (eventType === 'DELETE') {
     const id = (payload.old as OrgAgentRow | undefined)?.id
-    if (id) changeEmitter({ eventType, id })
+    if (id) dispatchChange({ eventType, id })
     return
   }
   const row = payload?.new as OrgAgentRow | undefined
   if (!row?.id) return
-  changeEmitter({ eventType, id: row.id, agent: mapOrgAgentRow(row) })
+  dispatchChange({ eventType, id: row.id, agent: mapOrgAgentRow(row) })
 }
 
 function mapChannelStatus(status: string): RealtimeStatus {

--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -379,6 +379,18 @@ export function updateUsageLogsEnabled(enabled: boolean): Config {
 }
 
 /**
+ * Toggle the optional daily team digest (opt-in, default OFF). When enabled, the
+ * digest scheduler fires one summary notification at 9:00 local. The scheduler
+ * re-reads this flag at fire time, so a toggle takes effect on the next run.
+ */
+export function updateDailyDigestEnabled(enabled: boolean): Config {
+  const config = readConfig()
+  config.dailyDigest = { enabled }
+  writeConfig(config)
+  return config
+}
+
+/**
  * Toggle an integration flag. github is always true (const true in the schema);
  * only atlassian is user-settable. DISPLAY/detection only — no token is stored.
  */

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -28,6 +28,8 @@ import { setupOrgHandlers } from './ipc/org-handlers'
 import { stopOrgAgentsRealtime } from './cloud/realtime'
 import { PRReviewWatcher } from './pr-review-watcher/watcher'
 import { setupPRReviewHandlers } from './ipc/pr-review-handlers'
+import { setupReengagementNotifications } from './notifications/reengagement'
+import { DailyDigestScheduler } from './notifications/daily-digest'
 
 let mainWindow: BrowserWindow | null = null
 let isQuitting = false
@@ -35,6 +37,7 @@ let forceQuit = false
 let trayManager: TrayManager | null = null
 let aggregator: AgentStateAggregator | null = null
 let prReviewWatcher: PRReviewWatcher | null = null
+let dailyDigest: DailyDigestScheduler | null = null
 
 function createMenu() {
   const isMac = process.platform === 'darwin'
@@ -226,6 +229,15 @@ function setupHandlers() {
     notificationCallback,
   )
   setupPRReviewHandlers(prReviewWatcher)
+
+  // Re-engagement notifications: subscribe to the org-agents realtime stream and
+  // notify when a colleague picks up a shared ticket or one of the user's PRs
+  // goes to changes-requested. Fires through the same focus-guarded callback.
+  setupReengagementNotifications(notificationCallback)
+
+  // Optional daily team digest (opt-in — Config.dailyDigest.enabled). Started
+  // unconditionally; it re-reads the flag at fire time and no-ops when disabled.
+  dailyDigest = new DailyDigestScheduler(notificationCallback)
 
   // Window control handlers
   ipcMain.handle('window:minimize', () => {
@@ -535,6 +547,14 @@ async function initializeHooksAndSessions() {
       powerMonitor.on('unlock-screen', () => prReviewWatcher?.onResume())
     }
 
+    // Start the daily digest scheduler and re-arm it on wake/unlock (a slept
+    // machine's setTimeout may be stale or overdue).
+    if (dailyDigest) {
+      dailyDigest.start()
+      powerMonitor.on('resume', () => dailyDigest?.onResume())
+      powerMonitor.on('unlock-screen', () => dailyDigest?.onResume())
+    }
+
     // Trigger initial tray state update after agents are restored
     setTimeout(() => {
       if (aggregator) aggregator.update()
@@ -568,6 +588,12 @@ app.on('before-quit', async (event) => {
   if (prReviewWatcher) {
     prReviewWatcher.stop()
     prReviewWatcher = null
+  }
+
+  // Stop the daily digest scheduler
+  if (dailyDigest) {
+    dailyDigest.stop()
+    dailyDigest = null
   }
 
   // Tear down the org-agents realtime channel

--- a/desktop/src/main/ipc/config-handlers.ts
+++ b/desktop/src/main/ipc/config-handlers.ts
@@ -22,6 +22,7 @@ import {
   updateSplitActive,
   updateLaunchMode,
   updateUsageLogsEnabled,
+  updateDailyDigestEnabled,
   setIntegration,
 } from '../config/config'
 import { getGitHubAuthStatus } from '../github'
@@ -267,6 +268,12 @@ export function setupConfigHandlers(getMainWindow: () => BrowserWindow | null) {
   // GDPR opt-in for writing usage logs (default OFF). Gates WRITING only.
   ipcMain.handle('config:setUsageLogsEnabled', async (_event, { enabled }: { enabled: boolean }) => {
     const config = updateUsageLogsEnabled(enabled)
+    return { config }
+  })
+
+  // Opt-in daily team digest (default OFF).
+  ipcMain.handle('config:setDailyDigestEnabled', async (_event, { enabled }: { enabled: boolean }) => {
+    const config = updateDailyDigestEnabled(enabled)
     return { config }
   })
 

--- a/desktop/src/main/ipc/org-handlers.ts
+++ b/desktop/src/main/ipc/org-handlers.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron'
-import type { AcceptInvitationResult } from '../cloud/org'
+import type { AcceptInvitationResult, PickUpTaskResult } from '../cloud/org'
 import type { Config, Invitation, Member, MembershipRole, Org, OrgAgent, OrgSharedConfig, RealtimeStatus, UsageStats } from '../../types'
 import { getRealtimeStatus } from '../cloud/realtime'
 import {
@@ -13,6 +13,7 @@ import {
   listOrgs,
   listOrgAgents,
   listOrgUsageStats,
+  pickUpTask,
   removeMember,
   leaveOrg,
   updateMemberRole,
@@ -26,6 +27,7 @@ interface OrgIdArgs { orgId: string }
 interface MemberArgs { orgId: string; userId: string }
 interface RoleArgs { orgId: string; userId: string; role: MembershipRole }
 interface SetSharedArgs { shared: OrgSharedConfig; orgId?: string }
+interface PickUpArgs { ticketId: string; repositories: string[] }
 
 export function setupOrgHandlers(): void {
   ipcMain.handle('org:current', async (): Promise<Org | null> => getCurrentOrg())
@@ -37,6 +39,16 @@ export function setupOrgHandlers(): void {
   ipcMain.handle('org:listAgents', async (): Promise<OrgAgent[]> => listOrgAgents())
 
   ipcMain.handle('org:getUsageStats', async (): Promise<UsageStats> => listOrgUsageStats())
+
+  // Pick up a colleague's task: resolve their repo(s) to a LOCAL configured path
+  // and hand back the cwd + `/magic:continue` prompt (renderer launches). Throws a
+  // user-facing error when nothing maps locally.
+  ipcMain.handle('org:pickUpTask', async (_event, { ticketId, repositories }: PickUpArgs): Promise<PickUpTaskResult> => {
+    if (!Array.isArray(repositories)) {
+      throw new Error('org:pickUpTask requires repositories (string[])')
+    }
+    return pickUpTask(ticketId, repositories)
+  })
 
   ipcMain.handle('org:realtimeStatus', async (): Promise<RealtimeStatus> => getRealtimeStatus())
 

--- a/desktop/src/main/notifications/daily-digest.test.ts
+++ b/desktop/src/main/notifications/daily-digest.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { msUntilNextDigest } from './daily-digest'
+
+// msUntilNextDigest is pure: given a fixed `now` it returns the number of ms
+// until the next 9:00 local boundary. Passing a fixed Date keeps the tests
+// deterministic without touching the system clock.
+const DIGEST_HOUR = 9
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+/** The local Date that lands `delay` ms after `now`. */
+const landing = (now: Date, delay: number) => new Date(now.getTime() + delay)
+
+describe('msUntilNextDigest', () => {
+  it('returns the ms until 9:00 later the same day', () => {
+    const now = new Date(2026, 6, 24, 8, 0, 0, 0) // 08:00 local
+    expect(msUntilNextDigest(now)).toBe(HOUR_MS)
+  })
+
+  it('rolls to the next day when now is exactly 9:00', () => {
+    const now = new Date(2026, 6, 24, 9, 0, 0, 0) // 09:00 local
+    expect(msUntilNextDigest(now)).toBe(DAY_MS)
+  })
+
+  it('rolls to the next day when now is past 9:00', () => {
+    const now = new Date(2026, 6, 24, 10, 30, 0, 0) // 10:30 local
+    expect(msUntilNextDigest(now)).toBe(DAY_MS - 90 * 60 * 1000)
+  })
+
+  it('is always a positive delay', () => {
+    for (const hour of [0, 8, 9, 10, 15, 23]) {
+      const now = new Date(2026, 6, 24, hour, 17, 42, 500)
+      expect(msUntilNextDigest(now)).toBeGreaterThan(0)
+    }
+  })
+
+  it('always lands exactly on a 9:00:00.000 local boundary', () => {
+    const nows = [
+      new Date(2026, 6, 24, 0, 0, 0, 0),
+      new Date(2026, 6, 24, 8, 59, 59, 500),
+      new Date(2026, 6, 24, 9, 0, 0, 1),
+      new Date(2026, 6, 24, 23, 59, 59, 999),
+      // Month/day rollover: 09:30 on the last day of a month.
+      new Date(2026, 6, 31, 9, 30, 0, 0),
+    ]
+    for (const now of nows) {
+      const at = landing(now, msUntilNextDigest(now))
+      expect(at.getHours()).toBe(DIGEST_HOUR)
+      expect(at.getMinutes()).toBe(0)
+      expect(at.getSeconds()).toBe(0)
+      expect(at.getMilliseconds()).toBe(0)
+    }
+  })
+
+  it('crosses a day boundary correctly at month end', () => {
+    const now = new Date(2026, 6, 31, 9, 30, 0, 0) // 2026-07-31 09:30 local
+    const at = landing(now, msUntilNextDigest(now))
+    expect(at.getDate()).toBe(1)
+    expect(at.getMonth()).toBe(7) // August
+    expect(at.getHours()).toBe(DIGEST_HOUR)
+  })
+})

--- a/desktop/src/main/notifications/daily-digest.ts
+++ b/desktop/src/main/notifications/daily-digest.ts
@@ -30,6 +30,10 @@ export function msUntilNextDigest(now: Date = new Date()): number {
 
 export class DailyDigestScheduler {
   private timer: ReturnType<typeof setTimeout> | null = null
+  // Once stopped (e.g. at app quit), arm() is a no-op. This prevents fire()'s
+  // finally block from resurrecting a zombie timer if stop() lands while fire()
+  // is mid-await.
+  private stopped = false
   private showNotification: (title: string, body: string) => void
 
   constructor(showNotification: (title: string, body: string) => void) {
@@ -37,10 +41,12 @@ export class DailyDigestScheduler {
   }
 
   start(): void {
+    this.stopped = false
     this.arm()
   }
 
   stop(): void {
+    this.stopped = true
     if (this.timer) {
       clearTimeout(this.timer)
       this.timer = null
@@ -53,7 +59,11 @@ export class DailyDigestScheduler {
   }
 
   private arm(): void {
-    this.stop()
+    if (this.stopped) return
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
     this.timer = setTimeout(() => {
       void this.fire()
     }, msUntilNextDigest())

--- a/desktop/src/main/notifications/daily-digest.ts
+++ b/desktop/src/main/notifications/daily-digest.ts
@@ -1,0 +1,133 @@
+import { readConfig } from '../config/config'
+import { getStore } from '../store/Store'
+
+// ---------------------------------------------------------------------------
+// Daily team digest (main process, opt-in — Config.dailyDigest.enabled).
+//
+// Fires ONE OS notification at 9:00 local summarizing the last ~24h of team
+// activity ("Yesterday your team merged N PRs and moved M tickets to Done").
+// Skips silently when nothing happened. Self-arming: computes the ms until the
+// next 9:00, sleeps, fires, then re-arms for the following day. Re-armed on
+// power resume/unlock (a suspended machine's setTimeout does not advance), so a
+// laptop that was asleep at 9:00 still gets the digest shortly after waking.
+//
+// The enabled flag is re-read from config at fire time (not cached), so toggling
+// it in Settings takes effect on the next run without restarting the scheduler.
+// ---------------------------------------------------------------------------
+
+const DIGEST_HOUR = 9
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** Milliseconds from `now` until the next occurrence of DIGEST_HOUR:00 local. */
+export function msUntilNextDigest(now: Date = new Date()): number {
+  const next = new Date(now)
+  next.setHours(DIGEST_HOUR, 0, 0, 0)
+  if (next.getTime() <= now.getTime()) {
+    next.setDate(next.getDate() + 1)
+  }
+  return next.getTime() - now.getTime()
+}
+
+export class DailyDigestScheduler {
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private showNotification: (title: string, body: string) => void
+
+  constructor(showNotification: (title: string, body: string) => void) {
+    this.showNotification = showNotification
+  }
+
+  start(): void {
+    this.arm()
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  /** Re-arm on wake/unlock (a slept timer may be stale or overdue). */
+  onResume(): void {
+    this.arm()
+  }
+
+  private arm(): void {
+    this.stop()
+    this.timer = setTimeout(() => {
+      void this.fire()
+    }, msUntilNextDigest())
+  }
+
+  private async fire(): Promise<void> {
+    try {
+      if (readConfig().dailyDigest?.enabled !== true) return
+      const summary = await this.composeSummary()
+      if (summary) {
+        this.showNotification('Your team yesterday', summary)
+      }
+    } catch (error) {
+      console.error('[daily-digest] failed to compose/fire digest:', error)
+    } finally {
+      // Always re-arm for the next day, even after an error/skip.
+      this.arm()
+    }
+  }
+
+  /**
+   * Build the digest string from genuine TEAM-WIDE data available in the main
+   * process — NOT the local user's activity history. The org agents roster
+   * (loadOrgAgents: RLS-scoped to the org, so every member's agents) yields the
+   * merged-PR count (metadata.repositoryMetadata.prMerged, synced org-wide by the
+   * PR-review watcher → OrgAgent.prReviews[].merged) and the tickets-moved-to-Done
+   * count (the "Done" workflow column is agent status 'PR merged'). Org usage
+   * stats (loadOrgUsageStats, already org-wide) yield the sessions count. Only
+   * agents touched within the last ~24h are counted, so "Yesterday your team…"
+   * stays honest. Returns null when nothing happened (so we never fire an empty
+   * "0 PRs, 0 tickets").
+   */
+  private async composeSummary(): Promise<string | null> {
+    const since = Date.now() - DAY_MS
+
+    let mergedPRs = 0
+    let ticketsDone = 0
+    try {
+      const orgAgents = await getStore().loadOrgAgents()
+      for (const agent of orgAgents) {
+        // Scope to the digest window via the row's last-write timestamp; an agent
+        // with no/older updatedAt is stale roster state, not "yesterday".
+        const touched = agent.updatedAt ? Date.parse(agent.updatedAt) : NaN
+        if (!Number.isFinite(touched) || touched < since) continue
+        // Merged PRs: count every repo whose PR was merged across the team.
+        mergedPRs += agent.prReviews?.filter((r) => r.merged === true).length ?? 0
+        // Tickets moved to Done: the "Done" workflow column is status 'PR merged'.
+        if (agent.status === 'PR merged') ticketsDone += 1
+      }
+    } catch {
+      /* org roster is best-effort — a failure just yields 0 merged/done */
+    }
+
+    let sessions = 0
+    try {
+      const stats = await getStore().loadOrgUsageStats()
+      sessions = stats.rows.filter((r) => Date.parse(r.occurredAt) >= since).length
+    } catch {
+      /* usage is best-effort — a failure just omits the sessions clause */
+    }
+
+    if (mergedPRs === 0 && ticketsDone === 0 && sessions === 0) return null
+
+    const parts: string[] = []
+    if (mergedPRs > 0) parts.push(`shipped ${mergedPRs} PR${mergedPRs === 1 ? '' : 's'}`)
+    if (ticketsDone > 0) parts.push(`moved ${ticketsDone} ticket${ticketsDone === 1 ? '' : 's'} to Done`)
+    if (sessions > 0) parts.push(`ran ${sessions} session${sessions === 1 ? '' : 's'}`)
+
+    return `Yesterday your team ${joinParts(parts)}.`
+  }
+}
+
+/** "a", "a and b", "a, b and c". */
+function joinParts(parts: string[]): string {
+  if (parts.length <= 1) return parts[0] ?? ''
+  return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`
+}

--- a/desktop/src/main/notifications/reengagement.ts
+++ b/desktop/src/main/notifications/reengagement.ts
@@ -1,0 +1,120 @@
+import type { OrgAgent, OrgAgentChange } from '../../types'
+import { addOrgAgentChangeListener } from '../cloud/realtime'
+import { loadSession } from '../cloud/session-store'
+import { getStore } from '../store/Store'
+
+// ---------------------------------------------------------------------------
+// Re-engagement notifications (main process).
+//
+// Subscribes to the org-agents realtime stream (via the fan-out listener added
+// in cloud/realtime) and surfaces two OS notifications designed to bring the
+// user back into the app — the "no daily trigger" adoption blocker (#128):
+//
+//   (a) a colleague picked up a ticket the current user also has an agent for;
+//   (b) one of the current user's own PRs went to changes-requested.
+//
+// Both fire through the shared notificationCallback (which already guards on
+// !window.isFocused and wires click → focus), with a per-key 5-minute cooldown
+// mirroring the PRReviewWatcher. We deliberately do NOT attempt GitHub-login-
+// targeted "your review" notifications — there is no GH-identity mapping.
+// ---------------------------------------------------------------------------
+
+const COOLDOWN_MS = 5 * 60 * 1000
+
+export function setupReengagementNotifications(
+  showNotification: (title: string, body: string) => void,
+): () => void {
+  // owner_id (auth.users id) of the signed-in user. Re-read on every event so a
+  // sign-out / different user is picked up without re-wiring.
+  let myId: string | undefined = loadSession()?.user?.id
+  // Latest known roster keyed by DB row uuid, so we can (1) know which tickets
+  // the current user owns and (2) detect transitions (e.g. → changes-requested).
+  const roster = new Map<string, OrgAgent>()
+  const lastNotifiedAt = new Map<string, number>()
+  let seeded = false
+  let seeding = false
+
+  const cooldownOk = (key: string): boolean => {
+    const now = Date.now()
+    const last = lastNotifiedAt.get(key) ?? 0
+    if (now - last < COOLDOWN_MS) return false
+    lastNotifiedAt.set(key, now)
+    return true
+  }
+
+  // Seed the roster once from the store so "a colleague picked up MY ticket" can
+  // match the current user's existing agents even if they never emit a change.
+  // Best-effort: retried on the first realtime event if it returned empty (the
+  // backend may not be authed/hydrated yet at wiring time).
+  const ensureSeeded = async (): Promise<void> => {
+    // `seeding` guards against an event burst on realtime connect each firing its
+    // own concurrent (fire-and-forget) load before the first resolves.
+    if (seeded || seeding) return
+    seeding = true
+    try {
+      const agents = await getStore().loadOrgAgents()
+      for (const a of agents) if (!roster.has(a.id)) roster.set(a.id, a)
+      if (agents.length > 0) seeded = true
+    } catch {
+      /* keep seeded=false so a later event retries */
+    } finally {
+      seeding = false
+    }
+  }
+  void ensureSeeded()
+
+  const ownsTicket = (ticketId: string, exceptRowId: string): boolean => {
+    for (const a of roster.values()) {
+      if (a.id === exceptRowId) continue
+      if (a.ownerId === myId && a.ticketId === ticketId) return true
+    }
+    return false
+  }
+
+  const unsubscribe = addOrgAgentChangeListener((change: OrgAgentChange) => {
+    myId = loadSession()?.user?.id ?? myId
+    void ensureSeeded()
+    if (!myId) return
+
+    const prev = roster.get(change.id)
+
+    if (change.eventType === 'DELETE') {
+      roster.delete(change.id)
+      return
+    }
+
+    const agent = change.agent
+    if (!agent) return
+    roster.set(agent.id, agent)
+
+    // (a) A colleague picked up a ticket the current user is also on.
+    if (agent.ownerId && agent.ownerId !== myId && agent.ticketId && ownsTicket(agent.ticketId, agent.id)) {
+      const isNewPickup = !prev || prev.ownerId !== agent.ownerId || prev.ticketId !== agent.ticketId
+      if (isNewPickup && cooldownOk(`pickup:${agent.ticketId}:${agent.ownerId}`)) {
+        showNotification(
+          `A colleague picked up ${agent.ticketId}`,
+          `A teammate is now working on ${agent.ticketId} — you also have an agent on it.`,
+        )
+      }
+    }
+
+    // (b) One of the current user's own PRs transitioned to changes-requested.
+    if (agent.ownerId === myId && agent.prReviews) {
+      for (const review of agent.prReviews) {
+        if (review.status !== 'changes-requested') continue
+        const wasAlreadyChanges = prev?.prReviews?.some(
+          (p) => p.repo === review.repo && p.status === 'changes-requested',
+        )
+        if (wasAlreadyChanges) continue
+        if (cooldownOk(`changes:${review.prUrl ?? review.repo}`)) {
+          showNotification(
+            'Changes requested on your PR',
+            `${agent.ticketId ?? agent.name}: a reviewer requested changes.`,
+          )
+        }
+      }
+    }
+  })
+
+  return unsubscribe
+}

--- a/desktop/src/main/notifications/reengagement.ts
+++ b/desktop/src/main/notifications/reengagement.ts
@@ -72,7 +72,10 @@ export function setupReengagementNotifications(
   }
 
   const unsubscribe = addOrgAgentChangeListener((change: OrgAgentChange) => {
-    myId = loadSession()?.user?.id ?? myId
+    // Re-read per event, letting myId go undefined on sign-out (the !myId guard
+    // below then short-circuits) — no stale fallback that would keep firing
+    // under the former identity while the channel is briefly still connected.
+    myId = loadSession()?.user?.id
     void ensureSeeded()
     if (!myId) return
 

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -56,6 +56,8 @@ const configApi = {
     ipcRenderer.invoke('config:setUsageCardMinimized', { minimized }),
   setUsageLogsEnabled: (enabled: boolean): Promise<{ config: Config }> =>
     ipcRenderer.invoke('config:setUsageLogsEnabled', { enabled }),
+  setDailyDigestEnabled: (enabled: boolean): Promise<{ config: Config }> =>
+    ipcRenderer.invoke('config:setDailyDigestEnabled', { enabled }),
 
   updateSplitEnabled: (enabled: boolean) =>
     ipcRenderer.invoke('config:updateSplitEnabled', { enabled }),
@@ -460,6 +462,10 @@ const orgApi = {
   listAgents: (): Promise<OrgAgent[]> => ipcRenderer.invoke('org:listAgents'),
   // Team dashboard: org-wide usage stats (read is open to any member).
   getUsageStats: (): Promise<UsageStats> => ipcRenderer.invoke('org:getUsageStats'),
+  // Team dashboard: pick up a colleague's task. Resolves their repo(s) to a LOCAL
+  // configured path; rejects when nothing maps locally. Renderer then launches.
+  pickUpTask: (ticketId: string, repositories: string[]): Promise<{ cwd: string; initialPrompt: string }> =>
+    ipcRenderer.invoke('org:pickUpTask', { ticketId, repositories }),
   getRealtimeStatus: (): Promise<RealtimeStatus> => ipcRenderer.invoke('org:realtimeStatus'),
   onAgentsChanged: (callback: (change: OrgAgentChange) => void) => {
     const listener = (_event: IpcRendererEvent, change: OrgAgentChange) => callback(change)

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -4,6 +4,7 @@ import type { InvalidRepo } from '../preload'
 import { useStore } from './store'
 import { useConfig } from './hooks/useConfig'
 import { useTerminals } from './hooks/useTerminals'
+import { useAuth } from './hooks/useAuth'
 import { TitleBar } from './components/TitleBar'
 import { Sidebar } from './components/Sidebar'
 import { AgentInfoSidebar } from './components/AgentInfoSidebar'
@@ -52,10 +53,26 @@ export function App() {
   const { currentPage, closeAgentModal, closeCloseAgentModal, terminals, activeTerminalId, toggleRightSidebar, toggleLeftSidebar, toggleSplitActive, isWideScreen, splitEnabled, config, noReposWarningShown, setNoReposWarningShown, setCurrentPage } = useStore()
   const { configLoading, configError, loadConfig } = useConfig()
   const { killTerminal, launchClaudeTerminal } = useTerminals()
+  const { status: authStatus } = useAuth()
   useWindowSplitMode()
   const confirmCloseButtonRef = useRef<HTMLButtonElement>(null)
   const [showNoReposModal, setShowNoReposModal] = useState(false)
   const [showProfileWizard, setShowProfileWizard] = useState(false)
+  const didLandRef = useRef(false)
+
+  // Landing page: when cloud is enabled AND the user is logged in, open on the
+  // team dashboard (the #128 "daily trigger" adoption hook). Runs once, only
+  // while still on the default 'terminals' page, so it never overrides a user's
+  // own navigation and never strands a logged-out user on an empty dashboard.
+  useEffect(() => {
+    if (didLandRef.current) return
+    if (authStatus.enabled && authStatus.loggedIn) {
+      didLandRef.current = true
+      if (useStore.getState().currentPage === 'terminals') {
+        setCurrentPage('dashboard')
+      }
+    }
+  }, [authStatus.enabled, authStatus.loggedIn, setCurrentPage])
 
   // Check if user profile exists on mount
   useEffect(() => {

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, Fragment } from 'react'
-import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, GitPullRequest, History, Gauge, User, Coins, BarChart3 } from 'lucide-react'
+import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, GitPullRequest, History, Gauge, User, Coins, BarChart3, Bell } from 'lucide-react'
 import { ProfileSection } from './ProfileSection'
 import { RepoPage } from './RepoPage'
 import { OrgPage } from './OrgPage'
@@ -84,6 +84,7 @@ function WelcomePage() {
   const [historyEnabled, setHistoryEnabled] = useState(config?.historyEnabled ?? true)
   const [usageCardEnabled, setUsageCardEnabled] = useState(config?.usageCardEnabled ?? false)
   const [usageLogsEnabled, setUsageLogsEnabled] = useState(config?.usageLogsEnabled ?? false)
+  const [dailyDigestEnabled, setDailyDigestEnabled] = useState(config?.dailyDigest?.enabled ?? false)
   const [prWatcherEnabled, setPrWatcherEnabled] = useState(config?.prReviews?.enabled ?? true)
   const [prWatcherInterval, setPrWatcherInterval] = useState(config?.prReviews?.pollIntervalMs ?? 60_000)
   const [prWatcherAutoLaunch, setPrWatcherAutoLaunch] = useState(config?.prReviews?.autoLaunchSkills ?? false)
@@ -114,6 +115,11 @@ function WelcomePage() {
   useEffect(() => {
     if (configUsageLogsEnabled !== undefined) setUsageLogsEnabled(configUsageLogsEnabled)
   }, [configUsageLogsEnabled])
+
+  const configDailyDigestEnabled = config?.dailyDigest?.enabled
+  useEffect(() => {
+    if (configDailyDigestEnabled !== undefined) setDailyDigestEnabled(configDailyDigestEnabled)
+  }, [configDailyDigestEnabled])
 
   const configPrWatcherEnabled = config?.prReviews?.enabled
   const configPrWatcherInterval = config?.prReviews?.pollIntervalMs
@@ -577,6 +583,39 @@ function WelcomePage() {
             >
               <div className={`absolute top-[3px] left-[3px] w-4 h-4 rounded-full bg-white transition-transform duration-200 ${
                 usageLogsEnabled ? 'translate-x-[18px]' : 'translate-x-0'
+              }`} />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Daily Digest Section (opt-in — off by default) */}
+      <div>
+        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
+          <Bell className="w-4 h-4" />
+          <span>Daily digest</span>
+        </div>
+        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <div className="text-sm font-medium">Daily team digest</div>
+              <div className="text-xs text-text-secondary/50 mt-0.5">
+                Off by default. When enabled, you get one notification at 9:00 AM summarizing your team's activity from the last 24 hours (PRs shipped, tickets moved to Done). Nothing is sent when there was no activity.
+              </div>
+            </div>
+            <button
+              onClick={async () => {
+                const newValue = !dailyDigestEnabled
+                setDailyDigestEnabled(newValue)
+                const result = await window.electronAPI.config.setDailyDigestEnabled(newValue)
+                setConfig(result.config)
+              }}
+              className={`relative w-10 h-[22px] rounded-full transition-colors duration-200 flex-shrink-0 ${
+                dailyDigestEnabled ? 'bg-accent' : 'bg-white/20'
+              }`}
+            >
+              <div className={`absolute top-[3px] left-[3px] w-4 h-4 rounded-full bg-white transition-transform duration-200 ${
+                dailyDigestEnabled ? 'translate-x-[18px]' : 'translate-x-0'
               }`} />
             </button>
           </div>

--- a/desktop/src/renderer/pages/Dashboard/index.tsx
+++ b/desktop/src/renderer/pages/Dashboard/index.tsx
@@ -1,10 +1,14 @@
-import { useMemo } from 'react'
-import { Users, Bot, Coins, Plus, Minus, Clock, Activity, BarChart3 } from 'lucide-react'
-import type { OrgAgent } from '../../../types'
+import { useMemo, useState } from 'react'
+import { Users, Bot, Coins, Plus, Minus, Clock, Activity, BarChart3, GitPullRequest, AlertOctagon, ExternalLink, ArrowRightCircle } from 'lucide-react'
+import type { OrgAgent, OrgAgentPRReview } from '../../../types'
 import { useOrgAgents } from '../../hooks/useOrgAgents'
 import { useOrgUsageStats } from '../../hooks/useOrgUsageStats'
 import { useOrg } from '../../hooks/useOrg'
+import { useAuth } from '../../hooks/useAuth'
+import { useTerminals } from '../../hooks/useTerminals'
+import { useStore } from '../../store'
 import { LiveIndicator } from '../../components/LiveIndicator'
+import { showToast } from '../../components/Toast'
 import { ActivityHeatmap } from '../History/ActivityHeatmap'
 import { aggregateUsageTotals, aggregateUsageByMember, computeUsageHeatmap, formatUsd } from '../../utils/usageStats'
 
@@ -133,6 +137,41 @@ function StatusPill({ status }: { status?: string }) {
   )
 }
 
+// PR review status → label + badge color for the "awaiting review" widget.
+const PR_STATUS_CONFIG: Record<NonNullable<OrgAgentPRReview['status']>, { label: string; className: string }> = {
+  pending:              { label: 'Awaiting review',    className: 'bg-blue/15 text-blue' },
+  commented:            { label: 'Commented',          className: 'bg-purple/15 text-purple' },
+  'changes-requested':  { label: 'Changes requested',  className: 'bg-red/15 text-red' },
+  approved:             { label: 'Approved',           className: 'bg-green/15 text-green' },
+}
+
+// "Awaiting review" = a live PR (not merged/closed) whose review is still open.
+const AWAITING_REVIEW_STATUSES: ReadonlySet<string> = new Set(['pending', 'commented', 'changes-requested'])
+// Workflow statuses that mean the author is blocked / must act next.
+const BLOCKED_STATUSES: ReadonlySet<string> = new Set(['changes requested'])
+
+interface ReviewItem {
+  agent: OrgAgent
+  review: OrgAgentPRReview
+}
+
+function collectAwaitingReview(agents: OrgAgent[]): ReviewItem[] {
+  const items: ReviewItem[] = []
+  for (const agent of agents) {
+    for (const review of agent.prReviews ?? []) {
+      if (review.merged || review.closed) continue
+      if (review.status && AWAITING_REVIEW_STATUSES.has(review.status)) {
+        items.push({ agent, review })
+      }
+    }
+  }
+  return items
+}
+
+function collectBlocked(agents: OrgAgent[]): OrgAgent[] {
+  return agents.filter((a) => a.status && BLOCKED_STATUSES.has(a.status))
+}
+
 function RepoTag({ repo }: { repo: string }) {
   const name = repo.split('/').pop() ?? repo
   return (
@@ -142,18 +181,37 @@ function RepoTag({ repo }: { repo: string }) {
   )
 }
 
-function AgentRow({ agent }: { agent: OrgAgent }) {
+function TicketBadge({ ticketId }: { ticketId?: string }) {
+  if (!ticketId) return null
+  return (
+    <span className="text-xs text-accent/80 bg-accent/10 px-2 py-0.5 rounded flex-shrink-0">
+      {ticketId}
+    </span>
+  )
+}
+
+function AgentRow({
+  agent,
+  currentUserId,
+  onPickUp,
+  pickingUp,
+}: {
+  agent: OrgAgent
+  currentUserId?: string
+  onPickUp?: (agent: OrgAgent) => void
+  pickingUp?: boolean
+}) {
+  // "Pick up" only makes sense for a teammate's ticketed agent (never your own).
+  const canPickUp =
+    !!onPickUp && !!agent.ticketId && !!agent.ownerId && agent.ownerId !== currentUserId
+
   return (
     <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-white/[0.04] border border-white/[0.08] min-w-0">
       <Bot className="w-4 h-4 text-text-secondary/60 flex-shrink-0" />
       <span className="text-sm font-medium text-white truncate min-w-0 flex-1">
         {agent.name}
       </span>
-      {agent.ticketId && (
-        <span className="text-xs text-accent/80 bg-accent/10 px-2 py-0.5 rounded flex-shrink-0">
-          {agent.ticketId}
-        </span>
-      )}
+      <TicketBadge ticketId={agent.ticketId} />
       {agent.repositories.slice(0, 2).map((repo) => (
         <RepoTag key={repo} repo={repo} />
       ))}
@@ -161,6 +219,101 @@ function AgentRow({ agent }: { agent: OrgAgent }) {
         <span className="text-xs text-text-secondary/40 flex-shrink-0">+{agent.repositories.length - 2}</span>
       )}
       <StatusPill status={agent.status} />
+      {canPickUp && (
+        <button
+          onClick={() => onPickUp!(agent)}
+          disabled={pickingUp}
+          title={`Launch a local agent on ${agent.ticketId} with /magic:continue`}
+          className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-accent bg-accent/10 border border-accent/20 rounded-lg hover:bg-accent/20 transition-colors flex-shrink-0 disabled:opacity-50"
+        >
+          <ArrowRightCircle className="w-3.5 h-3.5" />
+          <span>{pickingUp ? 'Picking up…' : 'Pick up'}</span>
+        </button>
+      )}
+    </div>
+  )
+}
+
+function OwnerLabel({ agent, emailByOwner }: { agent: OrgAgent; emailByOwner: Map<string, string> }) {
+  const label = agent.ownerId ? emailByOwner.get(agent.ownerId) ?? agent.ownerId : 'Unassigned'
+  return <span className="text-xs text-text-secondary/60 truncate">{label}</span>
+}
+
+/** "PRs awaiting review": teammates' live PRs whose review is still open. */
+function AwaitingReviewSection({ items, emailByOwner }: { items: ReviewItem[]; emailByOwner: Map<string, string> }) {
+  if (items.length === 0) return null
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
+        <GitPullRequest className="w-4 h-4" />
+        <span>PRs awaiting review</span>
+        <span className="text-xs text-text-secondary/50">{items.length}</span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {items.map(({ agent, review }) => {
+          const pr = review.status ? PR_STATUS_CONFIG[review.status] : undefined
+          return (
+            <div
+              key={`${agent.id}:${review.repo}`}
+              className="flex items-center gap-3 px-4 py-3 rounded-lg bg-white/[0.04] border border-white/[0.08] min-w-0"
+            >
+              <GitPullRequest className="w-4 h-4 text-purple flex-shrink-0" />
+              <div className="flex flex-col min-w-0 flex-1">
+                <span className="text-sm font-medium text-white truncate">{agent.name}</span>
+                <OwnerLabel agent={agent} emailByOwner={emailByOwner} />
+              </div>
+              <TicketBadge ticketId={agent.ticketId} />
+              <RepoTag repo={review.repo} />
+              {pr && (
+                <span className={`text-xs px-2 py-0.5 rounded-full flex-shrink-0 ${pr.className}`}>{pr.label}</span>
+              )}
+              {review.prUrl && (
+                <button
+                  onClick={() => review.prUrl && window.electronAPI.shell.openExternal(review.prUrl)}
+                  title="Open the pull request"
+                  className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-colors flex-shrink-0"
+                >
+                  <ExternalLink className="w-3.5 h-3.5" />
+                  <span>View PR</span>
+                </button>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/** "Blocked": agents whose workflow status means the author must act next. */
+function BlockedSection({ agents, emailByOwner }: { agents: OrgAgent[]; emailByOwner: Map<string, string> }) {
+  if (agents.length === 0) return null
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
+        <AlertOctagon className="w-4 h-4" />
+        <span>Blocked</span>
+        <span className="text-xs text-text-secondary/50">{agents.length}</span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {agents.map((agent) => (
+          <div
+            key={agent.id}
+            className="flex items-center gap-3 px-4 py-3 rounded-lg bg-red/[0.04] border border-red/[0.12] min-w-0"
+          >
+            <AlertOctagon className="w-4 h-4 text-red flex-shrink-0" />
+            <div className="flex flex-col min-w-0 flex-1">
+              <span className="text-sm font-medium text-white truncate">{agent.name}</span>
+              <OwnerLabel agent={agent} emailByOwner={emailByOwner} />
+            </div>
+            <TicketBadge ticketId={agent.ticketId} />
+            {agent.repositories.slice(0, 2).map((repo) => (
+              <RepoTag key={repo} repo={repo} />
+            ))}
+            <StatusPill status={agent.status} />
+          </div>
+        ))}
+      </div>
     </div>
   )
 }
@@ -174,6 +327,11 @@ interface MemberGroup {
 export function DashboardPage() {
   const { agents, loading } = useOrgAgents()
   const { members } = useOrg()
+  const { status: authStatus } = useAuth()
+  const { launchClaudeTerminal, terminals } = useTerminals()
+  const setCurrentPage = useStore((s) => s.setCurrentPage)
+  const [pickingUpId, setPickingUpId] = useState<string | null>(null)
+  const currentUserId = authStatus.user?.id
 
   // owner_id → email, so agents can be grouped under a readable member label.
   const emailByOwner = useMemo(() => {
@@ -183,6 +341,27 @@ export function DashboardPage() {
     }
     return map
   }, [members])
+
+  const awaitingReview = useMemo(() => collectAwaitingReview(agents), [agents])
+  const blocked = useMemo(() => collectBlocked(agents), [agents])
+
+  // Pick up a colleague's task: resolve their repo(s) to a local cwd (main), then
+  // launch a fresh local agent with /magic:continue to resume the ticket.
+  const handlePickUp = async (agent: OrgAgent) => {
+    if (!agent.ticketId) return
+    setPickingUpId(agent.id)
+    try {
+      const { cwd, initialPrompt } = await window.electronAPI.org.pickUpTask(agent.ticketId, agent.repositories)
+      const name = `Claude ${terminals.length + 1}`
+      await launchClaudeTerminal(name, cwd, initialPrompt)
+      setCurrentPage('terminals')
+      showToast(`Picked up ${agent.ticketId}`, 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to pick up task', 'error')
+    } finally {
+      setPickingUpId(null)
+    }
+  }
 
   // Group agents by owner (unassigned/unknown owners fall into a trailing group).
   const groups: MemberGroup[] = useMemo(() => {
@@ -227,8 +406,12 @@ export function DashboardPage() {
         <LiveIndicator />
       </div>
 
-      {/* Body — usage stats + active agents share one scroll container */}
+      {/* Body — attention widgets + usage stats + active agents share one scroll container */}
       <div className="flex-1 overflow-auto flex flex-col gap-8">
+        {/* Attention hooks: PRs awaiting review + blocked work (hidden when empty) */}
+        <AwaitingReviewSection items={awaitingReview} emailByOwner={emailByOwner} />
+        <BlockedSection agents={blocked} emailByOwner={emailByOwner} />
+
         {/* Org usage stats (read is open to any member) */}
         <UsageStatsSection />
 
@@ -257,7 +440,13 @@ export function DashboardPage() {
                   </div>
                   <div className="flex flex-col gap-2">
                     {group.agents.map((agent) => (
-                      <AgentRow key={agent.id} agent={agent} />
+                      <AgentRow
+                        key={agent.id}
+                        agent={agent}
+                        currentUserId={currentUserId}
+                        onPickUp={handlePickUp}
+                        pickingUp={pickingUpId === agent.id}
+                      />
                     ))}
                   </div>
                 </div>

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -162,6 +162,11 @@ export interface Config {
     pollIntervalMs?: number
     autoLaunchSkills?: boolean
   }
+  // Optional daily team digest (opt-in, default OFF): a single OS notification at
+  // 9:00 local summarizing yesterday's team activity (merged PRs / tickets done).
+  dailyDigest?: {
+    enabled: boolean
+  }
   // Cloud: the org the local install is currently associated with (set after
   // signing up / accepting an invitation). Purely a local hint — never required.
   currentOrgId?: string
@@ -221,6 +226,22 @@ export interface Member {
 // row uuid (NOT the app-level metadata.__app.id). It is READ-ONLY — it never
 // feeds the local terminal-restoration cache.
 // ---------------------------------------------------------------------------
+/**
+ * Compact per-repository PR review summary for a teammate's agent, sourced from
+ * the agent row's metadata.repositoryMetadata (already synced org-wide by the
+ * PRReviewWatcher). Read-only; surfaced on the team dashboard so "awaiting
+ * review" / "blocked" work is visible without opening each agent.
+ */
+export interface OrgAgentPRReview {
+  /** Repository path key from repositoryMetadata (owner's local path). */
+  repo: string
+  prUrl?: string
+  status?: RepositoryMetadata['prReviewStatus']
+  reviewers?: string[]
+  merged?: boolean
+  closed?: boolean
+}
+
 export interface OrgAgent {
   /** The `agents` table row id (uuid). Reconcile realtime events by this. */
   id: string
@@ -232,6 +253,8 @@ export interface OrgAgent {
   ticketId?: string
   status?: string
   repositories: string[]
+  /** PR review state per repo, distilled from metadata.repositoryMetadata. */
+  prReviews?: OrgAgentPRReview[]
   /** ISO timestamp of the last write (agents.updated_at). */
   updatedAt?: string
 }

--- a/install/config-schema.json
+++ b/install/config-schema.json
@@ -83,6 +83,17 @@
     "currentOrgId": {
       "type": "string",
       "description": "Cloud org this install is associated with (optional local hint)"
+    },
+    "dailyDigest": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"],
+      "additionalProperties": false,
+      "description": "Optional daily team digest notification (opt-in, off by default)"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Description

Turns the desktop app into a daily adoption hook (epic #121, Cloud PR 6). The existing Team dashboard becomes the landing page (only when cloud is enabled and the user is logged in) and gains real-time "PRs awaiting review" and "Blocked" widgets aggregated from the org roster — PR review status is already synced org-wide in `agents.metadata`, so no DB migration was needed. Tray re-engagement OS notifications bring the user back into the app, an opt-in daily digest summarizes team activity, and a "Pick up" action lets you resume a colleague's task in the matching local repo.

## Related Issue

Closes #128

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **Team dashboard**: added "PRs awaiting review" and "Blocked" widgets to `pages/Dashboard/index.tsx` (hidden when empty) and a per-row "Pick up" action; land on the dashboard once at startup when cloud is enabled and logged in (`App.tsx`).
- **Org data plumbing**: extended `OrgAgent` with `prReviews` (`types.ts`) and distilled it from `metadata.repositoryMetadata` in `mapOrgAgentRow` (`cloud/realtime.ts`) — covers both the realtime and store paths, no DB migration.
- **Re-engagement notifications**: new `main/notifications/reengagement.ts` observing the org roster via a new multi-listener fan-out in `realtime.ts`; fires when a colleague picks up a ticket you own or when your PR goes to changes-requested (focus-guarded, 5-min cooldown, click-to-focus, reusing the shared notification callback).
- **Daily digest**: new `main/notifications/daily-digest.ts` self-arming 9:00-local scheduler (re-armed on `powerMonitor` resume/unlock), sourcing genuine team-wide counts (merged PRs, tickets to Done, sessions) from the org roster + usage stats; opt-in via a new `Config.dailyDigest` flag with a Settings › Features toggle.
- **Pick up a colleague's task**: `org.ts pickUpTask` resolves the colleague's repo to a local configured path and returns a `/magic:continue <ticket>` launch context; wired via `org:pickUpTask` IPC + preload bridge.
- **Wiring**: handler registration in `index.ts`/`setupHandlers`, preload domain methods, `config:setDailyDigestEnabled`, and `install/config-schema.json`.
- **Tests**: new `org.test.ts`, `daily-digest.test.ts` and extended `realtime.test.ts` (34 cases across the new pure logic).

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [x] Tested affected slash commands

### Test Steps

1. `cd desktop && nvm use && npm run dev`, then sign in with cloud enabled — you should land directly on the **Team** dashboard (not the terminals view). Sign out / disable cloud and relaunch: you should land on terminals instead (no empty dashboard).
2. With teammates' agents present in the org, confirm the **PRs awaiting review** and **Blocked** sections show the expected agents in real time, and that both sections disappear when there is nothing to show.
3. On a teammate's agent that has a ticket, click **Pick up** → a terminal opens in your matching local repo prefilled with `/magic:continue <ticket>`; on an agent whose repo has no local match, confirm you get a clear error toast instead of a broken launch.
4. In **Settings › Features**, toggle **Daily digest** on/off and confirm the setting persists across relaunch.
5. Run the suite from the repo root: `npm test` → 262/262 pass (includes the new `org.test.ts`, `daily-digest.test.ts`, and extended `realtime.test.ts`).

## Screenshots

_N/A — see Test Steps to view the dashboard widgets and Settings toggle locally._

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

- The literal "a teammate's PR needs **your** review" notification from the ticket is intentionally not implemented: there is no Supabase→GitHub identity mapping, so it would be false-positive-prone. The robust substitute (your PR → changes-requested) ships instead; "awaiting review" still surfaces visually on the dashboard.
- Daily-digest counts are best-effort, derived from org agents whose `updatedAt` falls in the last ~24h, so they are approximate.
- Follow-up opportunity: unit tests for `reengagement.ts` and the digest's `composeSummary` (pure helpers are covered; these two modules are not yet).