### PR TITLE
feat: bridge cloud config/metadata to terminal skills

### DIFF
--- a/desktop/src/main/hooks/status-server.test.ts
+++ b/desktop/src/main/hooks/status-server.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from 'vitest'
-import { parseStatusLinePayload } from './status-server'
+import * as http from 'http'
+import { afterAll, beforeAll, describe, it, expect } from 'vitest'
+import {
+  parseStatusLinePayload,
+  startStatusServer,
+  stopStatusServer,
+  getServerPort,
+  setConfigProvider,
+  setAgentProvider,
+  setWorktreeFilesWriter,
+} from './status-server'
 
 describe('parseStatusLinePayload', () => {
   const fullPayload = JSON.stringify({
@@ -85,5 +94,62 @@ describe('parseStatusLinePayload', () => {
     expect(usage.model).toBeUndefined()
     expect(usage.costUsd).toBeUndefined()
     expect(usage.contextPercent).toBeUndefined()
+  })
+})
+
+describe('read-back endpoints', () => {
+  const httpGet = (path: string): Promise<{ status: number; body: string }> =>
+    new Promise((resolve, reject) => {
+      http
+        .get(`http://127.0.0.1:${getServerPort()}${path}`, (res) => {
+          const chunks: Buffer[] = []
+          res.on('data', (c: Buffer) => chunks.push(c))
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf-8') }))
+        })
+        .on('error', reject)
+    })
+
+  beforeAll(async () => {
+    await startStatusServer()
+  })
+
+  afterAll(async () => {
+    await stopStatusServer()
+  })
+
+  it('GET /config returns the provider config as JSON', async () => {
+    setConfigProvider(() => ({ version: '1.0.0', repositories: { api: { path: '/tmp/api', keywords: ['api'] } } }))
+    const { status, body } = await httpGet('/config')
+    expect(status).toBe(200)
+    expect(JSON.parse(body)).toEqual({ version: '1.0.0', repositories: { api: { path: '/tmp/api', keywords: ['api'] } } })
+  })
+
+  it('GET /config returns {} when no provider is set to a throwing value', async () => {
+    setConfigProvider(() => {
+      throw new Error('boom')
+    })
+    const { status, body } = await httpGet('/config')
+    expect(status).toBe(200)
+    expect(body).toBe('{}')
+  })
+
+  it('GET /agent returns the metadata for the given terminal id', async () => {
+    setAgentProvider((id) => (id === 'term-1' ? { id, metadata: { ticketId: 'PROJ-9' } } : null))
+    const found = await httpGet('/agent?id=term-1')
+    expect(JSON.parse(found.body)).toEqual({ id: 'term-1', metadata: { ticketId: 'PROJ-9' } })
+    const missing = await httpGet('/agent?id=nope')
+    expect(missing.body).toBe('null')
+  })
+
+  it('GET /config/worktree-files forwards repo + parsed files to the writer', async () => {
+    let received: { repo: string; files: string[] } | null = null
+    setWorktreeFilesWriter((repo, files) => {
+      received = { repo, files }
+    })
+    const files = encodeURIComponent(JSON.stringify(['.env', '.npmrc', 42]))
+    const { status } = await httpGet(`/config/worktree-files?repo=api&files=${files}`)
+    expect(status).toBe(200)
+    // Non-string entries (42) are filtered out before reaching the writer.
+    expect(received).toEqual({ repo: 'api', files: ['.env', '.npmrc'] })
   })
 })

--- a/desktop/src/main/hooks/status-server.ts
+++ b/desktop/src/main/hooks/status-server.ts
@@ -8,6 +8,12 @@ type CommandStartCallback = (terminalId: string, command: string) => void
 type CommandEndCallback = (terminalId: string, exitCode: number) => void
 type RepositoriesCallback = (terminalId: string, repositories: string[]) => void
 type UsageCallback = (terminalId: string, usage: TerminalUsage) => void
+// Read-back providers: unlike the callbacks above (terminal → app writes), these let a
+// terminal-run skill READ from the app's in-memory caches (hydrated from the cloud store).
+// Loosely typed on purpose — the values are just JSON-serialized to the response.
+type ConfigProvider = () => unknown
+type AgentProvider = (terminalId: string) => unknown
+type WorktreeFilesWriter = (repo: string, files: string[]) => void
 
 let server: http.Server | null = null
 let serverPort: number = 0
@@ -17,6 +23,9 @@ let commandStartCallback: CommandStartCallback | null = null
 let commandEndCallback: CommandEndCallback | null = null
 let repositoriesCallback: RepositoriesCallback | null = null
 let usageCallback: UsageCallback | null = null
+let configProvider: ConfigProvider | null = null
+let agentProvider: AgentProvider | null = null
+let worktreeFilesWriter: WorktreeFilesWriter | null = null
 
 export function getServerPort(): number {
   return serverPort
@@ -44,6 +53,18 @@ export function setRepositoriesCallback(callback: RepositoriesCallback) {
 
 export function setUsageCallback(callback: UsageCallback) {
   usageCallback = callback
+}
+
+export function setConfigProvider(provider: ConfigProvider) {
+  configProvider = provider
+}
+
+export function setAgentProvider(provider: AgentProvider) {
+  agentProvider = provider
+}
+
+export function setWorktreeFilesWriter(writer: WorktreeFilesWriter) {
+  worktreeFilesWriter = writer
 }
 
 // Read the full request body (used by the POST /usage route)
@@ -272,6 +293,47 @@ export function startStatusServer(): Promise<number> {
               }
             } catch (e) {
               console.error('[Hook Repositories] Failed to parse repos:', e)
+            }
+          }
+
+          res.writeHead(200)
+          res.end('OK')
+        } else if (url.pathname === '/config') {
+          // Read-only: the current config from the app's in-memory cache (hydrated from the
+          // cloud store). Lets skills read the live config instead of a stale local config.json.
+          let payload = '{}'
+          try {
+            if (configProvider) payload = JSON.stringify(configProvider() ?? {})
+          } catch (e) {
+            console.error('[StatusServer] /config provider failed:', e)
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(payload)
+        } else if (url.pathname === '/agent') {
+          // Read-only: the agent/task metadata for a given terminal id (terminalId === agent.id).
+          const terminalId = url.searchParams.get('id')
+          let payload = 'null'
+          try {
+            if (terminalId && agentProvider) payload = JSON.stringify(agentProvider(terminalId) ?? null)
+          } catch (e) {
+            console.error('[StatusServer] /agent provider failed:', e)
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(payload)
+        } else if (url.pathname === '/config/worktree-files') {
+          // Write: persist a repo's worktreeFiles to the cloud store (the one config mutation
+          // skills perform). Kept as GET+query to match the other curl-friendly write routes.
+          const repo = url.searchParams.get('repo')
+          const filesRaw = url.searchParams.get('files')
+
+          if (repo && filesRaw && worktreeFilesWriter) {
+            try {
+              const files = JSON.parse(filesRaw)
+              if (Array.isArray(files)) {
+                worktreeFilesWriter(repo, files.filter((f): f is string => typeof f === 'string'))
+              }
+            } catch (e) {
+              console.error('[StatusServer] /config/worktree-files failed:', e)
             }
           }
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, Notification, ipcMain, dialog, Menu, shell, globalS
 import { join } from 'path'
 import { setupConfigHandlers } from './ipc/config-handlers'
 import { setupTerminalHandlers, cleanupTerminals } from './ipc/terminal-handlers'
-import { startStatusServer, stopStatusServer, setStateCallback, setMetadataCallback, setCommandStartCallback, setCommandEndCallback, setRepositoriesCallback, setUsageCallback } from './hooks/status-server'
+import { startStatusServer, stopStatusServer, setStateCallback, setMetadataCallback, setCommandStartCallback, setCommandEndCallback, setRepositoriesCallback, setUsageCallback, setConfigProvider, setAgentProvider, setWorktreeFilesWriter } from './hooks/status-server'
 import { installShellIntegration } from './hooks/shell-integration'
 import { configureClaudeHooks, configureStatusLine } from './hooks/claude-hooks-config'
 import { setStatusServerPort, setInnerStatusLine, updateTerminalStateFromHook, updateTerminalMetadataFromHook, updateTerminalUsageFromHook, updateTerminalRepositoriesFromHook } from './pty/terminal-manager'
@@ -15,7 +15,8 @@ import { registerActivityHistoryHandlers } from './ipc/activity-history-handlers
 import { setupConnectivityHandlers } from './ipc/connectivity-handlers'
 import { setStore } from './store/Store'
 import { CloudStore } from './store/CloudStore'
-import { readConfig, writeConfig } from './config/config'
+import { readConfig, writeConfig, updateRepositoryWorktreeFilesSettings } from './config/config'
+import { readAgents } from './config/agents'
 import { TrayManager } from './tray/tray-manager'
 import { AgentStateAggregator } from './tray/agent-state-aggregator'
 import { destroyPopover } from './windows/popover-window'
@@ -512,6 +513,15 @@ async function initializeHooksAndSessions() {
           repositories
         })
       }
+    })
+
+    // Read-back providers: let terminal-run skills read the live config/agent metadata
+    // (served from the in-memory caches hydrated from the cloud store) and persist the
+    // one config mutation they perform (worktreeFiles).
+    setConfigProvider(() => readConfig())
+    setAgentProvider((terminalId: string) => readAgents().find((a) => a.id === terminalId) ?? null)
+    setWorktreeFilesWriter((repo: string, files: string[]) => {
+      updateRepositoryWorktreeFilesSettings(repo, { worktreeFiles: files })
     })
 
     // Install shell integration hooks

--- a/skills/magic-commit/SKILL.md
+++ b/skills/magic-commit/SKILL.md
@@ -24,6 +24,15 @@ Atomic commits (one commit = one logical unit of change) are a core expectation.
 
 ```bash
 CONFIG_FILE=~/.config/magic-slash/config.json
+# Magic Slash Desktop (cloud) is the source of truth. When the app is running, fetch the live
+# config; otherwise fall back to the local file (may be stale, or absent if never installed).
+if [ -n "$MAGIC_SLASH_PORT" ]; then
+  MS_TMP_CONFIG="$(mktemp)"
+  if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
+     && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
+    CONFIG_FILE="$MS_TMP_CONFIG"
+  fi
+fi
 if [ ! -f "$CONFIG_FILE" ]; then
   echo "CONFIG_MISSING"
 else

--- a/skills/magic-commit/SKILL.md
+++ b/skills/magic-commit/SKILL.md
@@ -28,6 +28,7 @@ CONFIG_FILE=~/.config/magic-slash/config.json
 # config; otherwise fall back to the local file (may be stale, or absent if never installed).
 if [ -n "$MAGIC_SLASH_PORT" ]; then
   MS_TMP_CONFIG="$(mktemp)"
+  trap 'rm -f "$MS_TMP_CONFIG"' EXIT
   if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
      && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
     CONFIG_FILE="$MS_TMP_CONFIG"

--- a/skills/magic-continue/SKILL.md
+++ b/skills/magic-continue/SKILL.md
@@ -24,6 +24,15 @@ Follow each step in order. Each step builds on the previous one.
 
 ```bash
 CONFIG_FILE=~/.config/magic-slash/config.json
+# Magic Slash Desktop (cloud) is the source of truth. When the app is running, fetch the live
+# config; otherwise fall back to the local file (may be stale, or absent if never installed).
+if [ -n "$MAGIC_SLASH_PORT" ]; then
+  MS_TMP_CONFIG="$(mktemp)"
+  if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
+     && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
+    CONFIG_FILE="$MS_TMP_CONFIG"
+  fi
+fi
 [ ! -f "$CONFIG_FILE" ] && echo "MISSING" || echo "OK"
 ```
 
@@ -275,8 +284,14 @@ done
 If files detected: Display `MSG_WORKTREE_FILES_DETECTED`. If user says yes, save to config via `jq`:
 
 ```bash
-jq --arg repo "{REPO_NAME}" --argjson files '["file1", "file2"]' \
-  '.repositories[$repo].worktreeFiles = $files' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+# Persist to the cloud via the desktop app when running; otherwise write the local config file.
+if [ -n "$MAGIC_SLASH_PORT" ]; then
+  curl -s "http://127.0.0.1:$MAGIC_SLASH_PORT/config/worktree-files?repo=$(echo -n '{REPO_NAME}' | jq -sRr @uri)&files=$(echo -n '["file1","file2"]' | jq -sRr @uri)" > /dev/null 2>&1 || true
+else
+  LOCAL_CONFIG=~/.config/magic-slash/config.json
+  [ -f "$LOCAL_CONFIG" ] && jq --arg repo "{REPO_NAME}" --argjson files '["file1", "file2"]' \
+    '.repositories[$repo].worktreeFiles = $files' "$LOCAL_CONFIG" > "$LOCAL_CONFIG.tmp" && mv "$LOCAL_CONFIG.tmp" "$LOCAL_CONFIG"
+fi
 ```
 
 Then copy files either way. If no files detected, skip silently.

--- a/skills/magic-continue/SKILL.md
+++ b/skills/magic-continue/SKILL.md
@@ -28,6 +28,7 @@ CONFIG_FILE=~/.config/magic-slash/config.json
 # config; otherwise fall back to the local file (may be stale, or absent if never installed).
 if [ -n "$MAGIC_SLASH_PORT" ]; then
   MS_TMP_CONFIG="$(mktemp)"
+  trap 'rm -f "$MS_TMP_CONFIG"' EXIT
   if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
      && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
     CONFIG_FILE="$MS_TMP_CONFIG"

--- a/skills/magic-continue/references/api.md
+++ b/skills/magic-continue/references/api.md
@@ -31,7 +31,7 @@ curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/agent?id=$MAGIC_SLASH_TERMINAL_ID"
 
 ## Write endpoints
 
-These endpoints update the Magic Slash Desktop UI / cloud store. They are silent (`|| true`) and never block the workflow. Only available when `$MAGIC_SLASH_PORT` and `$MAGIC_SLASH_TERMINAL_ID` are set.
+These endpoints update the Magic Slash Desktop UI / cloud store. They are silent (`|| true`) and never block the workflow. All require `$MAGIC_SLASH_PORT`; the terminal-scoped ones (`/metadata`, `/repositories`) additionally require `$MAGIC_SLASH_TERMINAL_ID`, while `/config/worktree-files` is keyed on `repo=` and needs only the port.
 
 ### `GET /config/worktree-files?repo=<name>&files=<json array>`
 

--- a/skills/magic-continue/references/api.md
+++ b/skills/magic-continue/references/api.md
@@ -1,6 +1,46 @@
 # API Reference — Magic Slash Desktop
 
-These endpoints update the Magic Slash Desktop UI. They are silent (`|| true`) and never block the workflow. Only available when `$MAGIC_SLASH_PORT` and `$MAGIC_SLASH_TERMINAL_ID` are set.
+These endpoints talk to the Magic Slash Desktop over `http://127.0.0.1:$MAGIC_SLASH_PORT`. The
+**write** endpoints update the UI, are silent (`|| true`) and never block the workflow. The
+**read** endpoints let a skill fetch the live config/metadata the app holds — the Supabase cloud
+store is the source of truth, so these return fresher data than the local `~/.config/magic-slash/config.json`
+(which the app no longer keeps in sync). All endpoints require `$MAGIC_SLASH_PORT`; the read
+endpoints keyed to a terminal also need `$MAGIC_SLASH_TERMINAL_ID`.
+
+## Read endpoints
+
+### `GET /config`
+
+Returns the current config as JSON (repositories, integrations, languages, …), served from the
+app's in-memory cache hydrated from the cloud. Skills prefer this over reading the local file, and
+fall back to `~/.config/magic-slash/config.json` when the app is not running (`$MAGIC_SLASH_PORT`
+unset) or the response has no repositories.
+
+```bash
+curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config"
+```
+
+### `GET /agent?id=<terminalId>`
+
+Returns the agent/task metadata (title, ticketId, description, status, baseBranch, branchName,
+repositories, prUrl, …) for the given terminal, or `null` if unknown. `id` is `$MAGIC_SLASH_TERMINAL_ID`.
+
+```bash
+curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/agent?id=$MAGIC_SLASH_TERMINAL_ID"
+```
+
+## Write endpoints
+
+These endpoints update the Magic Slash Desktop UI / cloud store. They are silent (`|| true`) and never block the workflow. Only available when `$MAGIC_SLASH_PORT` and `$MAGIC_SLASH_TERMINAL_ID` are set.
+
+### `GET /config/worktree-files?repo=<name>&files=<json array>`
+
+Persists a repository's `worktreeFiles` to the cloud store. `repo` and `files` (a URL-encoded JSON
+array of strings) are required. Replaces the legacy `jq`-into-local-file write when the app is running.
+
+```bash
+curl -s "http://127.0.0.1:$MAGIC_SLASH_PORT/config/worktree-files?repo=api&files=%5B%22.env%22%5D"
+```
 
 ## Endpoint `/metadata`
 

--- a/skills/magic-done/SKILL.md
+++ b/skills/magic-done/SKILL.md
@@ -53,6 +53,7 @@ CONFIG_FILE=~/.config/magic-slash/config.json
 # config; otherwise fall back to the local file (may be stale, or absent if never installed).
 if [ -n "$MAGIC_SLASH_PORT" ]; then
   MS_TMP_CONFIG="$(mktemp)"
+  trap 'rm -f "$MS_TMP_CONFIG"' EXIT
   if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
      && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
     CONFIG_FILE="$MS_TMP_CONFIG"

--- a/skills/magic-done/SKILL.md
+++ b/skills/magic-done/SKILL.md
@@ -49,6 +49,15 @@ Before starting, verify that the Magic Slash configuration exists:
 
 ```bash
 CONFIG_FILE=~/.config/magic-slash/config.json
+# Magic Slash Desktop (cloud) is the source of truth. When the app is running, fetch the live
+# config; otherwise fall back to the local file (may be stale, or absent if never installed).
+if [ -n "$MAGIC_SLASH_PORT" ]; then
+  MS_TMP_CONFIG="$(mktemp)"
+  if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
+     && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
+    CONFIG_FILE="$MS_TMP_CONFIG"
+  fi
+fi
 if [ ! -f "$CONFIG_FILE" ]; then
   # Display error based on system language
 fi

--- a/skills/magic-pr/SKILL.md
+++ b/skills/magic-pr/SKILL.md
@@ -81,6 +81,7 @@ CONFIG_FILE=~/.config/magic-slash/config.json
 # config; otherwise fall back to the local file (may be stale, or absent if never installed).
 if [ -n "$MAGIC_SLASH_PORT" ]; then
   MS_TMP_CONFIG="$(mktemp)"
+  trap 'rm -f "$MS_TMP_CONFIG"' EXIT
   if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
      && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
     CONFIG_FILE="$MS_TMP_CONFIG"

--- a/skills/magic-pr/SKILL.md
+++ b/skills/magic-pr/SKILL.md
@@ -77,6 +77,15 @@ Before starting, verify that the Magic Slash configuration exists:
 
 ```bash
 CONFIG_FILE=~/.config/magic-slash/config.json
+# Magic Slash Desktop (cloud) is the source of truth. When the app is running, fetch the live
+# config; otherwise fall back to the local file (may be stale, or absent if never installed).
+if [ -n "$MAGIC_SLASH_PORT" ]; then
+  MS_TMP_CONFIG="$(mktemp)"
+  if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
+     && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
+    CONFIG_FILE="$MS_TMP_CONFIG"
+  fi
+fi
 if [ ! -f "$CONFIG_FILE" ]; then
   # Display MSG_CONFIG_ERROR and stop
 fi

--- a/skills/magic-resolve/SKILL.md
+++ b/skills/magic-resolve/SKILL.md
@@ -60,6 +60,15 @@ Before starting, verify that the Magic Slash configuration exists and that requi
 
 ```bash
 CONFIG_FILE=~/.config/magic-slash/config.json
+# Magic Slash Desktop (cloud) is the source of truth. When the app is running, fetch the live
+# config; otherwise fall back to the local file (may be stale, or absent if never installed).
+if [ -n "$MAGIC_SLASH_PORT" ]; then
+  MS_TMP_CONFIG="$(mktemp)"
+  if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
+     && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
+    CONFIG_FILE="$MS_TMP_CONFIG"
+  fi
+fi
 if [ ! -f "$CONFIG_FILE" ]; then
   # Display error based on system language
 fi
@@ -169,6 +178,14 @@ The config was already dumped in Step 0.3. Before proceeding, resolve the curren
 
 ```bash
 CONFIG_FILE=~/.config/magic-slash/config.json
+# Re-resolve against the live config (cloud) when the app is running; else the local file.
+if [ -n "$MAGIC_SLASH_PORT" ]; then
+  MS_TMP_CONFIG="$(mktemp)"
+  if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
+     && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
+    CONFIG_FILE="$MS_TMP_CONFIG"
+  fi
+fi
 
 # Resolve the repo key whose path matches the current worktree/repo root.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")

--- a/skills/magic-resolve/SKILL.md
+++ b/skills/magic-resolve/SKILL.md
@@ -64,6 +64,7 @@ CONFIG_FILE=~/.config/magic-slash/config.json
 # config; otherwise fall back to the local file (may be stale, or absent if never installed).
 if [ -n "$MAGIC_SLASH_PORT" ]; then
   MS_TMP_CONFIG="$(mktemp)"
+  trap 'rm -f "$MS_TMP_CONFIG"' EXIT
   if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
      && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
     CONFIG_FILE="$MS_TMP_CONFIG"
@@ -181,6 +182,7 @@ CONFIG_FILE=~/.config/magic-slash/config.json
 # Re-resolve against the live config (cloud) when the app is running; else the local file.
 if [ -n "$MAGIC_SLASH_PORT" ]; then
   MS_TMP_CONFIG="$(mktemp)"
+  trap 'rm -f "$MS_TMP_CONFIG"' EXIT
   if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
      && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
     CONFIG_FILE="$MS_TMP_CONFIG"

--- a/skills/magic-review/SKILL.md
+++ b/skills/magic-review/SKILL.md
@@ -37,6 +37,15 @@ Before starting, verify that the Magic Slash configuration exists:
 
 ```bash
 CONFIG_FILE=~/.config/magic-slash/config.json
+# Magic Slash Desktop (cloud) is the source of truth. When the app is running, fetch the live
+# config; otherwise fall back to the local file (may be stale, or absent if never installed).
+if [ -n "$MAGIC_SLASH_PORT" ]; then
+  MS_TMP_CONFIG="$(mktemp)"
+  if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
+     && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
+    CONFIG_FILE="$MS_TMP_CONFIG"
+  fi
+fi
 if [ ! -f "$CONFIG_FILE" ]; then
   # Display error and stop
 fi

--- a/skills/magic-review/SKILL.md
+++ b/skills/magic-review/SKILL.md
@@ -41,6 +41,7 @@ CONFIG_FILE=~/.config/magic-slash/config.json
 # config; otherwise fall back to the local file (may be stale, or absent if never installed).
 if [ -n "$MAGIC_SLASH_PORT" ]; then
   MS_TMP_CONFIG="$(mktemp)"
+  trap 'rm -f "$MS_TMP_CONFIG"' EXIT
   if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
      && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
     CONFIG_FILE="$MS_TMP_CONFIG"

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -25,6 +25,15 @@ Follow each step in order. Each step builds on the previous one.
 
 ```bash
 CONFIG_FILE=~/.config/magic-slash/config.json
+# Magic Slash Desktop (cloud) is the source of truth. When the app is running, fetch the live
+# config; otherwise fall back to the local file (may be stale, or absent if never installed).
+if [ -n "$MAGIC_SLASH_PORT" ]; then
+  MS_TMP_CONFIG="$(mktemp)"
+  if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
+     && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
+    CONFIG_FILE="$MS_TMP_CONFIG"
+  fi
+fi
 [ ! -f "$CONFIG_FILE" ] && echo "MISSING" || echo "OK"
 ```
 
@@ -267,8 +276,14 @@ done
 If files detected: Use `AskUserQuestion` with `MSG_WORKTREE_FILES_DETECTED` (y/n). If user says yes, save to config via `jq`:
 
 ```bash
-jq --arg repo "{REPO_NAME}" --argjson files '["file1", "file2"]' \
-  '.repositories[$repo].worktreeFiles = $files' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+# Persist to the cloud via the desktop app when running; otherwise write the local config file.
+if [ -n "$MAGIC_SLASH_PORT" ]; then
+  curl -s "http://127.0.0.1:$MAGIC_SLASH_PORT/config/worktree-files?repo=$(echo -n '{REPO_NAME}' | jq -sRr @uri)&files=$(echo -n '["file1","file2"]' | jq -sRr @uri)" > /dev/null 2>&1 || true
+else
+  LOCAL_CONFIG=~/.config/magic-slash/config.json
+  [ -f "$LOCAL_CONFIG" ] && jq --arg repo "{REPO_NAME}" --argjson files '["file1", "file2"]' \
+    '.repositories[$repo].worktreeFiles = $files' "$LOCAL_CONFIG" > "$LOCAL_CONFIG.tmp" && mv "$LOCAL_CONFIG.tmp" "$LOCAL_CONFIG"
+fi
 ```
 
 Then copy the files either way. If no files detected, skip silently.

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -29,6 +29,7 @@ CONFIG_FILE=~/.config/magic-slash/config.json
 # config; otherwise fall back to the local file (may be stale, or absent if never installed).
 if [ -n "$MAGIC_SLASH_PORT" ]; then
   MS_TMP_CONFIG="$(mktemp)"
+  trap 'rm -f "$MS_TMP_CONFIG"' EXIT
   if curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config" -o "$MS_TMP_CONFIG" 2>/dev/null \
      && [ "$(jq '.repositories | length' "$MS_TMP_CONFIG" 2>/dev/null || echo 0)" -gt 0 ]; then
     CONFIG_FILE="$MS_TMP_CONFIG"

--- a/skills/magic-start/references/api.md
+++ b/skills/magic-start/references/api.md
@@ -31,7 +31,7 @@ curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/agent?id=$MAGIC_SLASH_TERMINAL_ID"
 
 ## Write endpoints
 
-These endpoints update the Magic Slash Desktop UI / cloud store. They are silent (`|| true`) and never block the workflow. Only available when `$MAGIC_SLASH_PORT` and `$MAGIC_SLASH_TERMINAL_ID` are set.
+These endpoints update the Magic Slash Desktop UI / cloud store. They are silent (`|| true`) and never block the workflow. All require `$MAGIC_SLASH_PORT`; the terminal-scoped ones (`/metadata`, `/repositories`) additionally require `$MAGIC_SLASH_TERMINAL_ID`, while `/config/worktree-files` is keyed on `repo=` and needs only the port.
 
 ### `GET /config/worktree-files?repo=<name>&files=<json array>`
 

--- a/skills/magic-start/references/api.md
+++ b/skills/magic-start/references/api.md
@@ -1,6 +1,46 @@
 # API Reference — Magic Slash Desktop
 
-These endpoints update the Magic Slash Desktop UI. They are silent (`|| true`) and never block the workflow. Only available when `$MAGIC_SLASH_PORT` and `$MAGIC_SLASH_TERMINAL_ID` are set.
+These endpoints talk to the Magic Slash Desktop over `http://127.0.0.1:$MAGIC_SLASH_PORT`. The
+**write** endpoints update the UI, are silent (`|| true`) and never block the workflow. The
+**read** endpoints let a skill fetch the live config/metadata the app holds — the Supabase cloud
+store is the source of truth, so these return fresher data than the local `~/.config/magic-slash/config.json`
+(which the app no longer keeps in sync). All endpoints require `$MAGIC_SLASH_PORT`; the read
+endpoints keyed to a terminal also need `$MAGIC_SLASH_TERMINAL_ID`.
+
+## Read endpoints
+
+### `GET /config`
+
+Returns the current config as JSON (repositories, integrations, languages, …), served from the
+app's in-memory cache hydrated from the cloud. Skills prefer this over reading the local file, and
+fall back to `~/.config/magic-slash/config.json` when the app is not running (`$MAGIC_SLASH_PORT`
+unset) or the response has no repositories.
+
+```bash
+curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/config"
+```
+
+### `GET /agent?id=<terminalId>`
+
+Returns the agent/task metadata (title, ticketId, description, status, baseBranch, branchName,
+repositories, prUrl, …) for the given terminal, or `null` if unknown. `id` is `$MAGIC_SLASH_TERMINAL_ID`.
+
+```bash
+curl -sf "http://127.0.0.1:$MAGIC_SLASH_PORT/agent?id=$MAGIC_SLASH_TERMINAL_ID"
+```
+
+## Write endpoints
+
+These endpoints update the Magic Slash Desktop UI / cloud store. They are silent (`|| true`) and never block the workflow. Only available when `$MAGIC_SLASH_PORT` and `$MAGIC_SLASH_TERMINAL_ID` are set.
+
+### `GET /config/worktree-files?repo=<name>&files=<json array>`
+
+Persists a repository's `worktreeFiles` to the cloud store. `repo` and `files` (a URL-encoded JSON
+array of strings) are required. Replaces the legacy `jq`-into-local-file write when the app is running.
+
+```bash
+curl -s "http://127.0.0.1:$MAGIC_SLASH_PORT/config/worktree-files?repo=api&files=%5B%22.env%22%5D"
+```
 
 ## Endpoint `/metadata`
 


### PR DESCRIPTION
## Contexte

Depuis la migration cloud (Supabase = source de vérité pour config/agents/history), l'app Desktop n'écrit plus `~/.config/magic-slash/config.json` sur disque. Or les skills (agents terminal) lisaient ce fichier via `jq`/`cat`, et le seul pont agent → app (le status server localhost) était **write-only**. Résultat : un agent ne pouvait pas récupérer les métadonnées stockées dans le cloud, et le `config.json` local qu'il lisait divergeait de ce que l'app affichait.

## Changements

**Backend (`feat(desktop)`)** — ajoute des routes de lecture au status server :
- `GET /config` — la config live depuis le cache en mémoire (hydraté du cloud)
- `GET /agent?id=<terminalId>` — les métadonnées de l'agent/tâche du terminal
- `GET /config/worktree-files?repo=&files=` — persiste `worktreeFiles` dans le cloud

Câblage via 3 providers dans `index.ts` (`readConfig` / `readAgents` / `updateRepositoryWorktreeFilesSettings`). L'app reste la frontière d'auth : aucun credential côté terminal.

**Skills** — les 7 SKILL.md récupèrent la config live via `curl /config` (avec fallback transparent sur le fichier local si l'app est fermée). Tous les `jq "$CONFIG_FILE"` en aval sont inchangés. Les écritures `worktreeFiles` passent par le nouvel endpoint. Docs `api.md` mises à jour.

## Tests
- `npm run lint:js` → 0 erreur
- `npm test` → 242 tests OK (dont 4 nouveaux tests d'intégration des routes)
- `npm run desktop:build` → compile clean

## Comportement
Données cloud fraîches uniquement quand l'app tourne (`$MAGIC_SLASH_PORT` défini) ; sinon fallback best-effort sur le `config.json` local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)