### PR TITLE
feat(desktop): rework settings around account and organizations

### DIFF
--- a/desktop/src/main/cloud/org.ts
+++ b/desktop/src/main/cloud/org.ts
@@ -210,6 +210,25 @@ export async function archiveOrg(orgId: string): Promise<void> {
   if (readConfig().currentOrgId === orgId) setCurrentOrgId(undefined)
 }
 
+/**
+ * Create an organization; the caller becomes its admin. There is deliberately no
+ * INSERT policy on `organizations` — the org row and the creator's admin
+ * membership must land atomically, so this goes through the SECURITY DEFINER
+ * `create_organization` RPC (the same one sign-up uses for the personal org).
+ * Returns the new org id. Does NOT switch to it — that stays an explicit choice.
+ */
+export async function createOrganization(name: string): Promise<string> {
+  const client = await getAuthedClient()
+  if (!client) throw new Error('Cloud features are not available')
+
+  const orgName = name.trim()
+  if (!orgName) throw new Error('createOrganization requires a name')
+
+  const { data, error } = await client.rpc('create_organization', { org_name: orgName })
+  if (error) throw new Error(error.message)
+  return data as string
+}
+
 /** Create an invitation (admin only — RLS enforces the admin gate). */
 export async function createInvitation(email: string, role: MembershipRole = 'user', orgId?: string): Promise<Invitation> {
   const client = await getAuthedClient()

--- a/desktop/src/main/ipc/org-handlers.ts
+++ b/desktop/src/main/ipc/org-handlers.ts
@@ -12,6 +12,7 @@ import {
   applySharedConfig,
   setOrgSharedConfig,
   listOrgs,
+  createOrganization,
   listOrgAgents,
   listOrgUsageStats,
   pickUpTask,
@@ -22,7 +23,9 @@ import {
   switchOrg,
 } from '../cloud/org'
 
-interface InviteArgs { email: string; role?: MembershipRole }
+interface InviteArgs { email: string; role?: MembershipRole; orgId?: string }
+interface OptionalOrgIdArgs { orgId?: string }
+interface CreateOrgArgs { name: string }
 interface AcceptArgs { token: string }
 interface OrgIdArgs { orgId: string }
 interface MemberArgs { orgId: string; userId: string }
@@ -33,7 +36,11 @@ interface PickUpArgs { ticketId: string; repositories: string[] }
 export function setupOrgHandlers(): void {
   ipcMain.handle('org:current', async (): Promise<Org | null> => getCurrentOrg())
 
-  ipcMain.handle('org:members', async (): Promise<Member[]> => listMembers())
+  // orgId is optional: omitted → the active org. The settings page passes it so
+  // it can render every org the user belongs to, not just the active one.
+  ipcMain.handle('org:members', async (_event, args?: OptionalOrgIdArgs): Promise<Member[]> =>
+    listMembers(args?.orgId),
+  )
 
   ipcMain.handle('org:list', async (): Promise<Org[]> => listOrgs())
 
@@ -53,10 +60,12 @@ export function setupOrgHandlers(): void {
 
   ipcMain.handle('org:realtimeStatus', async (): Promise<RealtimeStatus> => getRealtimeStatus())
 
-  ipcMain.handle('org:invitations', async (): Promise<Invitation[]> => listInvitations())
+  ipcMain.handle('org:invitations', async (_event, args?: OptionalOrgIdArgs): Promise<Invitation[]> =>
+    listInvitations(args?.orgId),
+  )
 
-  ipcMain.handle('org:invite', async (_event, { email, role }: InviteArgs): Promise<Invitation> =>
-    createInvitation(email, role ?? 'user'),
+  ipcMain.handle('org:invite', async (_event, { email, role, orgId }: InviteArgs): Promise<Invitation> =>
+    createInvitation(email, role ?? 'user', orgId),
   )
 
   ipcMain.handle('org:deleteInvitation', async (_event, { id }: { id: string }): Promise<void> =>
@@ -87,6 +96,13 @@ export function setupOrgHandlers(): void {
   )
 
   ipcMain.handle('org:archive', async (_event, { orgId }: OrgIdArgs): Promise<void> => archiveOrg(orgId))
+
+  ipcMain.handle('org:create', async (_event, { name }: CreateOrgArgs): Promise<string> => {
+    if (typeof name !== 'string' || !name.trim()) {
+      throw new Error('org:create requires a non-empty name')
+    }
+    return createOrganization(name)
+  })
 
   ipcMain.handle('org:switch', async (_event, { orgId }: OrgIdArgs): Promise<Config> => switchOrg(orgId))
 }

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -459,7 +459,8 @@ const authApi = {
 // Org API (organization membership + invitations + multi-org management)
 const orgApi = {
   current: (): Promise<Org | null> => ipcRenderer.invoke('org:current'),
-  members: (): Promise<Member[]> => ipcRenderer.invoke('org:members'),
+  // orgId omitted → the active org.
+  members: (orgId?: string): Promise<Member[]> => ipcRenderer.invoke('org:members', { orgId }),
   list: (): Promise<Org[]> => ipcRenderer.invoke('org:list'),
   // Team dashboard: org-wide agents roster + live realtime propagation.
   listAgents: (): Promise<OrgAgent[]> => ipcRenderer.invoke('org:listAgents'),
@@ -480,9 +481,11 @@ const orgApi = {
     ipcRenderer.on('org:realtimeStatusChanged', listener)
     return () => ipcRenderer.removeListener('org:realtimeStatusChanged', listener)
   },
-  invitations: (): Promise<Invitation[]> => ipcRenderer.invoke('org:invitations'),
-  invite: (email: string, role?: MembershipRole): Promise<Invitation> =>
-    ipcRenderer.invoke('org:invite', { email, role }),
+  invitations: (orgId?: string): Promise<Invitation[]> => ipcRenderer.invoke('org:invitations', { orgId }),
+  invite: (email: string, role?: MembershipRole, orgId?: string): Promise<Invitation> =>
+    ipcRenderer.invoke('org:invite', { email, role, orgId }),
+  /** Create an organization (caller becomes admin). Returns the new org id. */
+  create: (name: string): Promise<string> => ipcRenderer.invoke('org:create', { name }),
   deleteInvitation: (id: string): Promise<void> =>
     ipcRenderer.invoke('org:deleteInvitation', { id }),
   accept: (token: string): Promise<{ orgId: string; config: Config }> =>

--- a/desktop/src/renderer/components/Sidebar.tsx
+++ b/desktop/src/renderer/components/Sidebar.tsx
@@ -349,6 +349,8 @@ export function Sidebar() {
   const shortcutKey = isMac ? '⌘N' : 'Ctrl+N'
   const skillsShortcutKey = isMac ? '⌘;' : 'Ctrl+;'
   const historyShortcutKey = isMac ? '⌘H' : 'Ctrl+H'
+  const teamShortcutKey = isMac ? '⌘T' : 'Ctrl+T'
+  const settingsShortcutKey = isMac ? '⌘,' : 'Ctrl+,'
 
   // Listen for Command+; keyboard shortcut to open skills
   useEffect(() => {
@@ -378,19 +380,32 @@ export function Sidebar() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [setCurrentPage, setActiveTerminal])
 
+  // Listen for Command+T keyboard shortcut to open the team dashboard
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 't') {
+        e.preventDefault()
+        setCurrentPage('dashboard')
+        setActiveTerminal(null)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [setCurrentPage, setActiveTerminal])
+
   // Listen for Command+, keyboard shortcut to open settings
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === ',') {
         e.preventDefault()
-        setActiveTerminal(null)
         openSettingsModal()
       }
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [openSettingsModal, setActiveTerminal])
+  }, [openSettingsModal])
 
   return (
     <div
@@ -468,10 +483,11 @@ export function Sidebar() {
         >
           <Users className="w-3.5 h-3.5" />
           <span>Team</span>
+          <span className="ml-auto text-xs opacity-50">{teamShortcutKey}</span>
         </button>
 
         {/* Account / Settings — opens the settings modal (or login when signed out) */}
-        <SidebarAccount />
+        <SidebarAccount shortcutKey={settingsShortcutKey} />
       </div>
 
       {/* Mode toggle + Agents list */}

--- a/desktop/src/renderer/components/SidebarAccount.tsx
+++ b/desktop/src/renderer/components/SidebarAccount.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { createPortal } from 'react-dom'
-import { LogIn, Settings, AlertTriangle } from 'lucide-react'
+import { LogIn, Settings, AlertTriangle, CircleUserRound } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
 import { useStore } from '../store'
 import { LoginScreen } from './LoginScreen'
@@ -25,12 +25,14 @@ function displayNameFromEmail(email?: string): string {
  * falls back to a plain Settings entry so settings stay reachable. A warning
  * badge surfaces when no repositories are configured. Organization switching and
  * sign-out now live inside the Settings modal.
+ *
+ * `shortcutKey` is the pre-formatted accelerator label (⌘, / Ctrl+,) shown on the
+ * right, matching the other sidebar entries. The keybinding itself lives in Sidebar.
  */
-export function SidebarAccount() {
+export function SidebarAccount({ shortcutKey }: { shortcutKey?: string }) {
   const { status } = useAuth()
   const config = useStore((s) => s.config)
   const openSettingsModal = useStore((s) => s.openSettingsModal)
-  const setActiveTerminal = useStore((s) => s.setActiveTerminal)
 
   const [showLogin, setShowLogin] = useState(false)
 
@@ -39,8 +41,9 @@ export function SidebarAccount() {
     return Object.keys(config.repositories).length === 0
   }, [config])
 
+  // Settings is a modal, not a page: it must never clear the active terminal,
+  // otherwise the app behind the overlay renders blank.
   const openSettings = () => {
-    setActiveTerminal(null)
     openSettingsModal()
   }
 
@@ -75,7 +78,6 @@ export function SidebarAccount() {
   // Signed in → account button opening Settings.
   if (status.enabled && status.loggedIn) {
     const name = displayNameFromEmail(status.user?.email)
-    const initial = name.charAt(0).toUpperCase()
     return (
       <button
         onClick={openSettings}
@@ -85,10 +87,9 @@ export function SidebarAccount() {
             : 'text-text-secondary hover:bg-text-secondary/10 hover:text-white'
         }`}
       >
-        <span className="flex items-center justify-center w-5 h-5 rounded-full bg-accent/20 text-accent text-[10px] font-semibold shrink-0">
-          {initial}
-        </span>
+        <CircleUserRound className="w-3.5 h-3.5 shrink-0" />
         <span className="truncate">{name}</span>
+        {shortcutKey && <span className="ml-auto text-xs opacity-50 shrink-0">{shortcutKey}</span>}
         <WarningBadge />
       </button>
     )
@@ -106,6 +107,7 @@ export function SidebarAccount() {
     >
       <Settings className="w-3.5 h-3.5" />
       <span>Settings</span>
+      {shortcutKey && <span className="ml-auto text-xs opacity-50 shrink-0">{shortcutKey}</span>}
       <WarningBadge />
     </button>
   )

--- a/desktop/src/renderer/components/SidebarUsageCard.tsx
+++ b/desktop/src/renderer/components/SidebarUsageCard.tsx
@@ -4,15 +4,23 @@ import { useStore } from '../store'
 import { gaugeColors, formatReset } from './agent-info-sidebar/LimitGauge'
 import type { ClaudeAccount } from '../../types'
 
-// Small colored "session 5h 89%" pill used in the collapsed card.
-function UsagePill({ label, percent }: { label: string; percent: number }) {
+// "session ▬▬ 89%" gauge for the collapsed card. Both gauges share one row, so
+// each takes half of it: label and percent are shrink-0 and the bar absorbs
+// whatever is left — it goes very small on a narrow sidebar, by design.
+function UsageMiniBar({ label, percent }: { label: string; percent: number }) {
   const pct = Math.min(100, Math.max(0, percent))
   const colors = gaugeColors(pct)
   return (
-    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-white/[0.04] text-[10px] whitespace-nowrap">
-      <span className="text-text-secondary/60">{label}</span>
-      <span className={`font-mono font-semibold ${colors.text}`}>{Math.round(pct)}%</span>
-    </span>
+    <div className="flex items-center gap-1 flex-1 min-w-0">
+      <span className="shrink-0 text-[10px] text-text-secondary/60">{label}</span>
+      <div className="h-1 flex-1 min-w-[8px] rounded-full bg-white/[0.06] overflow-hidden">
+        <div
+          className={`h-full rounded-full ${colors.bar} transition-all duration-500`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className={`shrink-0 text-[10px] font-mono font-semibold ${colors.text}`}>{Math.round(pct)}%</span>
+    </div>
   )
 }
 
@@ -95,9 +103,9 @@ export function SidebarUsageCard() {
       {minimized ? (
         <div className="flex items-center justify-between gap-1.5">
           {hasGauges ? (
-            <div className="flex items-center gap-1 min-w-0 flex-wrap">
-              {hasFive && <UsagePill label="session 5h" percent={accountUsage!.fiveHourPercent!} />}
-              {hasSeven && <UsagePill label="hebdo 7d" percent={accountUsage!.sevenDayPercent!} />}
+            <div className="flex items-center gap-2 flex-1 min-w-0">
+              {hasFive && <UsageMiniBar label="session" percent={accountUsage!.fiveHourPercent!} />}
+              {hasSeven && <UsageMiniBar label="weekly" percent={accountUsage!.sevenDayPercent!} />}
             </div>
           ) : (
             <span className="text-[10px] text-text-secondary/40">No usage data</span>

--- a/desktop/src/renderer/components/agent-info-sidebar/UsageCard.tsx
+++ b/desktop/src/renderer/components/agent-info-sidebar/UsageCard.tsx
@@ -59,8 +59,10 @@ export function UsageCard({ usage }: UsageCardProps) {
   if (minimized) {
     return (
       <div className="bg-white/[0.06] rounded-xl px-3 py-2 flex items-center gap-2">
-        <span className="text-xs text-text-secondary/50 uppercase tracking-wider shrink-0">Session</span>
-        <div className="h-1.5 flex-1 min-w-0 rounded-full bg-white/[0.08] overflow-hidden">
+        <span className="text-xs text-text-secondary/50 uppercase tracking-wider shrink-0">Session context</span>
+        {/* Capped at a third of the row so the bar doesn't span the whole card;
+            ml-auto pushes it right, grouping it with the percent + expand button. */}
+        <div className="h-1.5 flex-1 min-w-0 max-w-[33%] ml-auto rounded-full bg-white/[0.08] overflow-hidden">
           <div
             className={`h-full rounded-full ${colors.bar} transition-all duration-500`}
             style={{ width: `${pct}%` }}
@@ -97,10 +99,13 @@ export function UsageCard({ usage }: UsageCardProps) {
               {model}
             </span>
           )}
+          {/* self-stretch makes the button exactly as tall as the model pill next
+              to it, whatever that pill's line-height works out to. With no model
+              it keeps its natural height. */}
           <button
             onClick={() => setMinimized(true)}
             title="Minimize"
-            className="p-0.5 rounded text-text-secondary/50 hover:text-white hover:bg-white/10 transition-colors shrink-0"
+            className="self-stretch px-1 flex items-center justify-center rounded-md text-text-secondary/50 hover:text-white hover:bg-white/10 transition-colors shrink-0"
           >
             <Minus className="w-3 h-3" />
           </button>

--- a/desktop/src/renderer/hooks/useOrg.ts
+++ b/desktop/src/renderer/hooks/useOrg.ts
@@ -18,6 +18,13 @@ export function useOrg() {
 
   const [members, setMembers] = useState<Member[]>([])
   const [invitations, setInvitations] = useState<Invitation[]>([])
+  // Per-org rosters, keyed by org id. A user can belong to several orgs
+  // (memberships is unique on (org_id, user_id), not on user_id), and the
+  // settings page renders one card per org — so it needs all of them, not just
+  // the active one. `members`/`invitations` above stay scoped to the active org
+  // for the callers that only care about it.
+  const [membersByOrg, setMembersByOrg] = useState<Record<string, Member[]>>({})
+  const [invitationsByOrg, setInvitationsByOrg] = useState<Record<string, Invitation[]>>({})
   const [loading, setLoading] = useState(false)
 
   const refresh = useCallback(async () => {
@@ -25,20 +32,36 @@ export function useOrg() {
     try {
       const current = await window.electronAPI.org.current()
       setActiveOrg(current)
-      setOrgs(await window.electronAPI.org.list().catch(() => []))
-      if (current) {
-        setMembers(await window.electronAPI.org.members().catch(() => []))
-        // Invitations are admin-only; a non-admin read simply yields [].
-        setInvitations(await window.electronAPI.org.invitations().catch(() => []))
-      } else {
-        setMembers([])
-        setInvitations([])
+      const list = await window.electronAPI.org.list().catch(() => [])
+      setOrgs(list)
+
+      // One round-trip pair per org, all in flight together.
+      const rosters = await Promise.all(
+        list.map(async (o) => ({
+          orgId: o.id,
+          members: await window.electronAPI.org.members(o.id).catch(() => []),
+          // Invitations are admin-only; a non-admin read simply yields [].
+          invitations: await window.electronAPI.org.invitations(o.id).catch(() => []),
+        })),
+      )
+
+      const byOrgMembers: Record<string, Member[]> = {}
+      const byOrgInvitations: Record<string, Invitation[]> = {}
+      for (const r of rosters) {
+        byOrgMembers[r.orgId] = r.members
+        byOrgInvitations[r.orgId] = r.invitations
       }
+      setMembersByOrg(byOrgMembers)
+      setInvitationsByOrg(byOrgInvitations)
+      setMembers(current ? byOrgMembers[current.id] ?? [] : [])
+      setInvitations(current ? byOrgInvitations[current.id] ?? [] : [])
     } catch {
       setActiveOrg(null)
       setOrgs([])
       setMembers([])
       setInvitations([])
+      setMembersByOrg({})
+      setInvitationsByOrg({})
     } finally {
       setLoading(false)
     }
@@ -49,10 +72,19 @@ export function useOrg() {
   }, [refresh])
 
   const invite = useCallback(
-    async (email: string, role: MembershipRole = 'user') => {
-      const invitation = await window.electronAPI.org.invite(email, role)
+    async (email: string, role: MembershipRole = 'user', orgId?: string) => {
+      const invitation = await window.electronAPI.org.invite(email, role, orgId)
       await refresh()
       return invitation
+    },
+    [refresh],
+  )
+
+  const createOrg = useCallback(
+    async (name: string) => {
+      const orgId = await window.electronAPI.org.create(name)
+      await refresh()
+      return orgId
     },
     [refresh],
   )
@@ -122,9 +154,12 @@ export function useOrg() {
     orgs,
     members,
     invitations,
+    membersByOrg,
+    invitationsByOrg,
     loading,
     refresh,
     invite,
+    createOrg,
     deleteInvitation,
     accept,
     removeMember,

--- a/desktop/src/renderer/pages/Config/AccountPage.tsx
+++ b/desktop/src/renderer/pages/Config/AccountPage.tsx
@@ -1,0 +1,16 @@
+import { CloudAccountSection } from './CloudAccountSection'
+import { ProfileSection } from './ProfileSection'
+
+/**
+ * Account tab: everything about *you* — the cloud identity you sign in with, and
+ * the profile Claude reads to adapt its answers. The Organization tab keeps the
+ * org-level concerns (members, invitations, integrations).
+ */
+export function AccountPage() {
+  return (
+    <div className="flex flex-col gap-8">
+      <CloudAccountSection />
+      <ProfileSection />
+    </div>
+  )
+}

--- a/desktop/src/renderer/pages/Config/CloudAccountSection.tsx
+++ b/desktop/src/renderer/pages/Config/CloudAccountSection.tsx
@@ -1,0 +1,339 @@
+import { useState, useCallback } from 'react'
+import { Cloud, LogOut, LogIn, UserPlus, Loader2, KeyRound, AtSign, Trash2, AlertTriangle } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import { useOrg } from '../../hooks/useOrg'
+import { LoginScreen } from '../../components/LoginScreen'
+import { Modal } from '../../components/Modal'
+import { SectionHeader } from './SectionHeader'
+import { InvitationOnboardingWizard } from '../../components/InvitationOnboardingWizard'
+import { showToast } from '../../components/Toast'
+
+/**
+ * Cloud identity block of the Account tab: sign in / out, change password,
+ * change email, delete account. Extracted from OrgPage so the Organization tab
+ * stays about the org itself while identity lives under Account.
+ *
+ * It owns its own auth modals — nothing else needs to know they exist.
+ */
+export function CloudAccountSection() {
+  const { status, loading: authLoading, logout, updatePassword, requestEmailChange, confirmEmailChange, deleteAccount } = useAuth()
+  const { refresh } = useOrg()
+
+  const [showLogin, setShowLogin] = useState(false)
+  const [showInvitationWizard, setShowInvitationWizard] = useState(false)
+
+  const [showChangePassword, setShowChangePassword] = useState(false)
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [changingPassword, setChangingPassword] = useState(false)
+
+  const [showChangeEmail, setShowChangeEmail] = useState(false)
+  const [emailStep, setEmailStep] = useState<'request' | 'confirm'>('request')
+  const [newEmail, setNewEmail] = useState('')
+  const [emailCode, setEmailCode] = useState('')
+  const [changingEmail, setChangingEmail] = useState(false)
+
+  const [showDeleteAccount, setShowDeleteAccount] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const handleLogout = useCallback(async () => {
+    await logout()
+    await refresh()
+  }, [logout, refresh])
+
+  const resetPasswordModal = useCallback(() => {
+    setShowChangePassword(false)
+    setNewPassword('')
+    setConfirmPassword('')
+  }, [])
+
+  const handleChangePassword = useCallback(async () => {
+    if (changingPassword) return
+    if (!newPassword || newPassword !== confirmPassword) {
+      showToast('Passwords do not match', 'error')
+      return
+    }
+    setChangingPassword(true)
+    try {
+      await updatePassword(newPassword)
+      showToast('Password updated', 'success')
+      resetPasswordModal()
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to update password', 'error')
+    } finally {
+      setChangingPassword(false)
+    }
+  }, [changingPassword, newPassword, confirmPassword, updatePassword, resetPasswordModal])
+
+  const resetEmailModal = useCallback(() => {
+    setShowChangeEmail(false)
+    setEmailStep('request')
+    setNewEmail('')
+    setEmailCode('')
+  }, [])
+
+  const handleChangeEmail = useCallback(async () => {
+    if (changingEmail) return
+    setChangingEmail(true)
+    try {
+      if (emailStep === 'request') {
+        if (!newEmail.trim()) { showToast('Enter a new email', 'error'); return }
+        await requestEmailChange(newEmail.trim())
+        showToast('Check your new email for the confirmation code', 'success')
+        setEmailStep('confirm')
+      } else {
+        if (!emailCode.trim()) { showToast('Enter the code', 'error'); return }
+        await confirmEmailChange(newEmail.trim(), emailCode.trim())
+        showToast('Email updated', 'success')
+        resetEmailModal()
+        await refresh()
+      }
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to change email', 'error')
+    } finally {
+      setChangingEmail(false)
+    }
+  }, [changingEmail, emailStep, newEmail, emailCode, requestEmailChange, confirmEmailChange, resetEmailModal, refresh])
+
+  const handleDeleteAccount = useCallback(async () => {
+    if (deleting) return
+    setDeleting(true)
+    try {
+      await deleteAccount()
+      showToast('Your account has been deleted', 'success')
+      setShowDeleteAccount(false)
+      await refresh()
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to delete account', 'error')
+    } finally {
+      setDeleting(false)
+    }
+  }, [deleting, deleteAccount, refresh])
+
+  // Cloud disabled entirely (no Supabase env baked in) → nothing to sign in to.
+  if (!authLoading && !status.enabled) {
+    return (
+      <div>
+        <SectionHeader icon={Cloud} title="Cloud account" />
+        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-6 text-center">
+          <Cloud className="w-8 h-8 text-text-secondary/30 mx-auto mb-3" />
+          <div className="text-sm text-text-secondary/60">Cloud features are not configured in this build.</div>
+          <div className="text-xs text-text-secondary/40 mt-1">Magic Slash works fully offline — no account required.</div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <SectionHeader icon={Cloud} title="Cloud account" />
+      <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
+        {status.loggedIn ? (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm font-medium">{status.user?.email ?? 'Signed in'}</div>
+                <div className="text-xs text-text-secondary/50 mt-0.5">Signed in to Magic Slash cloud</div>
+              </div>
+              <button
+                onClick={handleLogout}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+              >
+                <LogOut className="w-3.5 h-3.5" />
+                Sign out
+              </button>
+            </div>
+            <div className="border-t border-white/5 pt-3 flex flex-wrap items-center gap-2">
+              <button
+                onClick={() => setShowChangePassword(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+              >
+                <KeyRound className="w-3.5 h-3.5" />
+                Change password
+              </button>
+              <button
+                onClick={() => setShowChangeEmail(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+              >
+                <AtSign className="w-3.5 h-3.5" />
+                Change email
+              </button>
+              <button
+                onClick={() => setShowDeleteAccount(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red border border-red/20 rounded-lg hover:bg-red/10 transition-all ml-auto"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+                Delete my account
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium">Not signed in</div>
+              <div className="text-xs text-text-secondary/50 mt-0.5">Sign in to manage your organization (optional)</div>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowInvitationWizard(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+              >
+                <UserPlus className="w-3.5 h-3.5" />
+                Join with invitation
+              </button>
+              <button
+                onClick={() => setShowLogin(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all"
+              >
+                <LogIn className="w-3.5 h-3.5" />
+                Sign in
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <LoginScreen isOpen={showLogin} onClose={() => setShowLogin(false)} onSignedIn={refresh} />
+      <InvitationOnboardingWizard isOpen={showInvitationWizard} onClose={() => { setShowInvitationWizard(false); refresh() }} />
+
+      {/* Change password */}
+      <Modal
+        isOpen={showChangePassword}
+        onClose={resetPasswordModal}
+        title="Change password"
+        footer={
+          <>
+            <button
+              onClick={resetPasswordModal}
+              className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleChangePassword}
+              disabled={changingPassword || !newPassword || newPassword !== confirmPassword}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40"
+            >
+              {changingPassword ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <KeyRound className="w-3.5 h-3.5" />}
+              Update password
+            </button>
+          </>
+        }
+      >
+        <div className="space-y-2">
+          <input
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder="New password"
+            autoFocus
+            className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+          />
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="Confirm new password"
+            onKeyDown={(e) => { if (e.key === 'Enter') handleChangePassword() }}
+            className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+          />
+        </div>
+      </Modal>
+
+      {/* Change email (OTP code flow) */}
+      <Modal
+        isOpen={showChangeEmail}
+        onClose={resetEmailModal}
+        title="Change email"
+        footer={
+          <>
+            <button
+              onClick={resetEmailModal}
+              className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleChangeEmail}
+              disabled={changingEmail}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40"
+            >
+              {changingEmail ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <AtSign className="w-3.5 h-3.5" />}
+              {emailStep === 'request' ? 'Send code' : 'Confirm change'}
+            </button>
+          </>
+        }
+      >
+        {emailStep === 'request' ? (
+          <div className="space-y-2">
+            <p className="text-xs text-text-secondary/60">
+              We'll email a 6-digit confirmation code to your new address.
+            </p>
+            <input
+              type="email"
+              value={newEmail}
+              onChange={(e) => setNewEmail(e.target.value)}
+              placeholder="New email"
+              autoFocus
+              onKeyDown={(e) => { if (e.key === 'Enter') handleChangeEmail() }}
+              className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+            />
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-xs text-text-secondary/60">
+              Check <span className="text-white">{newEmail}</span> for the confirmation code and enter it below.
+            </p>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={emailCode}
+              onChange={(e) => setEmailCode(e.target.value)}
+              placeholder="6-digit code"
+              autoFocus
+              onKeyDown={(e) => { if (e.key === 'Enter') handleChangeEmail() }}
+              className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+            />
+          </div>
+        )}
+      </Modal>
+
+      {/* Delete account (danger) */}
+      <Modal
+        isOpen={showDeleteAccount}
+        onClose={() => setShowDeleteAccount(false)}
+        title="Delete my account"
+        footer={
+          <>
+            <button
+              onClick={() => setShowDeleteAccount(false)}
+              className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleDeleteAccount}
+              disabled={deleting}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-red hover:bg-red/80 rounded-lg transition-all disabled:opacity-40"
+            >
+              {deleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+              Delete permanently
+            </button>
+          </>
+        }
+      >
+        <div className="flex items-start gap-3">
+          <div className="p-2 bg-red/10 rounded-lg flex-shrink-0">
+            <AlertTriangle className="w-4 h-4 text-red" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm text-white">This permanently deletes your account and personal data.</p>
+            <p className="text-xs text-text-secondary/60">
+              Organizations you created will be removed along with their data. This cannot be undone. Magic Slash keeps working locally without an account.
+            </p>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  )
+}

--- a/desktop/src/renderer/pages/Config/OrgPage.tsx
+++ b/desktop/src/renderer/pages/Config/OrgPage.tsx
@@ -1,206 +1,398 @@
-import { useState, useEffect, useCallback } from 'react'
-import { Cloud, Users, Mail, LogOut, LogIn, UserPlus, Shield, Copy, Check, Github, Loader2, Building2, KeyRound, AtSign, Trash2, AlertTriangle, Archive, X } from 'lucide-react'
+import { useState, useCallback } from 'react'
+import { Cloud, Users, Mail, LogOut, Copy, Check, Loader2, Building2, Trash2, AlertTriangle, Archive, X, Plus, UserPlus, ArrowRightLeft } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import { useOrg } from '../../hooks/useOrg'
-import { useStore } from '../../store'
-import { LoginScreen } from '../../components/LoginScreen'
 import { Modal } from '../../components/Modal'
-import { InvitationOnboardingWizard } from '../../components/InvitationOnboardingWizard'
+import { RoleSelect } from './RoleSelect'
+import { SectionHeader } from './SectionHeader'
 import { showToast } from '../../components/Toast'
-import type { GitHubAuthStatus, MembershipRole } from '../../../types'
+import type { Invitation, Member, MembershipRole, Org } from '../../../types'
 
-export function OrgPage() {
-  const { status, loading: authLoading, logout, updatePassword, requestEmailChange, confirmEmailChange, deleteAccount } = useAuth()
-  const { org, members, invitations, loading: orgLoading, refresh, invite, deleteInvitation, removeMember, updateRole, leaveOrg, archiveOrg } = useOrg()
-  const { config, setConfig } = useStore()
+/** Sub-heading inside an organization card. */
+function CardSection({ label, count, action }: { label: string; count?: number; action?: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between h-5 mb-2">
+      <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-text-secondary/50">
+        <span>{label}</span>
+        {count !== undefined && <span className="text-text-secondary/30">{count}</span>}
+      </div>
+      {action}
+    </div>
+  )
+}
 
-  const [showLogin, setShowLogin] = useState(false)
-  const [showInvitationWizard, setShowInvitationWizard] = useState(false)
-  const [inviteEmail, setInviteEmail] = useState('')
-  const [inviting, setInviting] = useState(false)
-  const [copiedToken, setCopiedToken] = useState<string | null>(null)
-  const [deletingInvite, setDeletingInvite] = useState<string | null>(null)
+interface OrganizationCardProps {
+  org: Org
+  members: Member[]
+  invitations: Invitation[]
+  isActive: boolean
+  currentUserId?: string
+  busyMember: string | null
+  deletingInvite: string | null
+  copiedToken: string | null
+  leaving: boolean
+  switching: boolean
+  onSwitch: (orgId: string) => void
+  onInvite: (org: Org) => void
+  onChangeRole: (orgId: string, userId: string, role: MembershipRole) => void
+  onRemoveMember: (orgId: string, userId: string) => void
+  onCopyToken: (token: string) => void
+  onDeleteInvitation: (id: string) => void
+  onLeave: (orgId: string) => void
+  onArchive: (org: Org) => void
+}
 
-  // Account management modals.
-  const [showChangePassword, setShowChangePassword] = useState(false)
-  const [newPassword, setNewPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [changingPassword, setChangingPassword] = useState(false)
-
-  const [showChangeEmail, setShowChangeEmail] = useState(false)
-  const [emailStep, setEmailStep] = useState<'request' | 'confirm'>('request')
-  const [newEmail, setNewEmail] = useState('')
-  const [emailCode, setEmailCode] = useState('')
-  const [changingEmail, setChangingEmail] = useState(false)
-
-  const [showDeleteAccount, setShowDeleteAccount] = useState(false)
-  const [deleting, setDeleting] = useState(false)
-
-  // Org member management + archiving.
-  const [showArchive, setShowArchive] = useState(false)
-  const [archiving, setArchiving] = useState(false)
-  const [leaving, setLeaving] = useState(false)
-  // user_id currently being mutated (role change / removal), to disable its row.
-  const [busyMember, setBusyMember] = useState<string | null>(null)
-
-  // Integration status (DISPLAY only — no tokens stored).
-  const [githubStatus, setGithubStatus] = useState<GitHubAuthStatus | null>(null)
-  const atlassianEnabled = config?.integrations?.atlassian ?? true
-
-  useEffect(() => {
-    window.electronAPI.config.getGitHubAuthStatus().then(setGithubStatus).catch(() => setGithubStatus({ loggedIn: false }))
-  }, [])
-
-  const isAdmin = org?.role === 'admin'
-  const currentUserId = status.user?.id
+/**
+ * One organization, self-contained: identity, members, invitations and the
+ * destructive actions. A user can belong to several orgs, so the page renders
+ * one of these per membership rather than only showing the active one.
+ */
+function OrganizationCard({
+  org,
+  members,
+  invitations,
+  isActive,
+  currentUserId,
+  busyMember,
+  deletingInvite,
+  copiedToken,
+  leaving,
+  switching,
+  onSwitch,
+  onInvite,
+  onChangeRole,
+  onRemoveMember,
+  onCopyToken,
+  onDeleteInvitation,
+  onLeave,
+  onArchive,
+}: OrganizationCardProps) {
+  const isAdmin = org.role === 'admin'
   const adminCount = members.filter((m) => m.role === 'admin').length
-  // Sole admin: the last admin cannot leave/be demoted without lockout — such a
-  // user must archive the org instead of leaving it.
+  // Sole admin: the last admin cannot leave without locking everyone out — they
+  // must promote someone or archive the org instead.
   const isSoleAdmin = isAdmin && adminCount <= 1
 
-  const handleChangeRole = useCallback(async (userId: string, role: MembershipRole) => {
-    if (!org) return
+  return (
+    <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl overflow-hidden">
+      {/* Identity */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-white/5">
+        <div className="p-1.5 bg-accent/10 rounded-lg shrink-0">
+          <Building2 className="w-4 h-4 text-accent" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium truncate">{org.name}</div>
+        </div>
+        {isActive ? (
+          <span className="flex items-center h-7 px-2 rounded-lg text-[11px] font-medium bg-green/10 text-green shrink-0">
+            Active
+          </span>
+        ) : (
+          <button
+            onClick={() => onSwitch(org.id)}
+            disabled={switching}
+            className="flex items-center gap-1.5 h-7 px-2 text-[11px] font-medium text-text-secondary bg-white/[0.06] border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all disabled:opacity-40 shrink-0"
+            title="Make this the active organization"
+          >
+            {switching ? <Loader2 className="w-3 h-3 animate-spin" /> : <ArrowRightLeft className="w-3 h-3" />}
+            Switch to
+          </button>
+        )}
+      </div>
+
+      {/* Members */}
+      <div className="px-4 py-3 border-b border-white/5">
+        <CardSection label="Members" count={members.length} />
+        {members.length === 0 ? (
+          <div className="text-xs text-text-secondary/40 py-1">No members yet.</div>
+        ) : (
+          <div className="space-y-1">
+            {members.map((m) => {
+              const isSelf = m.userId === currentUserId
+              const rowBusy = busyMember === m.userId
+              return (
+                <div key={m.userId} className="flex items-center justify-between gap-2 py-0.5">
+                  <span className="text-sm truncate flex-1 min-w-0">
+                    {m.email ?? m.userId}
+                    {isSelf && <span className="text-text-secondary/40"> (you)</span>}
+                  </span>
+                  {rowBusy ? (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin text-text-secondary/50" />
+                  ) : isAdmin ? (
+                    <div className="flex items-center gap-2">
+                      <RoleSelect value={m.role} onChange={(role) => onChangeRole(org.id, m.userId, role)} />
+                      {!isSelf && (
+                        <button
+                          onClick={() => onRemoveMember(org.id, m.userId)}
+                          className="flex items-center justify-center h-7 w-7 shrink-0 text-text-secondary/60 bg-white/[0.06] border border-white/10 rounded-lg hover:text-red hover:border-red/20 hover:bg-red/10 transition-all"
+                          title="Remove member"
+                        >
+                          <X className="w-3.5 h-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  ) : (
+                    <span className={`flex items-center h-7 px-2 rounded-lg text-[11px] font-medium ${
+                      m.role === 'admin' ? 'bg-accent/15 text-accent' : 'bg-white/10 text-text-secondary'
+                    }`}>
+                      {m.role}
+                    </span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Invitations (admin only — a non-admin read yields [] anyway) */}
+      {isAdmin && (
+        <div className="px-4 py-3 border-b border-white/5">
+          <CardSection
+            label="Invitations"
+            count={invitations.length}
+            action={
+              <button
+                onClick={() => onInvite(org)}
+                className="flex items-center gap-1.5 h-7 px-2 text-[11px] font-medium text-text-secondary bg-white/[0.06] border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+              >
+                <UserPlus className="w-3 h-3" />
+                Invite
+              </button>
+            }
+          />
+          {invitations.length === 0 ? (
+            <div className="text-xs text-text-secondary/40 py-1">No invitation sent.</div>
+          ) : (
+            <div className="space-y-1">
+              {invitations.map((inv) => (
+                <div key={inv.id} className="flex items-center gap-2 text-sm py-0.5">
+                  <span className="flex-1 truncate min-w-0">{inv.email}</span>
+                  <span className={`flex items-center h-7 px-2 rounded-lg text-[11px] font-medium ${
+                    inv.status === 'pending' ? 'bg-yellow/10 text-yellow'
+                      : inv.status === 'accepted' ? 'bg-green/10 text-green'
+                      : 'bg-white/10 text-text-secondary'
+                  }`}>
+                    {inv.status}
+                  </span>
+                  {inv.status === 'pending' && (
+                    <button
+                      onClick={() => onCopyToken(inv.token)}
+                      className="flex items-center gap-1 h-7 px-2 text-[11px] font-medium text-text-secondary bg-white/[0.06] border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+                      title="Copy invitation link"
+                    >
+                      {copiedToken === inv.token ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+                      {copiedToken === inv.token ? 'Copied' : 'Invite link'}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => onDeleteInvitation(inv.id)}
+                    disabled={deletingInvite === inv.id}
+                    className="flex items-center justify-center h-7 w-7 shrink-0 text-text-secondary/60 bg-white/[0.06] border border-white/10 rounded-lg hover:text-red hover:border-red/20 hover:bg-red/10 transition-all disabled:opacity-50"
+                    title="Delete invitation"
+                  >
+                    {deletingInvite === inv.id ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Danger zone */}
+      <div className="px-4 py-3 flex items-center gap-2">
+        {isSoleAdmin ? (
+          <p className="text-xs text-text-secondary/50">
+            You are the last admin. Promote another member before leaving, or archive the organization.
+          </p>
+        ) : (
+          <button
+            onClick={() => onLeave(org.id)}
+            disabled={leaving}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all disabled:opacity-40"
+          >
+            {leaving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <LogOut className="w-3.5 h-3.5" />}
+            Leave organization
+          </button>
+        )}
+        {isAdmin && (
+          <button
+            onClick={() => onArchive(org)}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red border border-red/20 rounded-lg hover:bg-red/10 transition-all ml-auto"
+          >
+            <Archive className="w-3.5 h-3.5" />
+            Archive organization
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Accept both a raw token and a full invite link pasted from an email. */
+function extractInviteToken(input: string): string {
+  const trimmed = input.trim()
+  const match = trimmed.match(/\/invite\/([^/?#\s]+)/)
+  return match ? match[1] : trimmed
+}
+
+export function OrgPage() {
+  const { status, loading: authLoading } = useAuth()
+  const {
+    org: activeOrg,
+    orgs,
+    membersByOrg,
+    invitationsByOrg,
+    loading: orgLoading,
+    invite,
+    createOrg,
+    accept,
+    deleteInvitation,
+    removeMember,
+    updateRole,
+    leaveOrg,
+    archiveOrg,
+    switchOrg,
+  } = useOrg()
+
+  const [copiedToken, setCopiedToken] = useState<string | null>(null)
+  const [deletingInvite, setDeletingInvite] = useState<string | null>(null)
+  const [busyMember, setBusyMember] = useState<string | null>(null)
+  const [leavingOrgId, setLeavingOrgId] = useState<string | null>(null)
+  const [switchingOrgId, setSwitchingOrgId] = useState<string | null>(null)
+
+  // Modals. Each holds the org it acts on, so the same modal serves every card.
+  const [inviteOrg, setInviteOrg] = useState<Org | null>(null)
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [inviteRole, setInviteRole] = useState<MembershipRole>('user')
+  const [inviting, setInviting] = useState(false)
+
+  const [archiveOrgTarget, setArchiveOrgTarget] = useState<Org | null>(null)
+  const [archiving, setArchiving] = useState(false)
+
+  const [showCreate, setShowCreate] = useState(false)
+  const [createName, setCreateName] = useState('')
+  const [creating, setCreating] = useState(false)
+
+  const [showJoin, setShowJoin] = useState(false)
+  const [joinToken, setJoinToken] = useState('')
+  const [joining, setJoining] = useState(false)
+
+  const currentUserId = status.user?.id
+
+  const handleChangeRole = useCallback(async (orgId: string, userId: string, role: MembershipRole) => {
     setBusyMember(userId)
     try {
-      await updateRole(org.id, userId, role)
+      await updateRole(orgId, userId, role)
       showToast('Role updated', 'success')
     } catch (e) {
       showToast(e instanceof Error ? e.message : 'Failed to update role', 'error')
     } finally {
       setBusyMember(null)
     }
-  }, [org, updateRole])
+  }, [updateRole])
 
-  const handleRemoveMember = useCallback(async (userId: string) => {
-    if (!org) return
+  const handleRemoveMember = useCallback(async (orgId: string, userId: string) => {
     setBusyMember(userId)
     try {
-      await removeMember(org.id, userId)
+      await removeMember(orgId, userId)
       showToast('Member removed', 'success')
     } catch (e) {
       showToast(e instanceof Error ? e.message : 'Failed to remove member', 'error')
     } finally {
       setBusyMember(null)
     }
-  }, [org, removeMember])
+  }, [removeMember])
 
-  const handleLeave = useCallback(async () => {
-    if (!org || leaving) return
-    setLeaving(true)
+  const handleLeave = useCallback(async (orgId: string) => {
+    setLeavingOrgId(orgId)
     try {
-      await leaveOrg(org.id)
+      await leaveOrg(orgId)
       showToast('You left the organization', 'success')
     } catch (e) {
       showToast(e instanceof Error ? e.message : 'Failed to leave organization', 'error')
     } finally {
-      setLeaving(false)
+      setLeavingOrgId(null)
     }
-  }, [org, leaving, leaveOrg])
+  }, [leaveOrg])
+
+  const handleSwitch = useCallback(async (orgId: string) => {
+    setSwitchingOrgId(orgId)
+    try {
+      await switchOrg(orgId)
+      showToast('Switched organization', 'success')
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to switch organization', 'error')
+    } finally {
+      setSwitchingOrgId(null)
+    }
+  }, [switchOrg])
 
   const handleArchive = useCallback(async () => {
-    if (!org || archiving) return
+    if (!archiveOrgTarget || archiving) return
     setArchiving(true)
     try {
-      await archiveOrg(org.id)
+      await archiveOrg(archiveOrgTarget.id)
       showToast('Organization archived', 'success')
-      setShowArchive(false)
+      setArchiveOrgTarget(null)
     } catch (e) {
       showToast(e instanceof Error ? e.message : 'Failed to archive organization', 'error')
     } finally {
       setArchiving(false)
     }
-  }, [org, archiving, archiveOrg])
+  }, [archiveOrgTarget, archiving, archiveOrg])
+
+  const openInvite = useCallback((org: Org) => {
+    setInviteOrg(org)
+    setInviteEmail('')
+    setInviteRole('user')
+  }, [])
 
   const handleInvite = useCallback(async () => {
-    if (inviting || !inviteEmail.trim()) return
+    if (!inviteOrg || inviting || !inviteEmail.trim()) return
     setInviting(true)
     try {
-      await invite(inviteEmail.trim())
-      setInviteEmail('')
+      await invite(inviteEmail.trim(), inviteRole, inviteOrg.id)
       showToast('Invitation created', 'success')
+      setInviteOrg(null)
     } catch (e) {
       showToast(e instanceof Error ? e.message : 'Failed to create invitation', 'error')
     } finally {
       setInviting(false)
     }
-  }, [inviting, inviteEmail, invite])
+  }, [inviteOrg, inviting, inviteEmail, inviteRole, invite])
 
-  const handleLogout = useCallback(async () => {
-    await logout()
-    await refresh()
-  }, [logout, refresh])
-
-  const resetPasswordModal = useCallback(() => {
-    setShowChangePassword(false)
-    setNewPassword('')
-    setConfirmPassword('')
-  }, [])
-
-  const handleChangePassword = useCallback(async () => {
-    if (changingPassword) return
-    if (!newPassword || newPassword !== confirmPassword) {
-      showToast('Passwords do not match', 'error')
-      return
-    }
-    setChangingPassword(true)
+  const handleCreate = useCallback(async () => {
+    if (creating || !createName.trim()) return
+    setCreating(true)
     try {
-      await updatePassword(newPassword)
-      showToast('Password updated', 'success')
-      resetPasswordModal()
+      await createOrg(createName.trim())
+      showToast(`Organization "${createName.trim()}" created`, 'success')
+      setShowCreate(false)
+      setCreateName('')
     } catch (e) {
-      showToast(e instanceof Error ? e.message : 'Failed to update password', 'error')
+      showToast(e instanceof Error ? e.message : 'Failed to create organization', 'error')
     } finally {
-      setChangingPassword(false)
+      setCreating(false)
     }
-  }, [changingPassword, newPassword, confirmPassword, updatePassword, resetPasswordModal])
+  }, [creating, createName, createOrg])
 
-  const resetEmailModal = useCallback(() => {
-    setShowChangeEmail(false)
-    setEmailStep('request')
-    setNewEmail('')
-    setEmailCode('')
-  }, [])
-
-  const handleChangeEmail = useCallback(async () => {
-    if (changingEmail) return
-    setChangingEmail(true)
+  const handleJoin = useCallback(async () => {
+    if (joining || !joinToken.trim()) return
+    setJoining(true)
     try {
-      if (emailStep === 'request') {
-        if (!newEmail.trim()) { showToast('Enter a new email', 'error'); return }
-        await requestEmailChange(newEmail.trim())
-        showToast('Check your new email for the confirmation code', 'success')
-        setEmailStep('confirm')
-      } else {
-        if (!emailCode.trim()) { showToast('Enter the code', 'error'); return }
-        await confirmEmailChange(newEmail.trim(), emailCode.trim())
-        showToast('Email updated', 'success')
-        resetEmailModal()
-        await refresh()
-      }
+      await accept(extractInviteToken(joinToken))
+      showToast('You joined the organization', 'success')
+      setShowJoin(false)
+      setJoinToken('')
     } catch (e) {
-      showToast(e instanceof Error ? e.message : 'Failed to change email', 'error')
+      showToast(e instanceof Error ? e.message : 'Failed to join organization', 'error')
     } finally {
-      setChangingEmail(false)
+      setJoining(false)
     }
-  }, [changingEmail, emailStep, newEmail, emailCode, requestEmailChange, confirmEmailChange, resetEmailModal, refresh])
+  }, [joining, joinToken, accept])
 
-  const handleDeleteAccount = useCallback(async () => {
-    if (deleting) return
-    setDeleting(true)
-    try {
-      await deleteAccount()
-      showToast('Your account has been deleted', 'success')
-      setShowDeleteAccount(false)
-      await refresh()
-    } catch (e) {
-      showToast(e instanceof Error ? e.message : 'Failed to delete account', 'error')
-    } finally {
-      setDeleting(false)
-    }
-  }, [deleting, deleteAccount, refresh])
-
-  // Share a web invite link (app.magic-slash.io/invite/<token>) rather than the
-  // raw token: the invitee opens it, signs up, and joins the org in one flow.
   const handleCopyToken = useCallback((token: string) => {
     const link = `https://app.magic-slash.io/invite/${token}`
     navigator.clipboard.writeText(link).then(() => {
@@ -221,20 +413,11 @@ export function OrgPage() {
     }
   }, [deleteInvitation])
 
-  const handleAtlassianToggle = useCallback(async () => {
-    const next = !atlassianEnabled
-    const result = await window.electronAPI.config.setIntegration('atlassian', next)
-    setConfig(result.config)
-  }, [atlassianEnabled, setConfig])
-
   // Cloud disabled entirely (no Supabase env baked in) → hide cloud features.
   if (!authLoading && !status.enabled) {
     return (
       <div className="flex flex-col gap-6">
-        <div className="flex items-center gap-2 text-sm text-text-secondary">
-          <Cloud className="w-4 h-4" />
-          <span>Organization</span>
-        </div>
+        <SectionHeader icon={Cloud} title="Organization" spacing="none" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-6 text-center">
           <Cloud className="w-8 h-8 text-text-secondary/30 mx-auto mb-3" />
           <div className="text-sm text-text-secondary/60">Cloud features are not configured in this build.</div>
@@ -244,446 +427,207 @@ export function OrgPage() {
     )
   }
 
-  return (
-    <div className="flex flex-col gap-8">
-      {/* Account */}
-      <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <Cloud className="w-4 h-4" />
-          <span>Cloud account</span>
-        </div>
-        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
-          {status.loggedIn ? (
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="text-sm font-medium">{status.user?.email ?? 'Signed in'}</div>
-                  <div className="text-xs text-text-secondary/50 mt-0.5">Signed in to Magic Slash cloud</div>
-                </div>
-                <button
-                  onClick={handleLogout}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
-                >
-                  <LogOut className="w-3.5 h-3.5" />
-                  Sign out
-                </button>
-              </div>
-              <div className="border-t border-white/5 pt-3 flex flex-wrap items-center gap-2">
-                <button
-                  onClick={() => setShowChangePassword(true)}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
-                >
-                  <KeyRound className="w-3.5 h-3.5" />
-                  Change password
-                </button>
-                <button
-                  onClick={() => setShowChangeEmail(true)}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
-                >
-                  <AtSign className="w-3.5 h-3.5" />
-                  Change email
-                </button>
-                <button
-                  onClick={() => setShowDeleteAccount(true)}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red border border-red/20 rounded-lg hover:bg-red/10 transition-all ml-auto"
-                >
-                  <Trash2 className="w-3.5 h-3.5" />
-                  Delete my account
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="text-sm font-medium">Not signed in</div>
-                <div className="text-xs text-text-secondary/50 mt-0.5">Sign in to manage your organization (optional)</div>
-              </div>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => setShowInvitationWizard(true)}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
-                >
-                  <UserPlus className="w-3.5 h-3.5" />
-                  Join with invitation
-                </button>
-                <button
-                  onClick={() => setShowLogin(true)}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all"
-                >
-                  <LogIn className="w-3.5 h-3.5" />
-                  Sign in
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
+  if (!status.loggedIn) {
+    return (
+      <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-6 text-center">
+        <Building2 className="w-8 h-8 text-text-secondary/30 mx-auto mb-3" />
+        <div className="text-sm text-text-secondary/60">Sign in to manage your organization.</div>
+        <div className="text-xs text-text-secondary/40 mt-1">Settings → Account → Cloud account.</div>
       </div>
+    )
+  }
 
-      {/* Organization (signed in) */}
-      {status.loggedIn && (
-        <>
-          <div>
-            <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-              <Building2 className="w-4 h-4" />
-              <span>Organization</span>
-            </div>
-            <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
-              {orgLoading ? (
-                <div className="flex items-center justify-center py-4 text-text-secondary/50">
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                </div>
-              ) : org ? (
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="text-sm font-medium">{org.name}</div>
-                      <div className="text-xs text-text-secondary/50 mt-0.5">Your role in this organization</div>
-                    </div>
-                    <span className={`flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium ${isAdmin ? 'bg-accent/15 text-accent' : 'bg-white/10 text-text-secondary'}`}>
-                      {isAdmin && <Shield className="w-3 h-3" />}
-                      {org.role}
-                    </span>
-                  </div>
-                  <div className="border-t border-white/5 pt-3 flex items-center gap-2">
-                    {isSoleAdmin ? (
-                      <p className="text-xs text-text-secondary/50">
-                        You are the last admin. Promote another member before leaving, or archive the organization below.
-                      </p>
-                    ) : (
-                      <button
-                        onClick={handleLeave}
-                        disabled={leaving}
-                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all disabled:opacity-40"
-                      >
-                        {leaving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <LogOut className="w-3.5 h-3.5" />}
-                        Leave organization
-                      </button>
-                    )}
-                    {isAdmin && (
-                      <button
-                        onClick={() => setShowArchive(true)}
-                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red border border-red/20 rounded-lg hover:bg-red/10 transition-all ml-auto"
-                      >
-                        <Archive className="w-3.5 h-3.5" />
-                        Archive organization
-                      </button>
-                    )}
-                  </div>
-                </div>
-              ) : (
-                <div className="text-sm text-text-secondary/50 text-center py-2">No organization found for this account.</div>
-              )}
-            </div>
-          </div>
+  return (
+    <div className="flex flex-col gap-4">
+      <SectionHeader icon={Building2} title={`Organizations (${orgs.length})`} spacing="none" />
 
-          {/* Members */}
-          {org && (
-            <div>
-              <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-                <Users className="w-4 h-4" />
-                <span>Members ({members.length})</span>
-              </div>
-              <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-2">
-                {members.length === 0 ? (
-                  <div className="text-sm text-text-secondary/50 text-center py-2">No members yet.</div>
-                ) : (
-                  members.map((m) => {
-                    const isSelf = m.userId === currentUserId
-                    const rowBusy = busyMember === m.userId
-                    return (
-                      <div key={m.userId} className="flex items-center justify-between gap-2 py-1">
-                        <span className="text-sm truncate flex-1">
-                          {m.email ?? m.userId}
-                          {isSelf && <span className="text-text-secondary/40"> (you)</span>}
-                        </span>
-                        {rowBusy ? (
-                          <Loader2 className="w-3.5 h-3.5 animate-spin text-text-secondary/50" />
-                        ) : isAdmin ? (
-                          <div className="flex items-center gap-2">
-                            <select
-                              value={m.role}
-                              onChange={(e) => handleChangeRole(m.userId, e.target.value as MembershipRole)}
-                              className="px-2 py-0.5 bg-white/[0.06] border border-white/10 rounded text-[11px] font-medium text-text-secondary focus:outline-none focus:border-accent transition-colors"
-                            >
-                              <option value="user">user</option>
-                              <option value="admin">admin</option>
-                            </select>
-                            {!isSelf && (
-                              <button
-                                onClick={() => handleRemoveMember(m.userId)}
-                                className="p-1 text-text-secondary/60 rounded hover:bg-red/10 hover:text-red transition-all"
-                                title="Remove member"
-                              >
-                                <X className="w-3.5 h-3.5" />
-                              </button>
-                            )}
-                          </div>
-                        ) : (
-                          <span className={`px-2 py-0.5 rounded text-[11px] font-medium ${m.role === 'admin' ? 'bg-accent/15 text-accent' : 'bg-white/10 text-text-secondary'}`}>
-                            {m.role}
-                          </span>
-                        )}
-                      </div>
-                    )
-                  })
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Invitations (admin only) */}
-          {org && isAdmin && (
-            <div>
-              <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-                <Mail className="w-4 h-4" />
-                <span>Invite a colleague</span>
-              </div>
-              <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
-                <div className="flex items-center gap-2">
-                  <input
-                    type="email"
-                    value={inviteEmail}
-                    onChange={(e) => setInviteEmail(e.target.value)}
-                    placeholder="colleague@example.com"
-                    onKeyDown={(e) => { if (e.key === 'Enter') handleInvite() }}
-                    className="flex-1 px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
-                  />
-                  <button
-                    onClick={handleInvite}
-                    disabled={inviting || !inviteEmail.trim()}
-                    className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40"
-                  >
-                    {inviting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Mail className="w-3.5 h-3.5" />}
-                    Invite
-                  </button>
-                </div>
-
-                {invitations.length > 0 && (
-                  <div className="border-t border-white/5 pt-4 space-y-2">
-                    {invitations.map((inv) => (
-                      <div key={inv.id} className="flex items-center gap-2 text-sm">
-                        <span className="flex-1 truncate">{inv.email}</span>
-                        <span className={`px-2 py-0.5 rounded text-[11px] font-medium ${
-                          inv.status === 'pending' ? 'bg-yellow/10 text-yellow'
-                            : inv.status === 'accepted' ? 'bg-green/10 text-green'
-                            : 'bg-white/10 text-text-secondary'
-                        }`}>
-                          {inv.status}
-                        </span>
-                        {inv.status === 'pending' && (
-                          <button
-                            onClick={() => handleCopyToken(inv.token)}
-                            className="flex items-center gap-1 px-2 py-0.5 text-[11px] text-text-secondary border border-white/10 rounded hover:bg-white/10 hover:text-white transition-all"
-                            title="Copy invitation link"
-                          >
-                            {copiedToken === inv.token ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
-                            {copiedToken === inv.token ? 'Copied' : 'Invite link'}
-                          </button>
-                        )}
-                        <button
-                          onClick={() => handleDeleteInvitation(inv.id)}
-                          disabled={deletingInvite === inv.id}
-                          className="flex items-center justify-center p-1 text-text-secondary/60 rounded hover:text-red hover:bg-red/10 transition-colors disabled:opacity-50"
-                          title="Delete invitation"
-                        >
-                          {deletingInvite === inv.id ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-        </>
+      {orgLoading && orgs.length === 0 ? (
+        <div className="flex items-center justify-center py-8 text-text-secondary/50">
+          <Loader2 className="w-4 h-4 animate-spin" />
+        </div>
+      ) : orgs.length === 0 ? (
+        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-6 text-center">
+          <Users className="w-8 h-8 text-text-secondary/30 mx-auto mb-3" />
+          <div className="text-sm text-text-secondary/60">You do not belong to any organization.</div>
+          <div className="text-xs text-text-secondary/40 mt-1">Create one, or join with an invitation.</div>
+        </div>
+      ) : (
+        orgs.map((o) => (
+          <OrganizationCard
+            key={o.id}
+            org={o}
+            members={membersByOrg[o.id] ?? []}
+            invitations={invitationsByOrg[o.id] ?? []}
+            isActive={o.id === activeOrg?.id}
+            currentUserId={currentUserId}
+            busyMember={busyMember}
+            deletingInvite={deletingInvite}
+            copiedToken={copiedToken}
+            leaving={leavingOrgId === o.id}
+            switching={switchingOrgId === o.id}
+            onSwitch={handleSwitch}
+            onInvite={openInvite}
+            onChangeRole={handleChangeRole}
+            onRemoveMember={handleRemoveMember}
+            onCopyToken={handleCopyToken}
+            onDeleteInvitation={handleDeleteInvitation}
+            onLeave={handleLeave}
+            onArchive={setArchiveOrgTarget}
+          />
+        ))
       )}
 
-      {/* Integrations status (detection/display only — no tokens stored) */}
-      <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <Github className="w-4 h-4" />
-          <span>Integrations</span>
-        </div>
-        <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <div className="text-sm font-medium">GitHub CLI</div>
-              <div className="text-xs text-text-secondary/50 mt-0.5">
-                {githubStatus?.loggedIn
-                  ? `Detected via gh${githubStatus.account ? ` — ${githubStatus.account}` : ''}`
-                  : 'Not detected. Run `gh auth login` in your terminal.'}
-              </div>
-            </div>
-            <span className={`px-2 py-0.5 rounded text-[11px] font-medium ${githubStatus?.loggedIn ? 'bg-green/10 text-green' : 'bg-red/10 text-red'}`}>
-              {githubStatus?.loggedIn ? 'Connected' : 'Not connected'}
-            </span>
-          </div>
-          <div className="border-t border-white/5 pt-4 flex items-center justify-between">
-            <div>
-              <div className="text-sm font-medium">Atlassian (Jira)</div>
-              <div className="text-xs text-text-secondary/50 mt-0.5">Auth is handled by the Atlassian MCP server. Toggle whether Jira features are enabled.</div>
-            </div>
-            <button
-              onClick={handleAtlassianToggle}
-              className={`relative w-10 h-[22px] rounded-full transition-colors duration-200 flex-shrink-0 ${atlassianEnabled ? 'bg-accent' : 'bg-white/20'}`}
-            >
-              <div className={`absolute top-[3px] left-[3px] w-4 h-4 rounded-full bg-white transition-transform duration-200 ${atlassianEnabled ? 'translate-x-[18px]' : 'translate-x-0'}`} />
-            </button>
-          </div>
-        </div>
+      {/* Create / join */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => { setCreateName(''); setShowCreate(true) }}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary bg-white/[0.06] border border-white/[0.15] rounded-lg hover:bg-white/[0.12] hover:text-white transition-all"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          Create an organization
+        </button>
+        <button
+          onClick={() => { setJoinToken(''); setShowJoin(true) }}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary bg-white/[0.06] border border-white/[0.15] rounded-lg hover:bg-white/[0.12] hover:text-white transition-all"
+        >
+          <UserPlus className="w-3.5 h-3.5" />
+          Join an organization
+        </button>
       </div>
 
-      <LoginScreen isOpen={showLogin} onClose={() => setShowLogin(false)} onSignedIn={refresh} />
-      <InvitationOnboardingWizard isOpen={showInvitationWizard} onClose={() => { setShowInvitationWizard(false); refresh() }} />
-
-      {/* Change password */}
+      {/* Invite a member */}
       <Modal
-        isOpen={showChangePassword}
-        onClose={resetPasswordModal}
-        title="Change password"
+        isOpen={inviteOrg !== null}
+        onClose={() => setInviteOrg(null)}
+        title={inviteOrg ? `Invite to ${inviteOrg.name}` : 'Invite'}
         footer={
           <>
             <button
-              onClick={resetPasswordModal}
+              onClick={() => setInviteOrg(null)}
               className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
             >
               Cancel
             </button>
             <button
-              onClick={handleChangePassword}
-              disabled={changingPassword || !newPassword || newPassword !== confirmPassword}
+              onClick={handleInvite}
+              disabled={inviting || !inviteEmail.trim()}
               className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40"
             >
-              {changingPassword ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <KeyRound className="w-3.5 h-3.5" />}
-              Update password
+              {inviting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Mail className="w-3.5 h-3.5" />}
+              Send invitation
+            </button>
+          </>
+        }
+      >
+        <div className="space-y-3">
+          <p className="text-xs text-text-secondary/60">
+            An invitation link is generated — copy it from the list and send it to your colleague.
+          </p>
+          <input
+            type="email"
+            value={inviteEmail}
+            onChange={(e) => setInviteEmail(e.target.value)}
+            placeholder="colleague@example.com"
+            autoFocus
+            onKeyDown={(e) => { if (e.key === 'Enter') handleInvite() }}
+            className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+          />
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-secondary/60">Role</span>
+            <RoleSelect value={inviteRole} onChange={setInviteRole} />
+          </div>
+        </div>
+      </Modal>
+
+      {/* Create an organization */}
+      <Modal
+        isOpen={showCreate}
+        onClose={() => setShowCreate(false)}
+        title="Create an organization"
+        footer={
+          <>
+            <button
+              onClick={() => setShowCreate(false)}
+              className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={creating || !createName.trim()}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40"
+            >
+              {creating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Plus className="w-3.5 h-3.5" />}
+              Create
             </button>
           </>
         }
       >
         <div className="space-y-2">
+          <p className="text-xs text-text-secondary/60">
+            You become its admin. It is not made active — use “Switch to” on the card when you want to work in it.
+          </p>
           <input
-            type="password"
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-            placeholder="New password"
+            type="text"
+            value={createName}
+            onChange={(e) => setCreateName(e.target.value)}
+            placeholder="Organization name"
             autoFocus
-            className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
-          />
-          <input
-            type="password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            placeholder="Confirm new password"
-            onKeyDown={(e) => { if (e.key === 'Enter') handleChangePassword() }}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleCreate() }}
             className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
           />
         </div>
       </Modal>
 
-      {/* Change email (OTP code flow) */}
+      {/* Join an organization */}
       <Modal
-        isOpen={showChangeEmail}
-        onClose={resetEmailModal}
-        title="Change email"
+        isOpen={showJoin}
+        onClose={() => setShowJoin(false)}
+        title="Join an organization"
         footer={
           <>
             <button
-              onClick={resetEmailModal}
+              onClick={() => setShowJoin(false)}
               className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
             >
               Cancel
             </button>
             <button
-              onClick={handleChangeEmail}
-              disabled={changingEmail}
+              onClick={handleJoin}
+              disabled={joining || !joinToken.trim()}
               className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40"
             >
-              {changingEmail ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <AtSign className="w-3.5 h-3.5" />}
-              {emailStep === 'request' ? 'Send code' : 'Confirm change'}
+              {joining ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <UserPlus className="w-3.5 h-3.5" />}
+              Join
             </button>
           </>
         }
       >
-        {emailStep === 'request' ? (
-          <div className="space-y-2">
-            <p className="text-xs text-text-secondary/60">
-              We'll email a 6-digit confirmation code to your new address.
-            </p>
-            <input
-              type="email"
-              value={newEmail}
-              onChange={(e) => setNewEmail(e.target.value)}
-              placeholder="New email"
-              autoFocus
-              onKeyDown={(e) => { if (e.key === 'Enter') handleChangeEmail() }}
-              className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
-            />
-          </div>
-        ) : (
-          <div className="space-y-2">
-            <p className="text-xs text-text-secondary/60">
-              Check <span className="text-white">{newEmail}</span> for the confirmation code and enter it below.
-            </p>
-            <input
-              type="text"
-              inputMode="numeric"
-              value={emailCode}
-              onChange={(e) => setEmailCode(e.target.value)}
-              placeholder="6-digit code"
-              autoFocus
-              onKeyDown={(e) => { if (e.key === 'Enter') handleChangeEmail() }}
-              className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
-            />
-          </div>
-        )}
-      </Modal>
-
-      {/* Delete account (danger) */}
-      <Modal
-        isOpen={showDeleteAccount}
-        onClose={() => setShowDeleteAccount(false)}
-        title="Delete my account"
-        footer={
-          <>
-            <button
-              onClick={() => setShowDeleteAccount(false)}
-              className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleDeleteAccount}
-              disabled={deleting}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-red hover:bg-red/80 rounded-lg transition-all disabled:opacity-40"
-            >
-              {deleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
-              Delete permanently
-            </button>
-          </>
-        }
-      >
-        <div className="flex items-start gap-3">
-          <div className="p-2 bg-red/10 rounded-lg flex-shrink-0">
-            <AlertTriangle className="w-4 h-4 text-red" />
-          </div>
-          <div className="space-y-1">
-            <p className="text-sm text-white">This permanently deletes your account and personal data.</p>
-            <p className="text-xs text-text-secondary/60">
-              Organizations you created will be removed along with their data. This cannot be undone. Magic Slash keeps working locally without an account.
-            </p>
-          </div>
+        <div className="space-y-2">
+          <p className="text-xs text-text-secondary/60">
+            Paste the invitation link you received, or just its token.
+          </p>
+          <input
+            type="text"
+            value={joinToken}
+            onChange={(e) => setJoinToken(e.target.value)}
+            placeholder="https://app.magic-slash.io/invite/…"
+            autoFocus
+            onKeyDown={(e) => { if (e.key === 'Enter') handleJoin() }}
+            className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+          />
         </div>
       </Modal>
 
       {/* Archive organization (danger) */}
       <Modal
-        isOpen={showArchive}
-        onClose={() => setShowArchive(false)}
+        isOpen={archiveOrgTarget !== null}
+        onClose={() => setArchiveOrgTarget(null)}
         title="Archive organization"
         footer={
           <>
             <button
-              onClick={() => setShowArchive(false)}
+              onClick={() => setArchiveOrgTarget(null)}
               className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-white/10 rounded-lg hover:bg-white/10 hover:text-white transition-all"
             >
               Cancel
@@ -704,7 +648,7 @@ export function OrgPage() {
             <AlertTriangle className="w-4 h-4 text-red" />
           </div>
           <div className="space-y-1">
-            <p className="text-sm text-white">Archive {org?.name ?? 'this organization'}?</p>
+            <p className="text-sm text-white">Archive {archiveOrgTarget?.name ?? 'this organization'}?</p>
             <p className="text-xs text-text-secondary/60">
               The organization and its members lose access — it disappears for everyone. Its data is retained, not deleted, but this cannot be undone from the app.
             </p>

--- a/desktop/src/renderer/pages/Config/ProfileForm.tsx
+++ b/desktop/src/renderer/pages/Config/ProfileForm.tsx
@@ -1,0 +1,175 @@
+import { useState, useCallback } from 'react'
+import { Check, Loader2 } from 'lucide-react'
+import { ROLE_LABELS, LEVEL_LABELS, STYLE_LABELS, type UserProfile } from '../../../types'
+import { showToast } from '../../components/Toast'
+
+const ROLE_OPTIONS = (Object.entries(ROLE_LABELS) as [UserProfile['role'], string][]).map(
+  ([value, label]) => ({ value, label })
+)
+const LEVEL_OPTIONS = (Object.entries(LEVEL_LABELS) as [UserProfile['technical_level'], string][]).map(
+  ([value, label]) => ({ value, label })
+)
+const STYLE_OPTIONS = (Object.entries(STYLE_LABELS) as [NonNullable<UserProfile['communication_style']>, string][]).map(
+  ([value, label]) => ({ value, label })
+)
+const LANGUAGE_OPTIONS = ['English', 'Français']
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-xs font-medium text-white mb-1.5">
+        {label}
+        {hint && <span className="ml-1.5 font-normal text-text-secondary/50">{hint}</span>}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function Pill({ selected, onClick, children }: { selected: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1.5 text-xs rounded-lg border transition-all ${
+        selected
+          ? 'bg-accent/10 border-accent/30 text-accent'
+          : 'bg-white/[0.06] border-white/[0.08] text-text-secondary hover:bg-white/10 hover:text-white'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+/**
+ * Single-screen profile form, used when no profile exists yet so the Account tab
+ * can be filled in place. The 6-step ProfileOnboardingWizard stays the entry
+ * point for first launch and for editing — this is the same fields, flattened.
+ */
+export function ProfileForm({ onSaved }: { onSaved: () => void }) {
+  const [name, setName] = useState('')
+  const [role, setRole] = useState<UserProfile['role'] | ''>('')
+  const [technicalLevel, setTechnicalLevel] = useState<UserProfile['technical_level'] | ''>('')
+  const [communicationStyle, setCommunicationStyle] = useState<UserProfile['communication_style'] | ''>('')
+  const [languages, setLanguages] = useState<string[]>([])
+  const [freeText, setFreeText] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  // Name, role and level are what the /magic:* skills actually branch on.
+  const canSave = name.trim().length > 0 && role !== '' && technicalLevel !== ''
+
+  const toggleLanguage = useCallback((lang: string) => {
+    setLanguages((prev) => (prev.includes(lang) ? prev.filter((l) => l !== lang) : [...prev, lang]))
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    if (!canSave || saving) return
+    setSaving(true)
+    try {
+      const profile: UserProfile = {
+        name: name.trim(),
+        role: role as UserProfile['role'],
+        technical_level: technicalLevel as UserProfile['technical_level'],
+      }
+      if (communicationStyle) profile.communication_style = communicationStyle as UserProfile['communication_style']
+      if (languages.length > 0) profile.languages = languages
+      if (freeText.trim()) profile.freeText = freeText.trim()
+
+      await window.electronAPI.profile.save(profile)
+      showToast('Profile saved', 'success')
+      onSaved()
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Failed to save profile', 'error')
+    } finally {
+      setSaving(false)
+    }
+  }, [canSave, saving, name, role, technicalLevel, communicationStyle, languages, freeText, onSaved])
+
+  return (
+    <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 flex flex-col gap-4">
+      <p className="text-xs text-text-secondary/60">
+        No profile yet. Claude uses it to adapt its vocabulary, level of detail and language to you.
+      </p>
+
+      <Field label="First name">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Your first name"
+          className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30"
+        />
+      </Field>
+
+      <Field label="Role">
+        <div className="flex flex-wrap gap-1.5">
+          {ROLE_OPTIONS.map((opt) => (
+            <Pill key={opt.value} selected={role === opt.value} onClick={() => setRole(opt.value)}>
+              {opt.label}
+            </Pill>
+          ))}
+        </div>
+      </Field>
+
+      <Field label="Technical level">
+        <div className="flex flex-wrap gap-1.5">
+          {LEVEL_OPTIONS.map((opt) => (
+            <Pill
+              key={opt.value}
+              selected={technicalLevel === opt.value}
+              onClick={() => setTechnicalLevel(opt.value)}
+            >
+              {opt.label}
+            </Pill>
+          ))}
+        </div>
+      </Field>
+
+      <Field label="Communication style" hint="optional">
+        <div className="flex flex-wrap gap-1.5">
+          {STYLE_OPTIONS.map((opt) => (
+            <Pill
+              key={opt.value}
+              selected={communicationStyle === opt.value}
+              onClick={() => setCommunicationStyle((prev) => (prev === opt.value ? '' : opt.value))}
+            >
+              {opt.label}
+            </Pill>
+          ))}
+        </div>
+      </Field>
+
+      <Field label="Languages" hint="optional">
+        <div className="flex flex-wrap gap-1.5">
+          {LANGUAGE_OPTIONS.map((lang) => (
+            <Pill key={lang} selected={languages.includes(lang)} onClick={() => toggleLanguage(lang)}>
+              {lang}
+            </Pill>
+          ))}
+        </div>
+      </Field>
+
+      <Field label="Anything else" hint="optional">
+        <textarea
+          value={freeText}
+          onChange={(e) => setFreeText(e.target.value)}
+          placeholder="e.g., I prefer short answers, I work on mobile apps..."
+          rows={3}
+          className="w-full px-3 py-2 bg-white/[0.06] border border-white/[0.08] rounded-lg text-sm text-white focus:outline-none focus:border-accent transition-colors placeholder:text-text-secondary/30 resize-none"
+        />
+      </Field>
+
+      <div className="flex justify-end">
+        <button
+          onClick={handleSave}
+          disabled={!canSave || saving}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent hover:bg-accent-hover rounded-lg transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {saving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Check className="w-3.5 h-3.5" />}
+          Save profile
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/desktop/src/renderer/pages/Config/ProfileSection.tsx
+++ b/desktop/src/renderer/pages/Config/ProfileSection.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
-import { User, Pencil, Plus } from 'lucide-react'
+import { User, Pencil } from 'lucide-react'
 import { ProfileOnboardingWizard } from '../../components/ProfileOnboardingWizard'
+import { ProfileForm } from './ProfileForm'
+import { SectionHeader } from './SectionHeader'
 import { ROLE_LABELS, LEVEL_LABELS, STYLE_LABELS, type UserProfile } from '../../../types'
 
 export function ProfileSection() {
@@ -33,12 +35,10 @@ export function ProfileSection() {
   return (
     <>
       <div>
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2 text-sm text-text-secondary">
-            <User className="w-4 h-4" />
-            <span>Profile</span>
-          </div>
-          {profile && (
+        <SectionHeader
+          icon={User}
+          title="Profile"
+          action={profile && (
             <button
               onClick={() => setShowWizard(true)}
               className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-text-secondary bg-white/[0.06] border border-white/[0.15] rounded-lg hover:bg-white/[0.12] hover:text-white transition-all"
@@ -47,7 +47,7 @@ export function ProfileSection() {
               <span>Edit profile</span>
             </button>
           )}
-        </div>
+        />
 
         {profile ? (
           <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
@@ -82,17 +82,8 @@ export function ProfileSection() {
             </div>
           </div>
         ) : (
-          <button
-            onClick={() => setShowWizard(true)}
-            className="w-full py-6 text-center border border-dashed border-border/50 rounded-xl hover:border-text-secondary/50 hover:bg-white/5 transition-colors"
-          >
-            <User className="w-6 h-6 text-text-secondary/30 mx-auto mb-2" />
-            <div className="text-sm text-text-secondary/50 mb-1">No profile configured</div>
-            <div className="flex items-center gap-1 justify-center text-xs text-accent/70">
-              <Plus className="w-3 h-3" />
-              Create profile
-            </div>
-          </button>
+          /* No profile → fill it in right here rather than behind a wizard. */
+          <ProfileForm onSaved={loadProfile} />
         )}
       </div>
 

--- a/desktop/src/renderer/pages/Config/RoleSelect.tsx
+++ b/desktop/src/renderer/pages/Config/RoleSelect.tsx
@@ -1,0 +1,153 @@
+import { useRef, useState, useEffect, useCallback, useLayoutEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { Check, ChevronDown, Shield, User } from 'lucide-react'
+import type { MembershipRole } from '../../../types'
+
+const ROLE_OPTIONS: { value: MembershipRole; label: string; description: string; icon: typeof Shield }[] = [
+  { value: 'user', label: 'User', description: 'Can see the team and work on shared repositories', icon: User },
+  { value: 'admin', label: 'Admin', description: 'Can invite, change roles and archive the organization', icon: Shield },
+]
+
+const PANEL_WIDTH = 240
+const VIEWPORT_MARGIN = 8
+
+/**
+ * Role picker for a member row. Replaces the native <select>, which macOS
+ * renders with its own popup and ignores the app's dark styling.
+ *
+ * The panel is portalled to <body> and positioned `fixed`: inline it would be
+ * clipped by any scrolling ancestor, and it lives inside Modal — whose panel is
+ * `max-h-[90vh] overflow-y-auto`, so an absolutely-positioned dropdown got cut off.
+ */
+export function RoleSelect({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: MembershipRole
+  onChange: (role: MembershipRole) => void
+  disabled?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  const close = useCallback(() => setOpen(false), [])
+
+  // Anchor the panel to the trigger, flipping above when it would overflow the
+  // bottom of the viewport. Measured before paint so it never renders misplaced.
+  useLayoutEffect(() => {
+    if (!open) return
+    const trigger = triggerRef.current
+    if (!trigger) return
+
+    const rect = trigger.getBoundingClientRect()
+    const panelHeight = panelRef.current?.offsetHeight ?? 0
+    const spaceBelow = window.innerHeight - rect.bottom
+
+    const top = panelHeight > 0 && spaceBelow < panelHeight + VIEWPORT_MARGIN
+      ? rect.top - panelHeight - 4
+      : rect.bottom + 4
+
+    const left = Math.max(
+      VIEWPORT_MARGIN,
+      Math.min(rect.right - PANEL_WIDTH, window.innerWidth - PANEL_WIDTH - VIEWPORT_MARGIN),
+    )
+
+    setPosition({ top, left })
+  }, [open])
+
+  // Close on outside click, Escape, or anything that would detach the panel from
+  // its trigger (scrolling an ancestor, resizing). The portalled panel is NOT a
+  // DOM descendant of the trigger, so it needs its own containment check.
+  useEffect(() => {
+    if (!open) return
+
+    const onPointerDown = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (triggerRef.current?.contains(target)) return
+      if (panelRef.current?.contains(target)) return
+      close()
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    window.addEventListener('resize', close)
+    // capture: catches scrolls on any ancestor, not just the window.
+    window.addEventListener('scroll', close, true)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('resize', close)
+      window.removeEventListener('scroll', close, true)
+    }
+  }, [open, close])
+
+  const selected = ROLE_OPTIONS.find((o) => o.value === value) ?? ROLE_OPTIONS[0]
+  const SelectedIcon = selected.icon
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((o) => !o)}
+        className={`flex items-center gap-1.5 h-7 px-2 rounded-lg border text-[11px] font-medium transition-all disabled:opacity-40 ${
+          value === 'admin'
+            ? 'bg-accent/15 border-accent/25 text-accent hover:bg-accent/20'
+            : 'bg-white/[0.06] border-white/10 text-text-secondary hover:bg-white/10 hover:text-white'
+        }`}
+      >
+        <SelectedIcon className="w-3 h-3" />
+        <span>{selected.label}</span>
+        <ChevronDown className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && createPortal(
+        <div
+          ref={panelRef}
+          style={{
+            position: 'fixed',
+            top: position?.top ?? -9999,
+            left: position?.left ?? -9999,
+            width: PANEL_WIDTH,
+            // Hidden until measured, so the first paint never flashes at 0,0.
+            visibility: position ? 'visible' : 'hidden',
+          }}
+          className="bg-bg-secondary border border-white/10 rounded-xl shadow-2xl backdrop-blur-2xl overflow-hidden z-[60]"
+        >
+          {ROLE_OPTIONS.map((opt) => {
+            const Icon = opt.icon
+            const isSelected = opt.value === value
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => {
+                  setOpen(false)
+                  if (!isSelected) onChange(opt.value)
+                }}
+                className={`w-full flex items-start gap-2 px-3 py-2 text-left transition-colors ${
+                  isSelected ? 'bg-white/[0.06]' : 'hover:bg-white/[0.06]'
+                }`}
+              >
+                <Icon className={`w-3.5 h-3.5 mt-0.5 shrink-0 ${isSelected ? 'text-accent' : 'text-text-secondary/60'}`} />
+                <div className="min-w-0 flex-1">
+                  <div className={`text-xs font-medium ${isSelected ? 'text-accent' : 'text-white'}`}>{opt.label}</div>
+                  <div className="text-[11px] text-text-secondary/50 mt-0.5">{opt.description}</div>
+                </div>
+                {isSelected && <Check className="w-3.5 h-3.5 text-accent shrink-0 mt-0.5" />}
+              </button>
+            )
+          })}
+        </div>,
+        document.body,
+      )}
+    </>
+  )
+}

--- a/desktop/src/renderer/pages/Config/SectionHeader.tsx
+++ b/desktop/src/renderer/pages/Config/SectionHeader.tsx
@@ -1,0 +1,35 @@
+import type { LucideIcon } from 'lucide-react'
+
+/**
+ * Header of a settings section: icon + title, optionally with an action on the
+ * right (a button, a toggle…).
+ *
+ * The row is pinned to `h-5` — the natural height of the bare title — so a
+ * section carrying a taller action button lines up with one that doesn't.
+ * Without it the button stretches the row and pushes that tab's content ~10px
+ * lower than its neighbours. The action simply overflows the line, centered.
+ *
+ * `spacing="none"` drops the bottom margin, for parents that already space their
+ * children with a flex `gap`.
+ */
+export function SectionHeader({
+  icon: Icon,
+  title,
+  action,
+  spacing = 'default',
+}: {
+  icon: LucideIcon
+  title: string
+  action?: React.ReactNode
+  spacing?: 'default' | 'none'
+}) {
+  return (
+    <div className={`flex items-center justify-between h-5 ${spacing === 'none' ? '' : 'mb-4'}`}>
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
+        <Icon className="w-4 h-4" />
+        <span>{title}</span>
+      </div>
+      {action}
+    </div>
+  )
+}

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -1,14 +1,15 @@
 import { useState, useEffect, useMemo, Fragment } from 'react'
-import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, GitPullRequest, History, Gauge, User, Coins, BarChart3, Bell, LogOut, Building2, Check, Loader2, Lock } from 'lucide-react'
-import { ProfileSection } from './ProfileSection'
+import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, GitPullRequest, History, Gauge, User, Coins, BarChart3, Bell, LogOut, Building2, Check, Loader2, Lock, CircleUserRound, type LucideIcon } from 'lucide-react'
+import { AccountPage } from './AccountPage'
 import { RepoPage } from './RepoPage'
 import { OrgPage } from './OrgPage'
+import { SectionHeader } from './SectionHeader'
 import { LimitGauge } from '../../components/agent-info-sidebar/LimitGauge'
 import { useStore } from '../../store'
 import { useConfig } from '../../hooks/useConfig'
 import { useAuth } from '../../hooks/useAuth'
 import { useOrg } from '../../hooks/useOrg'
-import type { SpotlightShortcut, LaunchMode, ClaudeAccount, SpendSummary, SettingsTab } from '../../../types'
+import type { SpotlightShortcut, LaunchMode, ClaudeAccount, SpendSummary, SettingsTab, RepositoryConfig } from '../../../types'
 import { showToast } from '../../components/Toast'
 import { getProjectColorMap } from '../../utils/projectColors'
 import { formatUsd } from '../../utils/usageStats'
@@ -32,15 +33,16 @@ const LAUNCH_MODE_OPTIONS: { value: LaunchMode; label: string; description: stri
   { value: 'bypassPermissions', label: 'Bypass', description: 'No permission checks — for sandboxed environments only' },
 ]
 
-const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
-  { id: 'profile', label: 'Profile' },
-  { id: 'repositories', label: 'Repositories' },
-  { id: 'organization', label: 'Organization' },
-  { id: 'launch-mode', label: 'Launch Mode' },
-  { id: 'features', label: 'Features' },
-  { id: 'shortcuts', label: 'Shortcuts' },
-  { id: 'usage', label: 'Usage' },
-  { id: 'about', label: 'About' },
+// Icons mirror each tab's own section header, so the rail and the content agree.
+const SETTINGS_TABS: { id: SettingsTab; label: string; icon: LucideIcon }[] = [
+  { id: 'account', label: 'Account', icon: CircleUserRound },
+  { id: 'repositories', label: 'Repositories', icon: FolderGit },
+  { id: 'organization', label: 'Organization', icon: Building2 },
+  { id: 'launch-mode', label: 'Launch Mode', icon: Shield },
+  { id: 'features', label: 'Features', icon: Sparkles },
+  { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
+  { id: 'usage', label: 'Usage', icon: BarChart3 },
+  { id: 'about', label: 'About', icon: Info },
 ]
 
 function formatTokensCompact(n: number): string {
@@ -153,21 +155,43 @@ function SettingsAccountFooter() {
   )
 }
 
-function WelcomePage() {
+/** Hash route within Settings. `repo` is a sub-page of the Repositories tab. */
+interface SettingsRoute {
+  page: string
+  params: { name?: string }
+}
+
+function WelcomePage({ route }: { route: SettingsRoute }) {
   const { config, terminals, splitEnabled, toggleSplitEnabled, currentPage, setCurrentPage, setConfig, settingsInitialTab, setSettingsInitialTab } = useStore()
   const { addRepository, updateSplitEnabled, updateSpotlight, updateLaunchMode } = useConfig()
   const orgs = useStore((s) => s.orgs)
+  const activeOrg = useStore((s) => s.activeOrg)
   // Deep-link support: another view can request a specific settings tab via the
   // store (e.g. the sidebar account menu → Organization). Initialise straight
   // from it so the requested tab paints on first render (no Profile → target
   // flash), then clear the store value once so later visits start on the default.
-  const [activeTab, setActiveTab] = useState<SettingsTab>(settingsInitialTab ?? 'profile')
+  const [activeTab, setActiveTab] = useState<SettingsTab>(settingsInitialTab ?? 'account')
 
   useEffect(() => {
     if (!settingsInitialTab) return
     setActiveTab(settingsInitialTab)
     setSettingsInitialTab(null)
   }, [settingsInitialTab, setSettingsInitialTab])
+
+  // A repository detail page replaces the tab content but keeps the rail, so the
+  // menu never disappears. Repositories stays lit — the detail is its sub-page.
+  const isRepoRoute = route.page === 'repo'
+  const railActiveTab = isRepoRoute ? 'repositories' : activeTab
+  const contentTab = isRepoRoute ? null : activeTab
+
+  const handleSelectTab = (tab: SettingsTab) => {
+    setActiveTab(tab)
+    // Picking a tab from a repo detail page must also leave that hash route,
+    // otherwise the detail would keep covering the content pane.
+    if (window.location.hash && window.location.hash !== '#/') {
+      window.location.hash = '#/'
+    }
+  }
   const [githubStatus, setGithubStatus] = useState<Record<string, boolean>>({})
   const [isAdding, setIsAdding] = useState(false)
   const [appVersion, setAppVersion] = useState('')
@@ -278,6 +302,12 @@ function WelcomePage() {
   const repos = Object.entries(config?.repositories || {})
   const projectNames = repos.map(([name]) => name)
 
+  // Repos split by scope. Team repos include those the org owns but this user
+  // hasn't bound to a local folder yet (needsLocalPath) — they must stay visible,
+  // that's how you discover a colleague's repo and point it at your own clone.
+  const personalRepos = useMemo(() => repos.filter(([, r]) => !r.orgId), [repos])
+  const teamRepos = useMemo(() => repos.filter(([, r]) => !!r.orgId), [repos])
+
   // Generate color map for projects
   const colorMap = useMemo(
     () => getProjectColorMap(projectNames, config?.repositories),
@@ -290,7 +320,9 @@ function WelcomePage() {
     for (const terminal of terminals) {
       for (const repoPath of terminal.repositories || []) {
         for (const [name, repo] of repos) {
-          if (repoPath.startsWith(repo.path)) {
+          // Guard the empty path: ''.startsWith() matches everything, which would
+          // credit every agent to every repo with no local folder bound.
+          if (repo.path && repoPath.startsWith(repo.path)) {
             counts[name] = (counts[name] || 0) + 1
           }
         }
@@ -298,6 +330,76 @@ function WelcomePage() {
     }
     return counts
   }, [terminals, repos])
+
+  // One row of the repositories list. Shared by the Personal and Team sections —
+  // a plain render function, not a component, so React keeps the same elements
+  // across renders instead of remounting a freshly-declared type.
+  const renderRepoRow = ([name, repo]: [string, RepositoryConfig]) => {
+    const hasGithub = githubStatus[name]
+    const color = colorMap[name]
+    const agentCount = agentCountByRepo[name] || 0
+    const scopeOrg = repo.orgId ? orgs.find((o) => o.id === repo.orgId) : null
+
+    return (
+      <a
+        key={name}
+        href={`#/repo/${encodeURIComponent(name)}`}
+        className="group flex items-center gap-3 px-4 py-3 bg-white/[0.06] hover:bg-white/[0.12] border border-white/[0.15] hover:border-white/[0.15] rounded-xl transition-all"
+      >
+        {/* Color dot */}
+        <span
+          className="w-3 h-3 rounded-full flex-shrink-0"
+          style={{ backgroundColor: color }}
+        />
+
+        {/* Repo info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-medium truncate">{name}</span>
+            {/* Org name on a team repo — the section header already says "Team",
+                but a repo can belong to another org than the active one. */}
+            {repo.orgId && scopeOrg && scopeOrg.id !== activeOrg?.id && (
+              <span className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/15 text-accent">
+                <Building2 className="w-2.5 h-2.5" />
+                {scopeOrg.name}
+              </span>
+            )}
+            {/* GitHub status badge — only meaningful once a local folder is bound */}
+            {!repo.needsLocalPath && (
+              <span className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium ${
+                hasGithub
+                  ? 'bg-green/10 text-green'
+                  : 'bg-red/10 text-red'
+              }`}>
+                <Github className="w-2.5 h-2.5" />
+                {hasGithub ? 'Connected' : 'No remote'}
+              </span>
+            )}
+          </div>
+          {repo.needsLocalPath ? (
+            <div className="flex items-center gap-1 text-xs text-yellow mt-0.5">
+              <AlertTriangle className="w-3 h-3" />
+              No local folder — click to set it
+            </div>
+          ) : (
+            <div className="text-xs text-text-secondary/50 truncate mt-0.5">
+              {repo.path}
+            </div>
+          )}
+        </div>
+
+        {/* Agent count */}
+        {agentCount > 0 && (
+          <span className="px-2 py-0.5 bg-accent/10 text-accent text-xs font-medium rounded">
+            {agentCount} agent{agentCount > 1 ? 's' : ''}
+          </span>
+        )}
+
+        {/* Arrow */}
+        <ChevronRight className="w-4 h-4 text-text-secondary/30 group-hover:text-text-secondary transition-colors" />
+      </a>
+    )
+  }
 
   // Latest known Claude account usage (plan rate limits). These are account-global,
   // so they're identical across agents — pick the most recently reported one that
@@ -420,19 +522,23 @@ function WelcomePage() {
       {/* Left rail: vertical tabs, account footer */}
       <div className="w-56 shrink-0 flex flex-col border-r border-white/[0.08] bg-black/20">
         <nav className="flex-1 overflow-y-auto px-2 pt-3 space-y-0.5">
-          {SETTINGS_TABS.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`w-full text-left px-3 py-2 text-sm font-medium rounded-lg transition-all ${
-                activeTab === tab.id
-                  ? 'bg-accent/15 text-white'
-                  : 'text-text-secondary hover:text-white hover:bg-white/[0.06]'
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+          {SETTINGS_TABS.map((tab) => {
+            const Icon = tab.icon
+            return (
+              <button
+                key={tab.id}
+                onClick={() => handleSelectTab(tab.id)}
+                className={`w-full flex items-center gap-2.5 text-left px-3 py-2 text-sm font-medium rounded-lg transition-all ${
+                  railActiveTab === tab.id
+                    ? 'bg-accent/15 text-white'
+                    : 'text-text-secondary hover:text-white hover:bg-white/[0.06]'
+                }`}
+              >
+                <Icon className="w-4 h-4 shrink-0" />
+                <span className="truncate">{tab.label}</span>
+              </button>
+            )
+          })}
         </nav>
         <SettingsAccountFooter />
       </div>
@@ -441,32 +547,35 @@ function WelcomePage() {
       <div className="flex-1 overflow-y-auto p-6">
         <div className="max-w-4xl flex flex-col gap-6">
 
-      {/* Profile tab */}
-      {activeTab === 'profile' && (
-        <ProfileSection />
+      {/* Repository detail — sub-page of the Repositories tab */}
+      {isRepoRoute && <RepoPage repoName={route.params.name || ''} />}
+
+      {/* Account tab — cloud identity + Claude profile */}
+      {contentTab === 'account' && (
+        <AccountPage />
       )}
 
       {/* Organization tab */}
-      {activeTab === 'organization' && (
+      {contentTab === 'organization' && (
         <OrgPage />
       )}
 
       {/* Repositories tab */}
-      {activeTab === 'repositories' && <div>
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2 text-sm text-text-secondary">
-            <FolderGit className="w-4 h-4" />
-            <span>Repositories</span>
-          </div>
-          <button
-            onClick={handleOpenProject}
-            disabled={isAdding}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-text-secondary bg-white/[0.06] border border-white/[0.15] rounded-lg hover:bg-white/[0.12] hover:text-white transition-all disabled:opacity-50"
-          >
-            <Plus className="w-3 h-3" />
-            <span>{isAdding ? 'Adding...' : 'Add repository'}</span>
-          </button>
-        </div>
+      {contentTab === 'repositories' && <div>
+        <SectionHeader
+          icon={FolderGit}
+          title="Repositories"
+          action={
+            <button
+              onClick={handleOpenProject}
+              disabled={isAdding}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-text-secondary bg-white/[0.06] border border-white/[0.15] rounded-lg hover:bg-white/[0.12] hover:text-white transition-all disabled:opacity-50"
+            >
+              <Plus className="w-3 h-3" />
+              <span>{isAdding ? 'Adding...' : 'Add repository'}</span>
+            </button>
+          }
+        />
 
         {repos.length === 0 ? (
           <button
@@ -479,87 +588,47 @@ function WelcomePage() {
             <div className="text-xs text-text-secondary/30">Click to add your first project</div>
           </button>
         ) : (
-          <div className="space-y-2">
-            {repos.map(([name, repo]) => {
-              const hasGithub = githubStatus[name]
-              const color = colorMap[name]
-              const agentCount = agentCountByRepo[name] || 0
-              const scopeOrg = repo.orgId ? orgs.find((o) => o.id === repo.orgId) : null
+          <div className="flex flex-col gap-6">
+            {/* Personal */}
+            <div>
+              <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-text-secondary/50 mb-2">
+                <Lock className="w-3 h-3" />
+                <span>Personal</span>
+                <span className="text-text-secondary/30">{personalRepos.length}</span>
+              </div>
+              {personalRepos.length === 0 ? (
+                <div className="px-4 py-3 text-xs text-text-secondary/40 border border-dashed border-white/[0.08] rounded-xl">
+                  No personal repository — use “Add repository” above.
+                </div>
+              ) : (
+                <div className="space-y-2">{personalRepos.map(renderRepoRow)}</div>
+              )}
+            </div>
 
-              return (
-                <a
-                  key={name}
-                  href={`#/repo/${encodeURIComponent(name)}`}
-                  className="group flex items-center gap-3 px-4 py-3 bg-white/[0.06] hover:bg-white/[0.12] border border-white/[0.15] hover:border-white/[0.15] rounded-xl transition-all"
-                >
-                  {/* Color dot */}
-                  <span
-                    className="w-3 h-3 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: color }}
-                  />
-
-                  {/* Repo info */}
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium truncate">{name}</span>
-                      {/* Scope badge */}
-                      {repo.orgId ? (
-                        <span className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/15 text-accent">
-                          <Building2 className="w-2.5 h-2.5" />
-                          {scopeOrg?.name ?? 'Team'}
-                        </span>
-                      ) : (
-                        <span className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-white/10 text-text-secondary">
-                          <Lock className="w-2.5 h-2.5" />
-                          Personal
-                        </span>
-                      )}
-                      {/* GitHub status badge — only meaningful once a local folder is bound */}
-                      {!repo.needsLocalPath && (
-                        <span className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium ${
-                          hasGithub
-                            ? 'bg-green/10 text-green'
-                            : 'bg-red/10 text-red'
-                        }`}>
-                          <Github className="w-2.5 h-2.5" />
-                          {hasGithub ? 'Connected' : 'No remote'}
-                        </span>
-                      )}
-                    </div>
-                    {repo.needsLocalPath ? (
-                      <div className="flex items-center gap-1 text-xs text-yellow mt-0.5">
-                        <AlertTriangle className="w-3 h-3" />
-                        No local folder — click to set it
-                      </div>
-                    ) : (
-                      <div className="text-xs text-text-secondary/50 truncate mt-0.5">
-                        {repo.path}
-                      </div>
-                    )}
+            {/* Team — every repo of the active org, even those with no local folder yet */}
+            {(teamRepos.length > 0 || activeOrg) && (
+              <div>
+                <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-text-secondary/50 mb-2">
+                  <Building2 className="w-3 h-3" />
+                  <span>{activeOrg?.name ?? 'Team'}</span>
+                  <span className="text-text-secondary/30">{teamRepos.length}</span>
+                </div>
+                {teamRepos.length === 0 ? (
+                  <div className="px-4 py-3 text-xs text-text-secondary/40 border border-dashed border-white/[0.08] rounded-xl">
+                    No shared repository in this organization yet.
                   </div>
-
-                  {/* Agent count */}
-                  {agentCount > 0 && (
-                    <span className="px-2 py-0.5 bg-accent/10 text-accent text-xs font-medium rounded">
-                      {agentCount} agent{agentCount > 1 ? 's' : ''}
-                    </span>
-                  )}
-
-                  {/* Arrow */}
-                  <ChevronRight className="w-4 h-4 text-text-secondary/30 group-hover:text-text-secondary transition-colors" />
-                </a>
-              )
-            })}
+                ) : (
+                  <div className="space-y-2">{teamRepos.map(renderRepoRow)}</div>
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>}
 
       {/* Launch Mode tab */}
-      {activeTab === 'launch-mode' && <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <Shield className="w-4 h-4" />
-          <span>Launch Mode</span>
-        </div>
+      {contentTab === 'launch-mode' && <div>
+        <SectionHeader icon={Shield} title="Launch Mode" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
           <div className="flex items-center justify-between">
             <div>
@@ -608,14 +677,11 @@ function WelcomePage() {
       </div>}
 
       {/* Features tab */}
-      {activeTab === 'features' && <div className="flex flex-col gap-8">
+      {contentTab === 'features' && <div className="flex flex-col gap-8">
 
       {/* History Section */}
       <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <History className="w-4 h-4" />
-          <span>History</span>
-        </div>
+        <SectionHeader icon={History} title="History" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
           <div className="flex items-center justify-between">
             <div>
@@ -645,10 +711,7 @@ function WelcomePage() {
 
       {/* Usage Card Section */}
       <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <Gauge className="w-4 h-4" />
-          <span>Usage card</span>
-        </div>
+        <SectionHeader icon={Gauge} title="Usage card" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
           <div className="flex items-center justify-between">
             <div>
@@ -676,10 +739,7 @@ function WelcomePage() {
 
       {/* Usage Logs Section (GDPR opt-in — off by default) */}
       <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <BarChart3 className="w-4 h-4" />
-          <span>Usage logs</span>
-        </div>
+        <SectionHeader icon={BarChart3} title="Usage logs" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
           <div className="flex items-center justify-between gap-4">
             <div>
@@ -709,10 +769,7 @@ function WelcomePage() {
 
       {/* Daily Digest Section (opt-in — off by default) */}
       <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <Bell className="w-4 h-4" />
-          <span>Daily digest</span>
-        </div>
+        <SectionHeader icon={Bell} title="Daily digest" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
           <div className="flex items-center justify-between gap-4">
             <div>
@@ -742,10 +799,7 @@ function WelcomePage() {
 
       {/* Split View Section */}
       <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <Columns className="w-4 h-4" />
-          <span>Split View</span>
-        </div>
+        <SectionHeader icon={Columns} title="Split View" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
           <div className="flex items-center justify-between">
             <div>
@@ -768,10 +822,7 @@ function WelcomePage() {
 
       {/* PR Review Watcher Section */}
       <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <GitPullRequest className="w-4 h-4" />
-          <span>PR Review Watcher</span>
-        </div>
+        <SectionHeader icon={GitPullRequest} title="PR Review Watcher" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
           <div className="flex items-center justify-between">
             <div>
@@ -849,10 +900,7 @@ function WelcomePage() {
 
       {/* Spotlight Section */}
       <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <Search className="w-4 h-4" />
-          <span>Spotlight</span>
-        </div>
+        <SectionHeader icon={Search} title="Spotlight" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
           <div className="flex items-center justify-between">
             <div>
@@ -902,10 +950,7 @@ function WelcomePage() {
 
       {/* Background App Section */}
       <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <MonitorSmartphone className="w-4 h-4" />
-          <span>Background App</span>
-        </div>
+        <SectionHeader icon={MonitorSmartphone} title="Background App" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 space-y-4">
           <div className="flex items-center justify-between">
             <div>
@@ -939,11 +984,8 @@ function WelcomePage() {
       </div>}
 
       {/* Shortcuts tab */}
-      {activeTab === 'shortcuts' && <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <Keyboard className="w-4 h-4" />
-          <span>Keyboard Shortcuts</span>
-        </div>
+      {contentTab === 'shortcuts' && <div>
+        <SectionHeader icon={Keyboard} title="Keyboard Shortcuts" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
           <div className="grid grid-cols-2 gap-3 text-sm">
             <div className="flex items-center justify-between">
@@ -1005,16 +1047,13 @@ function WelcomePage() {
       </div>}
 
       {/* Usage tab */}
-      {activeTab === 'usage' && <div className="flex flex-col lg:flex-row gap-6">
+      {contentTab === 'usage' && <div className="flex flex-col lg:flex-row gap-6">
 
         {/* Left column: account + estimated spend */}
         <div className="flex-1 min-w-0 flex flex-col gap-6">
           {/* Current account */}
           <div>
-            <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-              <User className="w-4 h-4" />
-              <span>Current account</span>
-            </div>
+            <SectionHeader icon={User} title="Current account" />
             <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
               {claudeAccount ? (
                 <div className="space-y-2 text-sm">
@@ -1055,10 +1094,7 @@ function WelcomePage() {
 
           {/* Estimated spend & tokens */}
           <div>
-            <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-              <Coins className="w-4 h-4" />
-              <span>Spend &amp; tokens</span>
-            </div>
+            <SectionHeader icon={Coins} title="Spend & tokens" />
             <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
               {spend?.hasData ? (
                 <>
@@ -1094,10 +1130,7 @@ function WelcomePage() {
 
         {/* Right column: account rate-limit gauges */}
         <div className="lg:w-[280px] shrink-0">
-          <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-            <Gauge className="w-4 h-4" />
-            <span>Rate limits</span>
-          </div>
+          <SectionHeader icon={Gauge} title="Rate limits" />
           <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4">
             {accountUsage ? (
               <div className="flex items-start justify-center gap-8 py-2">
@@ -1128,11 +1161,8 @@ function WelcomePage() {
       </div>}
 
       {/* About tab */}
-      {activeTab === 'about' && <div>
-        <div className="flex items-center gap-2 text-sm text-text-secondary mb-4">
-          <Info className="w-4 h-4" />
-          <span>About</span>
-        </div>
+      {contentTab === 'about' && <div>
+        <SectionHeader icon={Info} title="About" />
         <div className="bg-white/[0.06] border border-white/[0.15] rounded-xl p-4 flex items-center justify-between">
           <div>
             <div className="font-medium">Magic Slash</div>
@@ -1198,13 +1228,7 @@ export function ConfigPage() {
 
   return (
     <div className="h-full">
-      {route.page === 'repo' ? (
-        <div className="h-full overflow-auto p-6">
-          <RepoPage repoName={route.params.name || ''} />
-        </div>
-      ) : (
-        <WelcomePage />
-      )}
+      <WelcomePage route={route} />
     </div>
   )
 }

--- a/desktop/src/renderer/pages/Dashboard/index.tsx
+++ b/desktop/src/renderer/pages/Dashboard/index.tsx
@@ -1,14 +1,10 @@
-import { useMemo, useState } from 'react'
-import { Users, Bot, Coins, Plus, Minus, Clock, Activity, BarChart3, GitPullRequest, AlertOctagon, ExternalLink, ArrowRightCircle } from 'lucide-react'
+import { useMemo } from 'react'
+import { Users, Coins, Plus, Minus, Clock, Activity, BarChart3, GitPullRequest, AlertOctagon, ExternalLink } from 'lucide-react'
 import type { OrgAgent, OrgAgentPRReview } from '../../../types'
 import { useOrgAgents } from '../../hooks/useOrgAgents'
 import { useOrgUsageStats } from '../../hooks/useOrgUsageStats'
 import { useOrg } from '../../hooks/useOrg'
-import { useAuth } from '../../hooks/useAuth'
-import { useTerminals } from '../../hooks/useTerminals'
-import { useStore } from '../../store'
 import { LiveIndicator } from '../../components/LiveIndicator'
-import { showToast } from '../../components/Toast'
 import { ActivityHeatmap } from '../History/ActivityHeatmap'
 import { aggregateUsageTotals, aggregateUsageByMember, computeUsageHeatmap, formatUsd } from '../../utils/usageStats'
 
@@ -190,50 +186,6 @@ function TicketBadge({ ticketId }: { ticketId?: string }) {
   )
 }
 
-function AgentRow({
-  agent,
-  currentUserId,
-  onPickUp,
-  pickingUp,
-}: {
-  agent: OrgAgent
-  currentUserId?: string
-  onPickUp?: (agent: OrgAgent) => void
-  pickingUp?: boolean
-}) {
-  // "Pick up" only makes sense for a teammate's ticketed agent (never your own).
-  const canPickUp =
-    !!onPickUp && !!agent.ticketId && !!agent.ownerId && agent.ownerId !== currentUserId
-
-  return (
-    <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-white/[0.04] border border-white/[0.08] min-w-0">
-      <Bot className="w-4 h-4 text-text-secondary/60 flex-shrink-0" />
-      <span className="text-sm font-medium text-white truncate min-w-0 flex-1">
-        {agent.name}
-      </span>
-      <TicketBadge ticketId={agent.ticketId} />
-      {agent.repositories.slice(0, 2).map((repo) => (
-        <RepoTag key={repo} repo={repo} />
-      ))}
-      {agent.repositories.length > 2 && (
-        <span className="text-xs text-text-secondary/40 flex-shrink-0">+{agent.repositories.length - 2}</span>
-      )}
-      <StatusPill status={agent.status} />
-      {canPickUp && (
-        <button
-          onClick={() => onPickUp!(agent)}
-          disabled={pickingUp}
-          title={`Launch a local agent on ${agent.ticketId} with /magic:continue`}
-          className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-accent bg-accent/10 border border-accent/20 rounded-lg hover:bg-accent/20 transition-colors flex-shrink-0 disabled:opacity-50"
-        >
-          <ArrowRightCircle className="w-3.5 h-3.5" />
-          <span>{pickingUp ? 'Picking up…' : 'Pick up'}</span>
-        </button>
-      )}
-    </div>
-  )
-}
-
 function OwnerLabel({ agent, emailByOwner }: { agent: OrgAgent; emailByOwner: Map<string, string> }) {
   const label = agent.ownerId ? emailByOwner.get(agent.ownerId) ?? agent.ownerId : 'Unassigned'
   return <span className="text-xs text-text-secondary/60 truncate">{label}</span>
@@ -318,22 +270,11 @@ function BlockedSection({ agents, emailByOwner }: { agents: OrgAgent[]; emailByO
   )
 }
 
-interface MemberGroup {
-  key: string
-  label: string
-  agents: OrgAgent[]
-}
-
 export function DashboardPage() {
-  const { agents, loading } = useOrgAgents()
+  const { agents } = useOrgAgents()
   const { members } = useOrg()
-  const { status: authStatus } = useAuth()
-  const { launchClaudeTerminal, terminals } = useTerminals()
-  const setCurrentPage = useStore((s) => s.setCurrentPage)
-  const [pickingUpId, setPickingUpId] = useState<string | null>(null)
-  const currentUserId = authStatus.user?.id
 
-  // owner_id → email, so agents can be grouped under a readable member label.
+  // owner_id → email, so agents show a readable member label.
   const emailByOwner = useMemo(() => {
     const map = new Map<string, string>()
     for (const m of members) {
@@ -344,51 +285,6 @@ export function DashboardPage() {
 
   const awaitingReview = useMemo(() => collectAwaitingReview(agents), [agents])
   const blocked = useMemo(() => collectBlocked(agents), [agents])
-
-  // Pick up a colleague's task: resolve their repo(s) to a local cwd (main), then
-  // launch a fresh local agent with /magic:continue to resume the ticket.
-  const handlePickUp = async (agent: OrgAgent) => {
-    if (!agent.ticketId) return
-    setPickingUpId(agent.id)
-    try {
-      const { cwd, initialPrompt } = await window.electronAPI.org.pickUpTask(agent.ticketId, agent.repositories)
-      const name = `Claude ${terminals.length + 1}`
-      await launchClaudeTerminal(name, cwd, initialPrompt)
-      setCurrentPage('terminals')
-      showToast(`Picked up ${agent.ticketId}`, 'success')
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to pick up task', 'error')
-    } finally {
-      setPickingUpId(null)
-    }
-  }
-
-  // Group agents by owner (unassigned/unknown owners fall into a trailing group).
-  const groups: MemberGroup[] = useMemo(() => {
-    const byOwner = new Map<string, OrgAgent[]>()
-    for (const agent of agents) {
-      const key = agent.ownerId ?? '__unassigned__'
-      if (!byOwner.has(key)) byOwner.set(key, [])
-      byOwner.get(key)!.push(agent)
-    }
-
-    const result: MemberGroup[] = []
-    for (const [key, list] of byOwner.entries()) {
-      if (key === '__unassigned__') continue
-      result.push({
-        key,
-        label: emailByOwner.get(key) ?? key,
-        agents: list.sort((a, b) => a.name.localeCompare(b.name)),
-      })
-    }
-    result.sort((a, b) => a.label.localeCompare(b.label))
-
-    const unassigned = byOwner.get('__unassigned__')
-    if (unassigned && unassigned.length > 0) {
-      result.push({ key: '__unassigned__', label: 'Unassigned', agents: unassigned })
-    }
-    return result
-  }, [agents, emailByOwner])
 
   return (
     <div className="h-full flex flex-col">
@@ -406,7 +302,7 @@ export function DashboardPage() {
         <LiveIndicator />
       </div>
 
-      {/* Body — attention widgets + usage stats + active agents share one scroll container */}
+      {/* Body — attention widgets + usage stats share one scroll container */}
       <div className="flex-1 overflow-auto flex flex-col gap-8">
         {/* Attention hooks: PRs awaiting review + blocked work (hidden when empty) */}
         <AwaitingReviewSection items={awaitingReview} emailByOwner={emailByOwner} />
@@ -414,46 +310,6 @@ export function DashboardPage() {
 
         {/* Org usage stats (read is open to any member) */}
         <UsageStatsSection />
-
-        {/* Active agents */}
-        <div className="flex flex-col gap-3">
-          <div className="flex items-center gap-2 text-sm text-text-secondary">
-            <Bot className="w-4 h-4" />
-            <span>Active agents</span>
-          </div>
-          {loading && agents.length === 0 ? (
-            <div className="py-10 flex items-center justify-center text-text-secondary text-sm">
-              Loading…
-            </div>
-          ) : agents.length === 0 ? (
-            <div className="py-10 flex flex-col items-center justify-center text-text-secondary text-sm gap-2 bg-white/[0.03] border border-white/[0.06] rounded-xl">
-              <Users className="w-8 h-8 opacity-30" />
-              <p>No active agents in the organization yet.</p>
-            </div>
-          ) : (
-            <div className="flex flex-col gap-6">
-              {groups.map((group) => (
-                <div key={group.key} className="flex flex-col gap-2">
-                  <div className="flex items-center gap-2 px-1">
-                    <span className="text-sm font-medium text-white truncate">{group.label}</span>
-                    <span className="text-xs text-text-secondary/50">{group.agents.length}</span>
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    {group.agents.map((agent) => (
-                      <AgentRow
-                        key={agent.id}
-                        agent={agent}
-                        currentUserId={currentUserId}
-                        onPickUp={handlePickUp}
-                        pickingUp={pickingUpId === agent.id}
-                      />
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
       </div>
     </div>
   )

--- a/desktop/src/renderer/store/index.ts
+++ b/desktop/src/renderer/store/index.ts
@@ -275,7 +275,18 @@ export const useStore = create<AppState>()(
 
         setCurrentPage: (currentPage) => set({ currentPage, selectedFile: null }),
         setSettingsInitialTab: (settingsInitialTab) => set({ settingsInitialTab }),
-        openSettingsModal: (tab) => set(tab ? { settingsModalOpen: true, settingsInitialTab: tab } : { settingsModalOpen: true }),
+        // Settings is an overlay, never a destination: it leaves currentPage and
+        // the active terminal untouched so the app stays visible behind it. The
+        // one exception is a blank agents page (nothing selected but agents
+        // exist) — select the first one so the overlay never sits on an empty app.
+        openSettingsModal: (tab) => set((state) => {
+          const updates: Partial<AppState> = { settingsModalOpen: true }
+          if (tab) updates.settingsInitialTab = tab
+          if (state.currentPage === 'terminals' && !state.activeTerminalId && state.terminals.length > 0) {
+            updates.activeTerminalId = state.terminals[0].id
+          }
+          return updates
+        }),
         closeSettingsModal: () => set({ settingsModalOpen: false }),
         setRightSidebar: (rightSidebar) => set({ rightSidebar }),
         toggleRightSidebar: (sidebar) => set((state) => ({

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -218,7 +218,7 @@ export type InvitationStatus = 'pending' | 'accepted' | 'revoked' | 'expired'
 /** Tabs of the Settings/Config page. Shared so other views (e.g. the sidebar
  *  account menu) can deep-link a specific tab in a type-safe way. */
 export type SettingsTab =
-  | 'profile'
+  | 'account'
   | 'repositories'
   | 'organization'
   | 'launch-mode'


### PR DESCRIPTION
## Description

Reworks the desktop Settings around a new **Account** tab, turns the **Organization** page into one card per organization (the data model has always allowed a user to belong to several — `memberships` is unique on `(org_id, user_id)`, not on `user_id`), splits **Repositories** into Personal / Team, and tightens a few sidebar details.

The main behavioural fix: opening Settings no longer blanks the app behind the modal.

## Related Issue

_No linked issue — direct request._

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

**Settings — new Account tab** (replaces the Profile tab)
- `Cloud account` moves out of the Organization tab, along with its sign-in / password / email / delete-account modals (`CloudAccountSection`).
- When no profile exists, a single-screen `ProfileForm` replaces the placeholder that opened the 6-step wizard. The wizard is kept for first launch and for editing.

**Settings — Organizations**
- One self-contained card per org: name, members (with role picker and removal), invitations, and the destructive actions. Non-active orgs get a `Switch to` button.
- Bottom-of-page actions to **create** an organization (via the existing `create_organization` RPC) or **join** one (the field accepts an invite link or a bare token).
- Invitations move behind a modal form, with a role selector — the API already supported inviting as admin, the UI did not.
- `Integrations` section and the per-user role badge removed.
- New `RoleSelect`: a custom dropdown replacing the native `<select>`, portalled to `<body>` so it is not clipped by the modal's `overflow-y-auto`.

**Settings — plumbing**
- `org:members`, `org:invitations` and `org:invite` now forward an optional `orgId` (the `cloud/org.ts` functions already accepted one). New `org:create` IPC + `createOrganization()`.
- `useOrg` exposes `membersByOrg` / `invitationsByOrg`, fetched for every org in parallel.

**Settings — layout**
- New shared `SectionHeader` (icon + title + optional action), applied to all 22 section headers. Its fixed `h-5` fixes the Repositories tab starting ~10px lower than the others, because its header carried the taller "Add repository" button.
- Icons in the tab rail; the rail now stays visible on a repository detail page instead of being replaced by it.
- Repositories split into Personal / Team. Org repos with no local folder bound were already returned by `fetchRepositories` — they are now grouped instead of lost in a flat list.

**Sidebar**
- Account entry uses an account icon instead of the blue initial avatar; `⌘T` added for Team, `⌘,` label surfaced for Settings.
- Opening Settings no longer calls `setActiveTerminal(null)`, which blanked the main pane behind the modal.
- Minimized usage cards now show progress gauges (left sidebar: `session` / `weekly` side by side).

**Team dashboard**
- `Active agents` section removed, with its now-dead grouping code.

**Fix**
- Agent-per-repo counting used `repoPath.startsWith(repo.path)`; with an empty path that matches everything, so every repo with no local folder was credited with every running agent.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

`npm run lint` (0 errors, 3 pre-existing warnings in `RepoPage.tsx`), `tsc --noEmit` clean, `npm test` 281/281 passing.

> **Not verified by running the app.** This PR is almost entirely UI and I did not launch `npm run desktop` to check the rendering. The steps below are the ones a reviewer should walk through.

### Test Steps

1. Run `npm run desktop`, start an agent, then open Settings (`⌘,`). The agent's terminal must stay visible behind the modal — before this PR the pane went blank.
2. In the tab rail, check every tab now shows an icon and that **Account** is the landing tab. Open **Repositories** and confirm its title sits at the same height as the other tabs' titles.
3. In **Repositories**, confirm two sections, Personal and Team. A team repo with no local folder must appear under Team with the yellow "No local folder" hint. Click it: the tab rail must stay visible with **Repositories** still highlighted, and the back arrow must return to the list.
4. In **Account**, confirm `Cloud account` is present with Change password / Change email / Delete account. If you have no profile yet, the profile form must be inline (not a wizard); fill it and save, then confirm the card replaces the form and `Edit profile` reopens the wizard.
5. In **Organizations**, confirm one card per org you belong to, each with its own members and invitations. On a non-active org, `Switch to` must make it active.
6. Click **Invite** on a card: in the modal, open the role dropdown — it must render fully, **not be clipped by the modal**. Pick Admin, submit, and confirm the invitation appears in that card's list.
7. At the bottom, **Create an organization** with a name: a new card must appear (it does *not* become active by design). Then **Join an organization** by pasting a full invite link — the token must be extracted from the URL.
8. Open the **Team** page (`⌘T`): the `Active agents` list must be gone, leaving PRs awaiting review, Blocked and Usage.
9. Minimize the usage card in the left sidebar: `session` and `weekly` gauges must sit side by side on one line with visible bars. Minimize the agent usage card in the right sidebar: the bar must be right-aligned at ~⅓ width, labelled `SESSION CONTEXT`.

## Screenshots

_None — reviewer should check the rendering while walking through the steps above._

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

Three deliberate choices worth a reviewer's opinion:

1. **The Atlassian (Jira) toggle is gone from the UI.** It lived in the removed `Integrations` section. `config.integrations.atlassian` is still read by the main process and the `setIntegration` IPC is intact — the setting is simply no longer editable, and defaults to `true`. It probably belongs in the Features tab.
2. **The `Pick up` button is gone.** It only existed inside the removed `Active agents` rows. The `org:pickUpTask` plumbing and its 10 tests are untouched, so it is just a button to re-place — the Blocked / Awaiting review rows would be the natural home.
3. **Creating an organization does not switch to it.** A switch re-applies the org's shared config over the local one, which felt too invasive as a side effect of "Create". The new card appears with a `Switch to` button.

Docs and CHANGELOG were not updated (`/magic:audit` territory), and no tests were added — the changes are UI-only and the suite has no renderer tests.
