### PR TITLE
[#148] Add an application language setting (English / French)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Desktop**: Make the interface themeable with eight light and dark themes
 - **Desktop**: Add an interface scale setting
+- **Desktop**: Add an application language setting (English / French)
 - **Desktop**: Animate page changes in the settings
 - **Desktop**: Animate modals when they close
 - Restrict team repository settings to org admins and the repo creator

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -1,0 +1,102 @@
+/**
+ * The message catalogue, English. This is the REFERENCE: every other language is
+ * typed as `Record<keyof typeof en, string>`, so a missing key is a `tsc` error
+ * rather than a string that silently falls back at runtime.
+ *
+ * Deliberately exported WITHOUT a type annotation. Annotating it
+ * `Record<string, string>` would widen `keyof typeof en` to `string` and void
+ * that guarantee entirely.
+ *
+ * Keys are dotted and grouped by where the string is shown, not by what it says
+ * — `menu.*`, `tray.*`, `notification.*`, `dialog.*`, `settings.*`. Placeholders
+ * are `{name}`; see t() for the interpolation, which is intentionally minimal.
+ */
+export const en = {
+  // ── Application menu ─────────────────────────────────────────────────────
+  'menu.file': 'File',
+  'menu.edit': 'Edit',
+  'menu.view': 'View',
+  'menu.window': 'Window',
+  'menu.actualSize': 'Actual Size',
+  'menu.zoomIn': 'Zoom In',
+  'menu.zoomOut': 'Zoom Out',
+
+  // ── Tray menu ────────────────────────────────────────────────────────────
+  'tray.version': 'Magic Slash v{version}',
+  'tray.noAgents': 'No active agents',
+  'tray.showWindow': 'Show Window',
+  'tray.settings': 'Settings',
+  'tray.changelog': 'Changelog',
+  'tray.documentation': 'Documentation',
+  'tray.github': 'GitHub',
+  'tray.quit': 'Quit Magic Slash',
+  'tray.update.checking': 'Checking for updates…',
+  'tray.update.downloadingVersion': 'Downloading v{version}…',
+  'tray.update.downloadingProgress': 'Downloading update… {percent}%',
+  'tray.update.restart': '↻ Restart to update (v{version})',
+  'tray.update.checkFailed': 'Check for Updates (last check failed)',
+  'tray.update.check': 'Check for Updates',
+
+  // ── OS notifications ─────────────────────────────────────────────────────
+  'notification.waiting.title': 'Claude Code needs attention',
+  'notification.waiting.body': 'Agent "{name}" is waiting for your input',
+  'notification.completed.title': 'Task completed',
+  'notification.completed.body': 'Agent "{name}" has finished',
+  'notification.prReview.title': 'PR review update',
+  'notification.prReview.body': '{url}: {status}',
+  'notification.pickup.title': 'A colleague picked up {ticket}',
+  'notification.pickup.body': 'A teammate is now working on {ticket} — you also have an agent on it.',
+  'notification.changesRequested.title': 'Changes requested on your PR',
+  'notification.changesRequested.body': '{subject}: a reviewer requested changes.',
+
+  // ── Daily team digest ────────────────────────────────────────────────────
+  // The clauses are whole sentences fragments rather than "{count} PR(s)": the
+  // plural break and the word order differ per language, and French agreement
+  // cannot be assembled from a suffix.
+  'digest.title': 'Your team yesterday',
+  'digest.sentence': 'Yesterday your team {parts}.',
+  'digest.prs.one': 'shipped 1 PR',
+  'digest.prs.other': 'shipped {count} PRs',
+  'digest.tickets.one': 'moved 1 ticket to Done',
+  'digest.tickets.other': 'moved {count} tickets to Done',
+  'digest.sessions.one': 'ran 1 session',
+  'digest.sessions.other': 'ran {count} sessions',
+  /** Separator between all but the last two clauses of an enumeration. */
+  'digest.list.separator': ', ',
+  /** Separator before the last clause — " and " in English, " et " in French. */
+  'digest.list.last': ' and ',
+
+  // ── Native dialogs ───────────────────────────────────────────────────────
+  'dialog.selectRepository': 'Select a repository folder',
+  'dialog.selectSkillFolder': 'Select a skill folder',
+  'dialog.selectImage': 'Select an image',
+  'dialog.filter.zip': 'ZIP Archive',
+  'dialog.filter.images': 'Images',
+
+  // ── Settings → Language & Region ─────────────────────────────────────────
+  'settings.tab.account': 'Account',
+  'settings.tab.organization': 'Organization',
+  'settings.tab.repositories': 'Repositories',
+  'settings.tab.claudeCode': 'Claude Code',
+  'settings.tab.appearance': 'Appearance',
+  'settings.tab.language': 'Language & Region',
+  'settings.tab.features': 'Features',
+  'settings.tab.shortcuts': 'Shortcuts',
+  'settings.tab.about': 'About',
+  'settings.language.section': 'Language & Region',
+  'settings.language.label': 'Interface language',
+  'settings.language.help':
+    'The language of the app itself — menus, settings, notifications, and how dates and numbers are written.',
+  'settings.language.distinction':
+    'It is not what Claude writes in: commit messages, pull requests and Jira comments follow each repository’s own language settings, and your profile’s languages decide how Claude talks to you.',
+  'settings.language.followsAccount': 'The language follows your account — every machine you sign in on uses it.',
+  'settings.language.error': 'Failed to change language',
+
+  // ── Title bar (terminal chrome) ──────────────────────────────────────────
+  'titlebar.normalView': 'Normal',
+  'titlebar.splitView': 'Split view',
+
+  // ── History ──────────────────────────────────────────────────────────────
+  'history.today': 'Today — {date}',
+  'history.yesterday': 'Yesterday — {date}',
+}

--- a/desktop/src/i18n/fr.ts
+++ b/desktop/src/i18n/fr.ts
@@ -1,0 +1,96 @@
+import type { en } from './en'
+
+/**
+ * French catalogue. The `Record<keyof typeof en, string>` alias is the whole
+ * point of this file's shape: forget a key and `tsc` fails, so a release can
+ * never ship a half-translated interface.
+ *
+ * Electron `role:` menu items are absent on purpose — the OS localizes those
+ * itself, and overriding them would give a French app English-looking system
+ * entries (or the reverse).
+ */
+export const fr: Record<keyof typeof en, string> = {
+  // ── Menu de l'application ────────────────────────────────────────────────
+  'menu.file': 'Fichier',
+  'menu.edit': 'Édition',
+  'menu.view': 'Affichage',
+  'menu.window': 'Fenêtre',
+  'menu.actualSize': 'Taille réelle',
+  'menu.zoomIn': 'Agrandir',
+  'menu.zoomOut': 'Réduire',
+
+  // ── Menu de la barre de menus ────────────────────────────────────────────
+  'tray.version': 'Magic Slash v{version}',
+  'tray.noAgents': 'Aucun agent actif',
+  'tray.showWindow': 'Afficher la fenêtre',
+  'tray.settings': 'Réglages',
+  'tray.changelog': 'Nouveautés',
+  'tray.documentation': 'Documentation',
+  'tray.github': 'GitHub',
+  'tray.quit': 'Quitter Magic Slash',
+  'tray.update.checking': 'Recherche de mises à jour…',
+  'tray.update.downloadingVersion': 'Téléchargement de la v{version}…',
+  'tray.update.downloadingProgress': 'Téléchargement de la mise à jour… {percent} %',
+  'tray.update.restart': '↻ Redémarrer pour mettre à jour (v{version})',
+  'tray.update.checkFailed': 'Rechercher les mises à jour (dernier essai échoué)',
+  'tray.update.check': 'Rechercher les mises à jour',
+
+  // ── Notifications système ────────────────────────────────────────────────
+  'notification.waiting.title': 'Claude Code a besoin de vous',
+  'notification.waiting.body': 'L’agent « {name} » attend votre réponse',
+  'notification.completed.title': 'Tâche terminée',
+  'notification.completed.body': 'L’agent « {name} » a terminé',
+  'notification.prReview.title': 'Mise à jour de revue de PR',
+  'notification.prReview.body': '{url} : {status}',
+  'notification.pickup.title': 'Un collègue a pris {ticket}',
+  'notification.pickup.body': 'Un collègue travaille maintenant sur {ticket} — vous avez aussi un agent dessus.',
+  'notification.changesRequested.title': 'Modifications demandées sur votre PR',
+  'notification.changesRequested.body': '{subject} : un relecteur demande des modifications.',
+
+  // ── Résumé quotidien de l'équipe ─────────────────────────────────────────
+  'digest.title': 'Votre équipe hier',
+  'digest.sentence': 'Hier, votre équipe {parts}.',
+  'digest.prs.one': 'a livré 1 PR',
+  'digest.prs.other': 'a livré {count} PR',
+  'digest.tickets.one': 'a passé 1 ticket en Terminé',
+  'digest.tickets.other': 'a passé {count} tickets en Terminé',
+  'digest.sessions.one': 'a lancé 1 session',
+  'digest.sessions.other': 'a lancé {count} sessions',
+  'digest.list.separator': ', ',
+  'digest.list.last': ' et ',
+
+  // ── Boîtes de dialogue natives ───────────────────────────────────────────
+  'dialog.selectRepository': 'Choisir un dossier de dépôt',
+  'dialog.selectSkillFolder': 'Choisir un dossier de skill',
+  'dialog.selectImage': 'Choisir une image',
+  'dialog.filter.zip': 'Archive ZIP',
+  'dialog.filter.images': 'Images',
+
+  // ── Réglages → Langue et région ──────────────────────────────────────────
+  'settings.tab.account': 'Compte',
+  'settings.tab.organization': 'Organisation',
+  'settings.tab.repositories': 'Dépôts',
+  'settings.tab.claudeCode': 'Claude Code',
+  'settings.tab.appearance': 'Apparence',
+  'settings.tab.language': 'Langue et région',
+  'settings.tab.features': 'Fonctionnalités',
+  'settings.tab.shortcuts': 'Raccourcis',
+  'settings.tab.about': 'À propos',
+  'settings.language.section': 'Langue et région',
+  'settings.language.label': 'Langue de l’interface',
+  'settings.language.help':
+    'La langue de l’application elle-même — menus, réglages, notifications, et la façon d’écrire les dates et les nombres.',
+  'settings.language.distinction':
+    'Ce n’est pas la langue dans laquelle Claude écrit : les messages de commit, les pull requests et les commentaires Jira suivent les réglages de chaque dépôt, et les langues de votre profil décident de la façon dont Claude vous parle.',
+  'settings.language.followsAccount':
+    'La langue suit votre compte — elle s’applique sur toutes les machines où vous vous connectez.',
+  'settings.language.error': 'Impossible de changer la langue',
+
+  // ── Barre de titre (chrome du terminal) ──────────────────────────────────
+  'titlebar.normalView': 'Normal',
+  'titlebar.splitView': 'Vue divisée',
+
+  // ── Historique ───────────────────────────────────────────────────────────
+  'history.today': 'Aujourd’hui — {date}',
+  'history.yesterday': 'Hier — {date}',
+}

--- a/desktop/src/i18n/i18n.test.ts
+++ b/desktop/src/i18n/i18n.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { join } from 'path'
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_LANGUAGE,
+  isValidLanguage,
+  LANGUAGE_IDS,
+  LANGUAGE_LOCALE,
+  type LanguageId,
+} from '../types'
+import { en } from './en'
+import { fr } from './fr'
+import { localeOf, t } from '.'
+
+// Node environment, no jsdom on purpose: this suite exercises the SHARED module,
+// which the main process imports before any window exists. A test that touched
+// `window` would hide a DOM dependency creeping into it.
+
+const SRC_DIR = join(__dirname, '..')
+
+const CATALOGUES: Record<LanguageId, Record<string, string>> = { en, fr }
+
+function walk(dir: string, extensions: string[]): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) return walk(full, extensions)
+    return extensions.some((ext) => full.endsWith(ext)) ? [full] : []
+  })
+}
+
+describe('message catalogues', () => {
+  it('translates every key into every language', () => {
+    // The `Record<keyof typeof en, string>` alias in fr.ts already makes a MISSING
+    // key a tsc error. This catches what types cannot: a key present but empty, or
+    // left as the English string by a copy-paste.
+    const keys = Object.keys(en) as (keyof typeof en)[]
+    expect(keys.length).toBeGreaterThan(0)
+
+    for (const lang of LANGUAGE_IDS) {
+      const catalogue = CATALOGUES[lang]
+      expect(Object.keys(catalogue).sort(), `${lang} key set`).toEqual([...keys].sort())
+
+      for (const key of keys) {
+        expect(catalogue[key], `${lang}.${key}`).toBeTruthy()
+      }
+    }
+  })
+
+  it('keeps the same placeholders in every language', () => {
+    // A translation that drops `{name}` renders a sentence with a hole in it, and
+    // one that invents `{nom}` renders the braces literally.
+    const placeholders = (message: string) => (message.match(/\{\w+\}/g) ?? []).sort()
+
+    for (const lang of LANGUAGE_IDS) {
+      for (const key of Object.keys(en) as (keyof typeof en)[]) {
+        expect(placeholders(CATALOGUES[lang][key]), `${lang}.${key} placeholders`).toEqual(
+          placeholders(en[key]),
+        )
+      }
+    }
+  })
+})
+
+describe('translation', () => {
+  it('returns the message for the language asked for', () => {
+    expect(t('tray.settings', 'en')).toBe('Settings')
+    expect(t('tray.settings', 'fr')).toBe('Réglages')
+  })
+
+  it('substitutes named placeholders', () => {
+    expect(t('notification.completed.body', 'en', { name: 'API refactor' })).toContain('API refactor')
+    expect(t('tray.version', 'fr', { version: '1.2.3' })).toBe('Magic Slash v1.2.3')
+  })
+
+  it('leaves a placeholder alone when no value is given for it', () => {
+    // Better a visible `{name}` than the word "undefined" in a notification.
+    expect(t('notification.completed.body', 'en', {})).toContain('{name}')
+    expect(t('notification.completed.body', 'en')).toContain('{name}')
+  })
+
+  it('falls back to English for a language it has never heard of', () => {
+    // The stored language is re-validated everywhere, but t() is called from the
+    // main process on every menu build and must never throw.
+    expect(t('tray.settings', 'de' as LanguageId)).toBe(en['tray.settings'])
+  })
+})
+
+describe('language preference', () => {
+  it('accepts the languages it knows and nothing else', () => {
+    expect(isValidLanguage('en')).toBe(true)
+    expect(isValidLanguage('fr')).toBe(true)
+    // A value a newer build could have written to user_settings or appearance.json.
+    expect(isValidLanguage('de')).toBe(false)
+    expect(isValidLanguage('en-US')).toBe(false)
+    expect(isValidLanguage(undefined)).toBe(false)
+    expect(isValidLanguage(null)).toBe(false)
+  })
+
+  it('gives every language a BCP-47 tag', () => {
+    // A total record, so this cannot fail without someone deleting an entry — the
+    // point is that the tags are real and usable by Intl, not merely present.
+    for (const lang of LANGUAGE_IDS) {
+      const tag = LANGUAGE_LOCALE[lang]
+      expect(tag, `${lang} locale`).toMatch(/^[a-z]{2}-[A-Z]{2}$/)
+      expect(new Intl.DateTimeFormat(tag).resolvedOptions().locale, `${lang} resolves`).toBeTruthy()
+    }
+    expect(localeOf(DEFAULT_LANGUAGE)).toBe(LANGUAGE_LOCALE[DEFAULT_LANGUAGE])
+  })
+})
+
+describe('no hardcoded locale', () => {
+  it('leaves no en-US in the code this branch made locale-aware', () => {
+    // Every `toLocaleString`/`Intl.*` call in the app used to name 'en-US' inline,
+    // which is exactly the kind of thing that comes back one component at a time.
+    // The tag now lives in one place — LANGUAGE_LOCALE in types.ts — and callers
+    // read it through useLocale(); nothing else may spell it out.
+    const files = [
+      ...walk(join(SRC_DIR, 'main'), ['.ts']),
+      ...walk(join(SRC_DIR, 'renderer'), ['.ts', '.tsx']),
+    ].filter((file) => !file.endsWith('.test.ts') && !file.endsWith('.test.tsx'))
+
+    // Asserted so a directory rename cannot quietly turn this into a green no-op
+    // that walks nothing and reports no offenders.
+    expect(files.length).toBeGreaterThan(50)
+
+    const offenders = files
+      .filter((file) => /['"]en-US['"]/.test(readFileSync(file, 'utf-8')))
+      .map((file) => file.slice(SRC_DIR.length + 1))
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/desktop/src/i18n/index.ts
+++ b/desktop/src/i18n/index.ts
@@ -1,0 +1,59 @@
+import { DEFAULT_LANGUAGE, LANGUAGE_LOCALE, type LanguageId } from '../types'
+import { en } from './en'
+import { fr } from './fr'
+
+/**
+ * The application's message catalogue, shared by the main process and all three
+ * renderers.
+ *
+ * Deliberately pure: no `electron`, no `window`, no `fs`. The main process needs
+ * these strings before any window exists (menus, the tray, notifications) and
+ * the renderer needs the same ones, so importing either side's environment here
+ * would make the module unusable from the other — and from a node-environment
+ * test. Whoever calls `t()` passes the language in; the two thin wrappers that
+ * know it are main/i18n.ts and renderer/i18n/index.ts.
+ */
+
+export type MessageKey = keyof typeof en
+
+/**
+ * A translate function with the language already bound. Both wrappers return this
+ * shape (`main/i18n.ts`'s `t`, the renderer's `useT()`), and anything that takes a
+ * translator as a parameter should say `Translate` rather than restate the
+ * signature — so widening `vars` stays a one-line change.
+ */
+export type Translate = (key: MessageKey, vars?: Record<string, string | number>) => string
+
+const CATALOGUES: Record<LanguageId, Record<MessageKey, string>> = { en, fr }
+
+/**
+ * Translate `key` into `lang`, substituting `{name}` placeholders from `vars`.
+ *
+ * Interpolation is intentionally minimal — no plurals, no dates, no nesting.
+ * Anything that varies grammatically (a plural, an enumeration) gets its own
+ * catalogue entry per form, because a suffix rule that works in English does not
+ * survive translation. See the `digest.*` keys for the pattern.
+ */
+export function t(
+  key: MessageKey,
+  lang: LanguageId = DEFAULT_LANGUAGE,
+  vars?: Record<string, string | number>,
+): string {
+  // An unknown language can only come from unvalidated storage; English is the
+  // reference catalogue, so it is always complete. No per-key fallback beyond
+  // that: every catalogue is typed `Record<keyof typeof en, string>`, so a key
+  // present in `en` is present everywhere.
+  const message = (CATALOGUES[lang] ?? en)[key]
+  if (!vars) return message
+  return message.replace(/\{(\w+)\}/g, (whole, name: string) =>
+    name in vars ? String(vars[name]) : whole,
+  )
+}
+
+/**
+ * The BCP-47 tag to format dates and numbers with, for a given language. The one
+ * door onto `LANGUAGE_LOCALE`: callers name a language, never a tag.
+ */
+export function localeOf(lang: LanguageId): string {
+  return LANGUAGE_LOCALE[lang]
+}

--- a/desktop/src/main/appearance.ts
+++ b/desktop/src/main/appearance.ts
@@ -2,22 +2,24 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { BrowserWindow, nativeTheme } from 'electron'
 import { CONFIG_DIR } from './config/config'
-import { clampZoom, DEFAULT_THEME, DEFAULT_ZOOM, isValidTheme, nextZoom, THEME_APPEARANCE, type ThemeId } from '../types'
+import { clampZoom, DEFAULT_LANGUAGE, DEFAULT_THEME, DEFAULT_ZOOM, isValidLanguage, isValidTheme, nextZoom, THEME_APPEARANCE, type LanguageId, type ThemeId } from '../types'
 
 /**
- * How the app looks on this machine: the theme, and the interface scale.
+ * How the app looks on this machine: the theme, the interface scale, and the
+ * interface language.
  *
- * Both are mirrored to a file here, for the same reason. The cloud owns the
- * theme like every other setting, but it only arrives once the user is
- * authenticated and the config has hydrated — several seconds after the window
- * exists. Opening in the wrong theme and repainting is worse than a file, so the
- * last known choice is kept next to the session (same directory, same idea as
- * cloud-session.enc) and read before anything is shown.
+ * All three are mirrored to a file here, for the same reason. The cloud owns the
+ * theme and the language like every other setting, but they only arrive once the
+ * user is authenticated and the config has hydrated — several seconds after the
+ * window exists. Opening in the wrong theme (or in English) and repainting is
+ * worse than a file, so the last known choice is kept next to the session (same
+ * directory, same idea as cloud-session.enc) and read before anything is shown.
  *
  * The main process has to know them anyway, not just the renderer:
  * `nativeTheme.themeSource` colours the traffic lights and picks the macOS
- * vibrancy material behind a transparent window, and the zoom factor belongs to
- * a window's webContents.
+ * vibrancy material behind a transparent window, the zoom factor belongs to a
+ * window's webContents, and the menus, the tray and the notifications are
+ * composed here with no renderer involved.
  *
  * The zoom is local ONLY, with no cloud column: it compensates for a particular
  * display, so following the account onto a laptop with a different screen would
@@ -29,10 +31,19 @@ const APPEARANCE_FILE = path.join(CONFIG_DIR, 'appearance.json')
 interface StoredAppearance {
   theme?: unknown
   zoom?: unknown
+  language?: unknown
 }
 
 let currentTheme_: ThemeId = DEFAULT_THEME
 let currentZoom_: number = DEFAULT_ZOOM
+let currentLanguage_: LanguageId = DEFAULT_LANGUAGE
+
+/**
+ * Who to tell when the language changes. A local Set rather than a direct call
+ * into the menu and tray modules: those import this one (for
+ * `appearanceArguments`), and reaching back would close the circle.
+ */
+const languageListeners = new Set<() => void>()
 
 /**
  * The window the zoom applies to. The tray popover and quick launch are sized in
@@ -52,7 +63,10 @@ function read(): StoredAppearance {
 function persist(): void {
   try {
     if (!fs.existsSync(CONFIG_DIR)) fs.mkdirSync(CONFIG_DIR, { recursive: true })
-    fs.writeFileSync(APPEARANCE_FILE, JSON.stringify({ theme: currentTheme_, zoom: currentZoom_ }, null, 2))
+    fs.writeFileSync(
+      APPEARANCE_FILE,
+      JSON.stringify({ theme: currentTheme_, zoom: currentZoom_, language: currentLanguage_ }, null, 2),
+    )
   } catch {
     // A cache that cannot be written costs a repaint at next launch, nothing more.
   }
@@ -63,6 +77,9 @@ export function initAppearance(): void {
   const stored = read()
   currentTheme_ = isValidTheme(stored.theme) ? stored.theme : DEFAULT_THEME
   currentZoom_ = clampZoom(stored.zoom)
+  // Re-validated, not trusted: the file may have been written by a build that
+  // knows a language this one does not.
+  currentLanguage_ = isValidLanguage(stored.language) ? stored.language : DEFAULT_LANGUAGE
   nativeTheme.themeSource = THEME_APPEARANCE[currentTheme_]
 }
 
@@ -74,12 +91,20 @@ export function currentZoom(): number {
   return currentZoom_
 }
 
+export function currentLanguage(): LanguageId {
+  return currentLanguage_
+}
+
 /**
  * Arguments handed to every window's preload, so the renderer knows the
  * appearance synchronously — before its first paint, and without a round trip.
  */
 export function appearanceArguments(): string[] {
-  return [`--magic-theme=${currentTheme_}`, `--magic-zoom=${currentZoom_}`]
+  return [
+    `--magic-theme=${currentTheme_}`,
+    `--magic-zoom=${currentZoom_}`,
+    `--magic-language=${currentLanguage_}`,
+  ]
 }
 
 /** Register the window the interface scale applies to. */
@@ -126,6 +151,33 @@ export function applyZoom(value: unknown): number {
   // value from here, and the menu and its ⌘+ / ⌘− change it from outside React.
   if (changed) broadcast('zoom:changed', zoom)
   return zoom
+}
+
+/**
+ * Subscribe to language changes, for the native chrome the main process owns
+ * (the application menu and the tray menu, both built from strings). Returns an
+ * unsubscribe, matching `onUpdateStatusChange` in main/updater.ts.
+ */
+export function onLanguageChanged(callback: () => void): () => void {
+  languageListeners.add(callback)
+  return () => languageListeners.delete(callback)
+}
+
+/**
+ * Apply a language everywhere: local cache, the native chrome via the listeners,
+ * and every open window (the tray popover and quick launch are long-lived and
+ * would otherwise keep the language they were created with).
+ */
+export function applyLanguage(preference: unknown): LanguageId {
+  const language = isValidLanguage(preference) ? preference : DEFAULT_LANGUAGE
+  const changed = language !== currentLanguage_
+  currentLanguage_ = language
+  persist()
+  if (changed) {
+    for (const listener of languageListeners) listener()
+    broadcast('language:changed', language)
+  }
+  return language
 }
 
 /** One step in or out, for the View menu and its keyboard shortcuts. */

--- a/desktop/src/main/appearance.ts
+++ b/desktop/src/main/appearance.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { BrowserWindow, nativeTheme } from 'electron'
 import { CONFIG_DIR } from './config/config'
+import { currentLanguage, setLanguage } from './i18n'
 import { clampZoom, DEFAULT_LANGUAGE, DEFAULT_THEME, DEFAULT_ZOOM, isValidLanguage, isValidTheme, nextZoom, THEME_APPEARANCE, type LanguageId, type ThemeId } from '../types'
 
 /**
@@ -36,7 +37,6 @@ interface StoredAppearance {
 
 let currentTheme_: ThemeId = DEFAULT_THEME
 let currentZoom_: number = DEFAULT_ZOOM
-let currentLanguage_: LanguageId = DEFAULT_LANGUAGE
 
 /**
  * Who to tell when the language changes. A local Set rather than a direct call
@@ -65,7 +65,7 @@ function persist(): void {
     if (!fs.existsSync(CONFIG_DIR)) fs.mkdirSync(CONFIG_DIR, { recursive: true })
     fs.writeFileSync(
       APPEARANCE_FILE,
-      JSON.stringify({ theme: currentTheme_, zoom: currentZoom_, language: currentLanguage_ }, null, 2),
+      JSON.stringify({ theme: currentTheme_, zoom: currentZoom_, language: currentLanguage() }, null, 2),
     )
   } catch {
     // A cache that cannot be written costs a repaint at next launch, nothing more.
@@ -79,7 +79,7 @@ export function initAppearance(): void {
   currentZoom_ = clampZoom(stored.zoom)
   // Re-validated, not trusted: the file may have been written by a build that
   // knows a language this one does not.
-  currentLanguage_ = isValidLanguage(stored.language) ? stored.language : DEFAULT_LANGUAGE
+  setLanguage(isValidLanguage(stored.language) ? stored.language : DEFAULT_LANGUAGE)
   nativeTheme.themeSource = THEME_APPEARANCE[currentTheme_]
 }
 
@@ -91,10 +91,6 @@ export function currentZoom(): number {
   return currentZoom_
 }
 
-export function currentLanguage(): LanguageId {
-  return currentLanguage_
-}
-
 /**
  * Arguments handed to every window's preload, so the renderer knows the
  * appearance synchronously — before its first paint, and without a round trip.
@@ -103,7 +99,7 @@ export function appearanceArguments(): string[] {
   return [
     `--magic-theme=${currentTheme_}`,
     `--magic-zoom=${currentZoom_}`,
-    `--magic-language=${currentLanguage_}`,
+    `--magic-language=${currentLanguage()}`,
   ]
 }
 
@@ -170,8 +166,8 @@ export function onLanguageChanged(callback: () => void): () => void {
  */
 export function applyLanguage(preference: unknown): LanguageId {
   const language = isValidLanguage(preference) ? preference : DEFAULT_LANGUAGE
-  const changed = language !== currentLanguage_
-  currentLanguage_ = language
+  const changed = language !== currentLanguage()
+  setLanguage(language)
   persist()
   if (changed) {
     for (const listener of languageListeners) listener()

--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import * as os from 'os'
 import { randomUUID } from 'crypto'
-import type { Config, RepositoryConfig, LaunchMode, OrgSharedConfig, ThemeId } from '../../types'
+import type { Config, RepositoryConfig, LanguageId, LaunchMode, OrgSharedConfig, ThemeId } from '../../types'
 import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig } from './defaults'
 import { expandPath } from './validation'
 import { getStore, reportWriteError } from '../store/Store'
@@ -491,6 +491,19 @@ export function updateSplitActive(active: boolean): Config {
 export function updateTheme(theme: ThemeId): Config {
   const config = readConfig()
   config.theme = theme
+  writeConfig(config)
+  return config
+}
+
+/**
+ * Store the chosen interface language. Same two destinations as the theme: the
+ * cloud is the reference (it follows the user from machine to machine) and the
+ * main process mirrors it locally so the next launch opens in the right language
+ * before the config has hydrated — see main/appearance.ts.
+ */
+export function updateLanguage(language: LanguageId): Config {
+  const config = readConfig()
+  config.language = language
   writeConfig(config)
   return config
 }

--- a/desktop/src/main/i18n.ts
+++ b/desktop/src/main/i18n.ts
@@ -1,13 +1,19 @@
 import { t as translate, type Translate } from '../i18n'
-import { currentLanguage } from './appearance'
+import { DEFAULT_LANGUAGE, type LanguageId } from '../types'
 
 /**
  * The main process's view of the catalogue: `t()` with the current language
  * already bound, so a menu or a notification reads as one call.
  *
  * It lives here rather than in src/i18n/index.ts because that module is shared
- * with the renderer — binding the language there would make it import
- * `appearance.ts`, and with it `electron` and `fs`.
+ * with the renderer, which binds the language its own way.
+ *
+ * The language is held here rather than in appearance.ts, even though
+ * appearance.ts is what reads it off disk and writes it back: this is the module
+ * every string-producing module imports, and appearance.ts pulls in `electron`
+ * and `fs`. Owning the value here keeps `t` importable from a plain node
+ * context — which is what the test suite runs in, with no electron installed at
+ * the repo root.
  *
  * Nothing is cached: menus and notifications are rebuilt on every language
  * change, so each call reads the language that is current at that moment.
@@ -17,4 +23,19 @@ import { currentLanguage } from './appearance'
  * notifications interpolate names and URLs). Whoever needs one writes
  * `localeOf(currentLanguage())`.
  */
-export const t: Translate = (key, vars) => translate(key, currentLanguage(), vars)
+
+let current: LanguageId = DEFAULT_LANGUAGE
+
+export function currentLanguage(): LanguageId {
+  return current
+}
+
+/**
+ * Record the language in force. Validating it, mirroring it to disk and telling
+ * the rest of the app belong to `applyLanguage` in appearance.ts, its only caller.
+ */
+export function setLanguage(language: LanguageId): void {
+  current = language
+}
+
+export const t: Translate = (key, vars) => translate(key, current, vars)

--- a/desktop/src/main/i18n.ts
+++ b/desktop/src/main/i18n.ts
@@ -1,0 +1,20 @@
+import { t as translate, type Translate } from '../i18n'
+import { currentLanguage } from './appearance'
+
+/**
+ * The main process's view of the catalogue: `t()` with the current language
+ * already bound, so a menu or a notification reads as one call.
+ *
+ * It lives here rather than in src/i18n/index.ts because that module is shared
+ * with the renderer — binding the language there would make it import
+ * `appearance.ts`, and with it `electron` and `fs`.
+ *
+ * Nothing is cached: menus and notifications are rebuilt on every language
+ * change, so each call reads the language that is current at that moment.
+ *
+ * There is no `locale()` companion to the renderer's `useLocale()`: nothing in the
+ * main process formats a date or a number (the digest interpolates raw counts, the
+ * notifications interpolate names and URLs). Whoever needs one writes
+ * `localeOf(currentLanguage())`.
+ */
+export const t: Translate = (key, vars) => translate(key, currentLanguage(), vars)

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -24,7 +24,8 @@ import { AgentStateAggregator } from './tray/agent-state-aggregator'
 import { destroyPopover } from './windows/popover-window'
 import { hideQuickLaunch, resizeQuickLaunch, destroyQuickLaunch } from './windows/quick-launch-window'
 import { reRegisterSpotlightShortcut } from './spotlight-shortcut'
-import { initAppearance, appearanceArguments, applyZoom, setZoomWindow, stepZoom } from './appearance'
+import { initAppearance, appearanceArguments, applyZoom, onLanguageChanged, setZoomWindow, stepZoom } from './appearance'
+import { t } from './i18n'
 import { setupProfileHandlers } from './ipc/profile-handlers'
 import { setupUsageHandlers } from './ipc/usage-handlers'
 import { setupAuthHandlers } from './ipc/auth-handlers'
@@ -68,12 +69,12 @@ function createMenu() {
       : []),
     // File menu - without Cmd+W close window
     {
-      label: 'File',
+      label: t('menu.file'),
       submenu: [isMac ? { role: 'close' as const, accelerator: '' } : { role: 'quit' as const }],
     },
     // Edit menu
     {
-      label: 'Edit',
+      label: t('menu.edit'),
       submenu: [
         { role: 'undo' as const },
         { role: 'redo' as const },
@@ -86,7 +87,7 @@ function createMenu() {
     },
     // View menu
     {
-      label: 'View',
+      label: t('menu.view'),
       submenu: [
         { role: 'reload' as const },
         { role: 'forceReload' as const },
@@ -95,16 +96,16 @@ function createMenu() {
         { type: 'separator' as const },
         // Not the built-in zoom roles: those change the factor behind the app's
         // back, so nothing would be saved and Settings would show a stale value.
-        { label: 'Actual Size', accelerator: 'CmdOrCtrl+0', click: () => applyZoom(1) },
-        { label: 'Zoom In', accelerator: 'CmdOrCtrl+Plus', click: () => stepZoom(1) },
-        { label: 'Zoom Out', accelerator: 'CmdOrCtrl+-', click: () => stepZoom(-1) },
+        { label: t('menu.actualSize'), accelerator: 'CmdOrCtrl+0', click: () => applyZoom(1) },
+        { label: t('menu.zoomIn'), accelerator: 'CmdOrCtrl+Plus', click: () => stepZoom(1) },
+        { label: t('menu.zoomOut'), accelerator: 'CmdOrCtrl+-', click: () => stepZoom(-1) },
         { type: 'separator' as const },
         { role: 'togglefullscreen' as const },
       ],
     },
     // Window menu
     {
-      label: 'Window',
+      label: t('menu.window'),
       submenu: [
         { role: 'minimize' as const },
         { role: 'zoom' as const },
@@ -297,7 +298,7 @@ function setupHandlers() {
   ipcMain.handle('dialog:openFolder', async () => {
     const result = await dialog.showOpenDialog(mainWindow!, {
       properties: ['openDirectory'],
-      title: 'Select a repository folder'
+      title: t('dialog.selectRepository')
     })
 
     if (result.canceled || result.filePaths.length === 0) {
@@ -393,6 +394,15 @@ app.whenReady().then(async () => {
 
   // Create custom menu (removes Cmd+W close window behavior)
   createMenu()
+
+  // The native chrome is built from strings, so it has to be rebuilt when the
+  // language changes — whether from Settings or from cloud hydration. Closures,
+  // not direct calls: the tray does not exist yet (it is created below, after the
+  // window), and `trayManager` is still null at this point.
+  onLanguageChanged(() => {
+    createMenu()
+    trayManager?.rebuildMenu()
+  })
 
   // Setup auto-updater handlers
   setupAutoUpdater()

--- a/desktop/src/main/ipc/config-handlers.ts
+++ b/desktop/src/main/ipc/config-handlers.ts
@@ -23,6 +23,7 @@ import {
   updateSplitActive,
   updateLaunchMode,
   updateTheme,
+  updateLanguage,
   updateUsageLogsEnabled,
   updateDailyDigestEnabled,
   setIntegration,
@@ -31,8 +32,8 @@ import { getGitHubAuthStatus } from '../github'
 import { reRegisterSpotlightShortcut } from '../spotlight-shortcut'
 import { repairConfig } from '../config/migrate'
 import { isValidSpotlightShortcut, isValidLaunchMode } from '../config/defaults'
-import { isValidTheme } from '../../types'
-import { applyTheme } from '../appearance'
+import { isValidLanguage, isValidTheme } from '../../types'
+import { applyLanguage, applyTheme } from '../appearance'
 import { validateConfig } from '../config/schema-validator'
 import {
   validateRepoName,
@@ -322,6 +323,18 @@ export function setupConfigHandlers(getMainWindow: () => BrowserWindow | null) {
     // open window (tray popover, quick launch) follow immediately.
     const config = updateTheme(theme)
     applyTheme(theme)
+    return { config }
+  })
+
+  ipcMain.handle('config:updateLanguage', async (_event, { language }: { language: string }) => {
+    if (!isValidLanguage(language)) {
+      throw new Error(`Invalid language: '${language}'.`)
+    }
+    // Same two destinations as the theme: the cloud so the choice follows the
+    // user, and the main process so the menus, the tray, the local cache and
+    // every open window switch immediately.
+    const config = updateLanguage(language)
+    applyLanguage(language)
     return { config }
   })
 

--- a/desktop/src/main/ipc/skills-handlers.ts
+++ b/desktop/src/main/ipc/skills-handlers.ts
@@ -5,6 +5,7 @@ import * as os from 'os'
 import { readConfig } from '../config/config'
 import { expandPath } from '../config/validation'
 import AdmZip from 'adm-zip'
+import { t } from '../i18n'
 
 const BUILT_IN_SKILLS = ['magic-start', 'magic-continue', 'magic-commit', 'magic-pr', 'magic-review', 'magic-resolve', 'magic-done']
 
@@ -223,7 +224,7 @@ export function setupSkillsHandlers() {
 
     const result = await dialog.showSaveDialog(window, {
       defaultPath: path.join(os.homedir(), 'Downloads', `${name}.zip`),
-      filters: [{ name: 'ZIP Archive', extensions: ['zip'] }],
+      filters: [{ name: t('dialog.filter.zip'), extensions: ['zip'] }],
     })
     if (result.canceled || !result.filePath) return { success: false, canceled: true }
 
@@ -242,7 +243,7 @@ export function setupSkillsHandlers() {
 
     const result = await dialog.showOpenDialog(window, {
       properties: ['openDirectory'],
-      title: 'Select a skill folder',
+      title: t('dialog.selectSkillFolder'),
     })
 
     if (result.canceled || result.filePaths.length === 0) {
@@ -413,9 +414,9 @@ export function setupSkillsHandlers() {
 
     const result = await dialog.showOpenDialog(window, {
       properties: ['openFile'],
-      title: 'Select an image',
+      title: t('dialog.selectImage'),
       filters: [
-        { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'svg', 'webp'] }
+        { name: t('dialog.filter.images'), extensions: ['png', 'jpg', 'jpeg', 'svg', 'webp'] }
       ]
     })
 

--- a/desktop/src/main/ipc/terminal-handlers.test.ts
+++ b/desktop/src/main/ipc/terminal-handlers.test.ts
@@ -59,7 +59,7 @@ vi.mock('../usage/usage-events', () => ({
   recordUsageSnapshot: (...args: unknown[]) => recordUsageSnapshot(...args),
 }))
 
-vi.mock('../config/config', () => ({ readConfig: vi.fn(() => ({ repositories: {} })), CONFIG_DIR: '/tmp/magic-slash-test' }))
+vi.mock('../config/config', () => ({ readConfig: vi.fn(() => ({ repositories: {} })) }))
 vi.mock('../config/validation', () => ({ expandPath: (p: string) => p }))
 vi.mock('../config/repo-validation', () => ({ checkRepoPath: vi.fn(() => ({ valid: true })) }))
 vi.mock('../store/hydrate', () => ({ ensureHydrated: vi.fn(async () => {}) }))

--- a/desktop/src/main/ipc/terminal-handlers.test.ts
+++ b/desktop/src/main/ipc/terminal-handlers.test.ts
@@ -59,7 +59,7 @@ vi.mock('../usage/usage-events', () => ({
   recordUsageSnapshot: (...args: unknown[]) => recordUsageSnapshot(...args),
 }))
 
-vi.mock('../config/config', () => ({ readConfig: vi.fn(() => ({ repositories: {} })) }))
+vi.mock('../config/config', () => ({ readConfig: vi.fn(() => ({ repositories: {} })), CONFIG_DIR: '/tmp/magic-slash-test' }))
 vi.mock('../config/validation', () => ({ expandPath: (p: string) => p }))
 vi.mock('../config/repo-validation', () => ({ checkRepoPath: vi.fn(() => ({ valid: true })) }))
 vi.mock('../store/hydrate', () => ({ ensureHydrated: vi.fn(async () => {}) }))

--- a/desktop/src/main/ipc/terminal-handlers.ts
+++ b/desktop/src/main/ipc/terminal-handlers.ts
@@ -1,5 +1,7 @@
 import os from 'os'
 import { ipcMain, BrowserWindow } from 'electron'
+// Aliased: `t` is already the local name for a terminal throughout this file.
+import { t as translate } from '../i18n'
 import {
   createTerminal,
   launchClaude,
@@ -164,8 +166,8 @@ function createTerminalCallbacks(id: string, name: string) {
         maybeShowNotification(
           id,
           displayName,
-          'Claude Code needs attention',
-          `Agent "${displayName}" is waiting for your input`
+          translate('notification.waiting.title'),
+          translate('notification.waiting.body', { name: displayName })
         )
         addHistoryEntry({
           agentId: id,
@@ -181,8 +183,8 @@ function createTerminalCallbacks(id: string, name: string) {
         maybeShowNotification(
           id,
           displayName,
-          'Task completed',
-          `Agent "${displayName}" has finished`
+          translate('notification.completed.title'),
+          translate('notification.completed.body', { name: displayName })
         )
         addHistoryEntry({
           agentId: id,

--- a/desktop/src/main/notifications/daily-digest.ts
+++ b/desktop/src/main/notifications/daily-digest.ts
@@ -1,4 +1,5 @@
 import { readConfig } from '../config/config'
+import { t } from '../i18n'
 import { getStore } from '../store/Store'
 
 // ---------------------------------------------------------------------------
@@ -74,7 +75,7 @@ export class DailyDigestScheduler {
       if (readConfig().dailyDigest?.enabled !== true) return
       const summary = await this.composeSummary()
       if (summary) {
-        this.showNotification('Your team yesterday', summary)
+        this.showNotification(t('digest.title'), summary)
       }
     } catch (error) {
       console.error('[daily-digest] failed to compose/fire digest:', error)
@@ -127,17 +128,20 @@ export class DailyDigestScheduler {
 
     if (mergedPRs === 0 && ticketsDone === 0 && sessions === 0) return null
 
+    // One catalogue entry per plural form rather than an English "s" suffix:
+    // the break is not the same in every language, and French agreement cannot be
+    // assembled from a suffix at all.
     const parts: string[] = []
-    if (mergedPRs > 0) parts.push(`shipped ${mergedPRs} PR${mergedPRs === 1 ? '' : 's'}`)
-    if (ticketsDone > 0) parts.push(`moved ${ticketsDone} ticket${ticketsDone === 1 ? '' : 's'} to Done`)
-    if (sessions > 0) parts.push(`ran ${sessions} session${sessions === 1 ? '' : 's'}`)
+    if (mergedPRs > 0) parts.push(t(mergedPRs === 1 ? 'digest.prs.one' : 'digest.prs.other', { count: mergedPRs }))
+    if (ticketsDone > 0) parts.push(t(ticketsDone === 1 ? 'digest.tickets.one' : 'digest.tickets.other', { count: ticketsDone }))
+    if (sessions > 0) parts.push(t(sessions === 1 ? 'digest.sessions.one' : 'digest.sessions.other', { count: sessions }))
 
-    return `Yesterday your team ${joinParts(parts)}.`
+    return t('digest.sentence', { parts: joinParts(parts) })
   }
 }
 
-/** "a", "a and b", "a, b and c". */
+/** "a", "a and b", "a, b and c" — with the separators the active language uses. */
 function joinParts(parts: string[]): string {
   if (parts.length <= 1) return parts[0] ?? ''
-  return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`
+  return parts.slice(0, -1).join(t('digest.list.separator')) + t('digest.list.last') + parts[parts.length - 1]
 }

--- a/desktop/src/main/notifications/reengagement.ts
+++ b/desktop/src/main/notifications/reengagement.ts
@@ -1,4 +1,5 @@
 import type { OrgAgent, OrgAgentChange } from '../../types'
+import { t } from '../i18n'
 import { addOrgAgentChangeListener } from '../cloud/realtime'
 import { loadSession } from '../cloud/session-store'
 import { getStore } from '../store/Store'
@@ -95,8 +96,8 @@ export function setupReengagementNotifications(
       const isNewPickup = !prev || prev.ownerId !== agent.ownerId || prev.ticketId !== agent.ticketId
       if (isNewPickup && cooldownOk(`pickup:${agent.ticketId}:${agent.ownerId}`)) {
         showNotification(
-          `A colleague picked up ${agent.ticketId}`,
-          `A teammate is now working on ${agent.ticketId} — you also have an agent on it.`,
+          t('notification.pickup.title', { ticket: agent.ticketId }),
+          t('notification.pickup.body', { ticket: agent.ticketId }),
         )
       }
     }
@@ -111,8 +112,8 @@ export function setupReengagementNotifications(
         if (wasAlreadyChanges) continue
         if (cooldownOk(`changes:${review.prUrl ?? review.repo}`)) {
           showNotification(
-            'Changes requested on your PR',
-            `${agent.ticketId ?? agent.name}: a reviewer requested changes.`,
+            t('notification.changesRequested.title'),
+            t('notification.changesRequested.body', { subject: agent.ticketId ?? agent.name }),
           )
         }
       }

--- a/desktop/src/main/pr-review-watcher/watcher.ts
+++ b/desktop/src/main/pr-review-watcher/watcher.ts
@@ -4,6 +4,7 @@ import { getAllTerminals, updateTerminalMetadataFromHook } from '../pty/terminal
 import { addHistoryEntry } from '../config/activity-history'
 import { fetchPRStatus, type AggregatedReviewStatus } from '../github'
 import type { RepositoryMetadata } from '../../types'
+import { t } from '../i18n'
 
 const DEFAULT_POLL_INTERVAL_MS = 60_000
 const MIN_POLL_INTERVAL_MS = 30_000
@@ -153,8 +154,8 @@ export class PRReviewWatcher {
         if (!windowFocused && now - lastNotified > NOTIFICATION_COOLDOWN_MS && prevStatus !== snapshot.status) {
           this.lastNotifiedAt.set(target.prUrl, now)
           this.showNotification(
-            'PR review update',
-            `${target.prUrl}: ${snapshot.status}`,
+            t('notification.prReview.title'),
+            t('notification.prReview.body', { url: target.prUrl, status: snapshot.status }),
           )
         }
 

--- a/desktop/src/main/store/CloudStore.test.ts
+++ b/desktop/src/main/store/CloudStore.test.ts
@@ -642,6 +642,7 @@ const emptySettingsRow = {
   launch_mode: null,
   atlassian_integration_enabled: null,
   theme: null,
+  language: null,
 }
 
 describe('user settings', () => {
@@ -765,6 +766,34 @@ describe('user settings', () => {
     expect((await new CloudStore().loadConfig())?.theme).toBe('light')
   })
 
+  it('ignores an interface language a newer build invented', async () => {
+    // The column takes any two-letter code so a new language needs no migration,
+    // which makes this the second setting a client can meet unknown.
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      configs: { data: null, error: null },
+      repositories: { data: [], error: null },
+      repository_paths: { data: [], error: null },
+      user_settings: { data: { ...emptySettingsRow, language: 'de' }, error: null },
+    })
+    h.state.client = client
+
+    expect(await new CloudStore().loadConfig()).not.toHaveProperty('language')
+  })
+
+  it('reads back an interface language it knows', async () => {
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      configs: { data: null, error: null },
+      repositories: { data: [], error: null },
+      repository_paths: { data: [], error: null },
+      user_settings: { data: { ...emptySettingsRow, language: 'fr' }, error: null },
+    })
+    h.state.client = client
+
+    expect((await new CloudStore().loadConfig())?.language).toBe('fr')
+  })
+
   it('upserts settings keyed by user_id, mapping absent keys to NULL', async () => {
     const { client, upserts } = makeClient({
       memberships: membershipsOk,
@@ -803,6 +832,7 @@ describe('user settings', () => {
       launch_mode: null,
       atlassian_integration_enabled: null,
       theme: null,
+      language: null,
     })
   })
 

--- a/desktop/src/main/store/CloudStore.ts
+++ b/desktop/src/main/store/CloudStore.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Agent, AppInstallationInfo, Config, HistoryEntry, OrgAgent, OrgSharedConfig, RepositoryConfig, RepositoryIdentity, SkillInvocationInput, SpotlightConfig, StoredRepository, TerminalMetadata, UsageEventInput, UsageStats, UserProfile } from '../../types'
-import { isValidTheme } from '../../types'
+import { isValidLanguage, isValidTheme } from '../../types'
 import { isValidLaunchMode, isValidSpotlightShortcut } from '../config/defaults'
 import { getAuthedClient } from '../cloud/auth'
 import { loadSession } from '../cloud/session-store'
@@ -97,13 +97,15 @@ interface UserSettingsRow {
   launch_mode: string | null
   atlassian_integration_enabled: boolean | null
   theme: string | null
+  language: string | null
 }
 
 const USER_SETTINGS_COLUMNS =
   'history_enabled, usage_card_enabled, usage_card_minimized, usage_logs_enabled, ' +
   'daily_digest_enabled, split_enabled, split_active, pr_reviews_enabled, ' +
   'pr_reviews_poll_interval_ms, pr_reviews_auto_launch_skills, spotlight_enabled, ' +
-  'spotlight_shortcut, auto_start_at_login, launch_mode, atlassian_integration_enabled, theme'
+  'spotlight_shortcut, auto_start_at_login, launch_mode, atlassian_integration_enabled, theme, ' +
+  'language'
 
 /**
  * Config keys that now live in `user_settings`. Stripped from the org-scoped
@@ -125,6 +127,7 @@ const SETTINGS_KEYS = [
   'launchMode',
   'integrations',
   'theme',
+  'language',
 ] as const
 
 /** `undefined` (key absent from Config) → `null` (column unset). */
@@ -156,6 +159,7 @@ function configToSettingsRow(config: Config): UserSettingsRow {
     launch_mode: orNull(config.launchMode),
     atlassian_integration_enabled: orNull(config.integrations?.atlassian),
     theme: orNull(config.theme),
+    language: orNull(config.language),
   }
 }
 
@@ -178,6 +182,9 @@ function applySettingsRow(config: Config, row: UserSettingsRow): void {
   // Re-validated rather than trusted: a newer version may have stored a theme
   // this build has never heard of, and it must read as "unset", not as a theme.
   if (isValidTheme(row.theme)) config.theme = row.theme
+  // Same treatment for the interface language: an unknown one reads as "unset",
+  // so this build falls back to English rather than to a locale it cannot show.
+  if (isValidLanguage(row.language)) config.language = row.language
 
   const prReviews: NonNullable<Config['prReviews']> = {}
   if (isSet(row.pr_reviews_enabled)) prReviews.enabled = row.pr_reviews_enabled

--- a/desktop/src/main/store/hydrate.ts
+++ b/desktop/src/main/store/hydrate.ts
@@ -3,12 +3,26 @@ import { hydrateAgents, resetAgentsCache } from '../config/agents'
 import { hydrateHistory, resetHistoryCache } from '../config/activity-history'
 import { hydrateProfile } from '../config/profile'
 import { applyLanguage, applyTheme } from '../appearance'
+import type { Config } from '../../types'
 
 // Coordinates a one-time hydration of the in-memory caches (config, agents,
 // history) from the store once auth + connectivity are established. Every mutating
 // IPC path awaits ensureHydrated() so it never reads a cold (empty) cache.
 
 let hydrationPromise: Promise<void> | null = null
+
+/**
+ * Adopt the cloud language, but only when the row actually carries one.
+ *
+ * An account that has never chosen a language leaves the column NULL, and
+ * `applyLanguage(undefined)` falls back to English *and persists it* — so a user
+ * running in French from the local mirror would flip to English seconds after
+ * launch, and stay there on every cold launch after that. Silence from the cloud
+ * means "no opinion", not "English".
+ */
+function adoptCloudLanguage(language: Config['language']): void {
+  if (language) applyLanguage(language)
+}
 
 /**
  * Hydrate config, agents and history from the store exactly once. Subsequent
@@ -25,7 +39,7 @@ export function ensureHydrated(): Promise<void> {
       applyTheme(config.theme)
       // Likewise for the interface language: it may have been changed on another
       // machine, and switching now rebuilds the menus, the tray and every window.
-      applyLanguage(config.language)
+      adoptCloudLanguage(config.language)
       await hydrateAgents()
       await hydrateHistory()
       await hydrateProfile()
@@ -47,7 +61,7 @@ export function rehydrate(): Promise<void> {
   hydrationPromise = (async () => {
     const config = await hydrateConfig()
     applyTheme(config.theme)
-    applyLanguage(config.language)
+    adoptCloudLanguage(config.language)
     await hydrateAgents()
     await hydrateHistory()
   })().catch((error) => {

--- a/desktop/src/main/store/hydrate.ts
+++ b/desktop/src/main/store/hydrate.ts
@@ -2,7 +2,7 @@ import { hydrateConfig, resetConfigCache } from '../config/config'
 import { hydrateAgents, resetAgentsCache } from '../config/agents'
 import { hydrateHistory, resetHistoryCache } from '../config/activity-history'
 import { hydrateProfile } from '../config/profile'
-import { applyTheme } from '../appearance'
+import { applyLanguage, applyTheme } from '../appearance'
 
 // Coordinates a one-time hydration of the in-memory caches (config, agents,
 // history) from the store once auth + connectivity are established. Every mutating
@@ -23,6 +23,9 @@ export function ensureHydrated(): Promise<void> {
       // the local cache and the native chrome if it was changed on another
       // machine, and repaints every open window.
       applyTheme(config.theme)
+      // Likewise for the interface language: it may have been changed on another
+      // machine, and switching now rebuilds the menus, the tray and every window.
+      applyLanguage(config.language)
       await hydrateAgents()
       await hydrateHistory()
       await hydrateProfile()
@@ -44,6 +47,7 @@ export function rehydrate(): Promise<void> {
   hydrationPromise = (async () => {
     const config = await hydrateConfig()
     applyTheme(config.theme)
+    applyLanguage(config.language)
     await hydrateAgents()
     await hydrateHistory()
   })().catch((error) => {

--- a/desktop/src/main/tray/tray-manager.ts
+++ b/desktop/src/main/tray/tray-manager.ts
@@ -3,6 +3,7 @@ import { getIconForState, type AggregateState } from './tray-icons'
 import { AgentStateAggregator } from './agent-state-aggregator'
 import { getUpdateStatus, onUpdateStatusChange, installUpdate, type UpdateStatus } from '../updater'
 import { autoUpdater } from 'electron-updater'
+import { t } from '../i18n'
 
 const GITHUB_URL = 'https://github.com/xrequillart/magic-slash'
 const DOCS_URL = 'https://magic-slash.io'
@@ -63,7 +64,12 @@ export class TrayManager {
     callback?.(win)
   }
 
-  private rebuildMenu(): void {
+  /**
+   * Rebuild the menu from the current agent state and the current strings. Public
+   * because a language switch has to trigger one from outside (see main/index.ts);
+   * everything else that invalidates it is an event this class owns.
+   */
+  rebuildMenu(): void {
     if (!this.tray) return
 
     const summaries = this.aggregator.getAgentSummaries()
@@ -81,7 +87,7 @@ export class TrayManager {
           { type: 'separator' as const },
         ]
       : [
-          { label: 'No active agents', enabled: false },
+          { label: t('tray.noAgents'), enabled: false },
           { type: 'separator' as const },
         ]
 
@@ -89,18 +95,18 @@ export class TrayManager {
 
     const menu = Menu.buildFromTemplate([
       {
-        label: `Magic Slash v${app.getVersion()}`,
+        label: t('tray.version', { version: app.getVersion() }),
         enabled: false,
       },
       updateItem,
       { type: 'separator' },
       ...agentItems,
       {
-        label: 'Show Window',
+        label: t('tray.showWindow'),
         click: () => this.showMainWindow(),
       },
       {
-        label: 'Settings',
+        label: t('tray.settings'),
         click: () => {
           this.showMainWindow(win => {
             win.webContents.send('tray:openSettings')
@@ -109,20 +115,20 @@ export class TrayManager {
       },
       { type: 'separator' },
       {
-        label: 'Changelog',
+        label: t('tray.changelog'),
         click: () => shell.openExternal(`${GITHUB_URL}/releases/tag/v${app.getVersion()}`),
       },
       {
-        label: 'Documentation',
+        label: t('tray.documentation'),
         click: () => shell.openExternal(DOCS_URL),
       },
       {
-        label: 'GitHub',
+        label: t('tray.github'),
         click: () => shell.openExternal(GITHUB_URL),
       },
       { type: 'separator' },
       {
-        label: 'Quit Magic Slash',
+        label: t('tray.quit'),
         click: () => {
           this.onQuit()
         },
@@ -137,27 +143,27 @@ export class TrayManager {
 
     switch (status.type) {
       case 'checking':
-        return { label: 'Checking for updates…', enabled: false }
+        return { label: t('tray.update.checking'), enabled: false }
       case 'available':
-        return { label: `Downloading v${status.version}…`, enabled: false }
+        return { label: t('tray.update.downloadingVersion', { version: status.version }), enabled: false }
       case 'downloading': {
         const pct = Math.round(status.progress)
-        return { label: `Downloading update… ${pct}%`, enabled: false }
+        return { label: t('tray.update.downloadingProgress', { percent: pct }), enabled: false }
       }
       case 'downloaded':
         return {
-          label: `↻ Restart to update (v${status.version})`,
+          label: t('tray.update.restart', { version: status.version }),
           click: () => installUpdate(),
         }
       case 'error':
         return {
-          label: 'Check for Updates (last check failed)',
+          label: t('tray.update.checkFailed'),
           click: () => { autoUpdater.checkForUpdates().catch(() => {}) },
         }
       case 'not-available':
       default:
         return {
-          label: 'Check for Updates',
+          label: t('tray.update.check'),
           click: () => { autoUpdater.checkForUpdates().catch(() => {}) },
         }
     }

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
-import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole, OrgSharedConfig, OrgAgent, OrgAgentChange, RealtimeStatus, UsageStats, ThemeId } from '../types'
+import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole, OrgSharedConfig, OrgAgent, OrgAgentChange, RealtimeStatus, UsageStats, ThemeId, LanguageId } from '../types'
 
 export type TerminalState = 'idle' | 'working' | 'waiting' | 'completed' | 'error'
 
@@ -76,6 +76,9 @@ const configApi = {
 
   updateTheme: (theme: ThemeId) =>
     ipcRenderer.invoke('config:updateTheme', { theme }),
+
+  updateLanguage: (language: LanguageId): Promise<{ config: Config }> =>
+    ipcRenderer.invoke('config:updateLanguage', { language }),
 
   repair: (): Promise<{ repaired: boolean; fixes: string[] }> =>
     ipcRenderer.invoke('config:repair'),
@@ -528,6 +531,22 @@ const themeApi = {
 }
 
 /**
+ * Interface language. Read like the theme, and for the same reason: a cold start
+ * in French must not flash English while the config hydrates. Changes are asked
+ * for through `config.updateLanguage` (the choice is a stored preference), so
+ * there is no `set` here.
+ */
+const languageApi = {
+  initial: (): string | null => launchArgument('language'),
+
+  onChanged: (callback: (language: LanguageId) => void) => {
+    const listener = (_event: IpcRendererEvent, language: LanguageId) => callback(language)
+    ipcRenderer.on('language:changed', listener)
+    return () => ipcRenderer.removeListener('language:changed', listener)
+  },
+}
+
+/**
  * Interface scale. Applied by the main process on the window's webContents, so
  * the renderer only reads it and asks for changes — it never scales itself.
  */
@@ -568,6 +587,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   connectivity: connectivityApi,
   theme: themeApi,
   zoom: zoomApi,
+  language: languageApi,
 })
 
 // Type definitions for the renderer
@@ -594,6 +614,7 @@ declare global {
       connectivity: typeof connectivityApi
       theme: typeof themeApi
       zoom: typeof zoomApi
+      language: typeof languageApi
     }
   }
 

--- a/desktop/src/renderer/components/TitleBar.tsx
+++ b/desktop/src/renderer/components/TitleBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useStore } from '../store'
+import { useT } from '../i18n'
 
 // Inline SVG components for left sidebar toggle icons
 const LeftSidebarOpenIcon = () => (
@@ -36,6 +37,7 @@ const RightSidebarCloseIcon = () => (
 )
 
 export function TitleBar() {
+  const t = useT()
   const { terminals, activeTerminalId, rightSidebar, leftSidebarVisible, toggleRightSidebar, toggleLeftSidebar, isSplitMode, splitTerminalId, focusedPane, isWideScreen, splitEnabled, splitActive, toggleSplitActive } = useStore()
   const activeTerminal = terminals.find((t) => t.id === activeTerminalId)
   const splitTerminal = terminals.find((t) => t.id === splitTerminalId)
@@ -101,7 +103,7 @@ export function TitleBar() {
                   }`}
                   title="Normal view (⌘/)"
                 >
-                  Normal
+                  {t('titlebar.normalView')}
                 </button>
                 <button
                   onClick={() => { if (!splitActive) toggleSplitActive() }}
@@ -110,15 +112,17 @@ export function TitleBar() {
                   }`}
                   title="Split view (⌘/)"
                 >
-                  Split view
+                  {t('titlebar.splitView')}
                 </button>
               </div>
             )}
         </div>
       </div>
 
-      {/* Center - Active agent name(s) */}
-      <div className="absolute left-1/2 -translate-x-1/2 text-sm truncate max-w-[40%]">
+      {/* Center - Active agent name(s). Absolutely positioned, so a width cap is
+          the only thing keeping it clear of the left controls; 36% rather than 40%
+          because the split toggle beside it is wider in French. */}
+      <div className="absolute left-1/2 -translate-x-1/2 text-sm truncate max-w-[36%]">
         {isSplitMode && splitTerminal ? (
           <div className="flex items-center gap-2">
             <span className={focusedPane === 'primary' ? 'text-ink' : 'text-text-secondary/50'}>

--- a/desktop/src/renderer/hooks/useActivityHistory.ts
+++ b/desktop/src/renderer/hooks/useActivityHistory.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import type { HistoryEntry, TicketEventGroup } from '../../types'
+import { useLocale, useT, type Translate } from '../i18n'
 
 export interface HistoryGroup {
   label: string
@@ -51,7 +52,12 @@ function getDateKey(timestamp: number): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
-function getDayLabel(dateKey: string): string {
+/**
+ * "Today — 12 June 2026", or just the date for any older day. The locale and the
+ * translator are passed in rather than read here: this is a plain function, and
+ * both must be the ones current at render time, not at import time.
+ */
+function getDayLabel(dateKey: string, locale: string, t: Translate): string {
   const today = new Date()
   const todayKey = getDateKey(today.getTime())
 
@@ -61,10 +67,10 @@ function getDayLabel(dateKey: string): string {
 
   const [year, month, day] = dateKey.split('-').map(Number)
   const d = new Date(year, month - 1, day)
-  const fullDate = d.toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' })
+  const fullDate = d.toLocaleDateString(locale, { day: 'numeric', month: 'long', year: 'numeric' })
 
-  if (dateKey === todayKey) return `Today — ${fullDate}`
-  if (dateKey === yesterdayKey) return `Yesterday — ${fullDate}`
+  if (dateKey === todayKey) return t('history.today', { date: fullDate })
+  if (dateKey === yesterdayKey) return t('history.yesterday', { date: fullDate })
 
   return fullDate
 }
@@ -73,6 +79,8 @@ export function useActivityHistory() {
   const [entries, setEntries] = useState<HistoryEntry[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const locale = useLocale()
+  const t = useT()
 
   const loadHistory = useCallback(async () => {
     try {
@@ -112,13 +120,13 @@ export function useActivityHistory() {
     return sortedKeys.map(key => {
       const sorted = grouped.get(key)!.sort((a, b) => b.timestamp - a.timestamp)
       return {
-        label: getDayLabel(key),
+        label: getDayLabel(key, locale, t),
         date: key,
         entries: sorted,
         ticketGroups: groupConsecutiveByTicket(sorted),
       }
     })
-  }, [entries])
+  }, [entries, locale, t])
 
   return { entries, groups, loading, error, refresh: loadHistory }
 }

--- a/desktop/src/renderer/hooks/useConfig.ts
+++ b/desktop/src/renderer/hooks/useConfig.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useStore } from '../store'
-import type { RepositoryConfig, ThemeId } from '../../types'
+import type { LanguageId, RepositoryConfig, ThemeId } from '../../types'
 
 export function useConfig() {
   const { config, configLoading, configError, setConfig, setConfigLoading, setConfigError } = useStore()
@@ -113,6 +113,14 @@ export function useConfig() {
     return result
   }, [setConfig])
 
+  // Re-rendering in the new language is the main process's job too (it owns the
+  // menus, the tray and the other windows), so this only records the choice.
+  const updateLanguage = useCallback(async (language: LanguageId) => {
+    const result = await window.electronAPI.config.updateLanguage(language)
+    setConfig(result.config)
+    return result
+  }, [setConfig])
+
   const validatePath = useCallback(async (path: string) => {
     return window.electronAPI.config.validatePath(path)
   }, [])
@@ -150,6 +158,7 @@ export function useConfig() {
     updateSpotlight,
     updateLaunchMode,
     updateTheme,
+    updateLanguage,
     validatePath,
     getPRTemplate,
     createPRTemplate,

--- a/desktop/src/renderer/i18n/index.ts
+++ b/desktop/src/renderer/i18n/index.ts
@@ -1,0 +1,82 @@
+import { useCallback, useSyncExternalStore } from 'react'
+import { DEFAULT_LANGUAGE, isValidLanguage, type LanguageId } from '../../types'
+import { localeOf, t as translate, type Translate } from '../../i18n'
+
+export type { MessageKey, Translate } from '../../i18n'
+
+/**
+ * The renderer's view of the interface language, for the three windows at once.
+ *
+ * Same shape as the theme store next door, and for the same reason: the tray
+ * popover and the quick launch never load a config, and the main window only
+ * gets one seconds after it opens. The main process is the one that knows — it
+ * hands the language over as a launch argument (so a cold start in French never
+ * flashes English) and broadcasts every change.
+ */
+
+function resolveLanguage(value: unknown): LanguageId {
+  return isValidLanguage(value) ? value : DEFAULT_LANGUAGE
+}
+
+let current: LanguageId = resolveLanguage(window.electronAPI?.language?.initial())
+const listeners = new Set<() => void>()
+
+/**
+ * Tell the user agent which language the document is in. Not decoration: `lang`
+ * drives spellcheck in every input, hyphenation, `:lang()` and the voice a screen
+ * reader picks. This is the language's counterpart to the theme's `applyTheme` —
+ * the one thing that has to reach the document, not just React.
+ */
+function applyDocumentLanguage(language: LanguageId): void {
+  document.documentElement.lang = language
+}
+
+// Subscribed here rather than inside initI18n(): a window that forgot the call
+// would silently stop following language changes, which is a bug you only meet
+// in the one window nobody tested.
+window.electronAPI?.language?.onChanged((language) => {
+  const applied = resolveLanguage(language)
+  if (applied === current) return
+  current = applied
+  applyDocumentLanguage(current)
+  for (const listener of listeners) listener()
+})
+
+/**
+ * Adopt the boot language before React renders. Call once per window entry point,
+ * at module scope: the shells ship `<html lang="en">`, so this is what makes a
+ * French window declare itself French, and an eager import is also what guarantees
+ * the subscription above is installed by the time the first change arrives (this
+ * module's only other consumers are components).
+ */
+export function initI18n(): void {
+  applyDocumentLanguage(current)
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function useLanguage(): LanguageId {
+  return useSyncExternalStore(subscribe, () => current)
+}
+
+/**
+ * The translate function for the active language. Its identity changes with the
+ * language, which is what makes every component holding it re-render on a
+ * switch — no reload, terminal chrome included.
+ */
+export function useT(): Translate {
+  const language = useLanguage()
+  return useCallback<Translate>((key, vars) => translate(key, language, vars), [language])
+}
+
+/**
+ * The BCP-47 tag for the active language. For the `Intl.*` and `toLocaleString`
+ * calls that must not freeze at the boot language — read it in the render path,
+ * never at module scope.
+ */
+export function useLocale(): string {
+  return localeOf(useLanguage())
+}

--- a/desktop/src/renderer/main.tsx
+++ b/desktop/src/renderer/main.tsx
@@ -2,11 +2,14 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from './App'
 import { initTheme } from './theme'
+import { initI18n } from './i18n'
 import { AppGate } from './components/AppGate'
 import './index.css'
 
-// Paint the stored theme before React renders anything.
+// Paint the stored theme and adopt the stored language before React renders
+// anything — both arrive as launch arguments, so the first frame is already right.
 initTheme()
+initI18n()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/desktop/src/renderer/pages/Config/LanguagePage.tsx
+++ b/desktop/src/renderer/pages/Config/LanguagePage.tsx
@@ -1,0 +1,68 @@
+import { ChevronDown, Languages } from 'lucide-react'
+import { useConfig } from '../../hooks/useConfig'
+import { showToast } from '../../components/Toast'
+import { SectionHeader } from './SectionHeader'
+import { useLanguage, useT } from '../../i18n'
+import { LANGUAGE_IDS, type LanguageId } from '../../../types'
+
+/**
+ * Autonyms — each language named in itself. Correct whichever language the app is
+ * showing, so this list needs no translation, and it is immune to the module-scope
+ * freeze that would pin a `t()` call here to the language the app booted in.
+ */
+const LANGUAGE_OPTIONS: Record<LanguageId, string> = {
+  en: 'English',
+  fr: 'Français',
+}
+
+/**
+ * Language & Region. Its own section rather than a row under Appearance: the
+ * choice is about who is reading, not about how the window looks, and it is the
+ * one setting users most often go looking for by name.
+ */
+export function LanguagePage() {
+  const { updateLanguage } = useConfig()
+  const active = useLanguage()
+  const t = useT()
+
+  const choose = async (id: LanguageId) => {
+    if (id === active) return
+    try {
+      await updateLanguage(id)
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : t('settings.language.error'), 'error')
+    }
+  }
+
+  return (
+    <div>
+      <SectionHeader icon={Languages} title={t('settings.language.section')} />
+      <div className="bg-surface border border-line-strong rounded-xl p-4">
+        <div className="flex items-center justify-between gap-6">
+          <div className="flex-1">
+            <div className="text-sm font-medium mb-0.5">{t('settings.language.label')}</div>
+            <p className="text-xs text-text-secondary/50">{t('settings.language.help')}</p>
+          </div>
+          <div className="relative shrink-0">
+            <select
+              value={active}
+              onChange={(e) => choose(e.target.value as LanguageId)}
+              className="w-52 px-3 py-2 bg-surface border border-line-field rounded-lg text-sm focus:outline-none focus:border-accent transition-colors appearance-none cursor-pointer"
+            >
+              {LANGUAGE_IDS.map((id) => (
+                <option key={id} value={id}>{LANGUAGE_OPTIONS[id]}</option>
+              ))}
+            </select>
+            <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary/50 pointer-events-none" />
+          </div>
+        </div>
+        {/* Spelled out because the two are constantly confused: this setting is
+            read by a person, the repository ones are written by Claude. */}
+        <p className="text-xs text-text-secondary/50 mt-4 leading-relaxed">
+          {t('settings.language.distinction')}
+        </p>
+      </div>
+      <p className="text-xs text-text-secondary/50 mt-3">{t('settings.language.followsAccount')}</p>
+    </div>
+  )
+}

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useMemo, useRef, Fragment } from 'react'
-import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, GitPullRequest, History, Gauge, User, Coins, BarChart3, Bell, LogOut, Building2, Check, Loader2, Lock, CircleUserRound, SquareTerminal, Palette, type LucideIcon } from 'lucide-react'
+import { Github, Plus, ChevronRight, Folder, Sparkles, FolderGit, Keyboard, Info, Columns, Clock, MonitorSmartphone, Search, ChevronDown, AlertTriangle, Shield, GitPullRequest, History, Gauge, User, Coins, BarChart3, Bell, LogOut, Building2, Check, Loader2, Lock, CircleUserRound, SquareTerminal, Palette, Languages, type LucideIcon } from 'lucide-react'
 import { AccountPage } from './AccountPage'
 import { RepoPage } from './RepoPage'
 import { OrgPage } from './OrgPage'
 import { AppearancePage } from './AppearancePage'
+import { LanguagePage } from './LanguagePage'
 import { SectionHeader } from './SectionHeader'
 import { RateLimitBar } from '../../components/agent-info-sidebar/LimitGauge'
 import { useStore } from '../../store'
@@ -14,6 +15,7 @@ import type { SpotlightShortcut, LaunchMode, ClaudeAccount, SpendSummary, Settin
 import { showToast } from '../../components/Toast'
 import { getProjectColorMap } from '../../utils/projectColors'
 import { formatUsd } from '../../utils/usageStats'
+import { useLocale, useT, type MessageKey } from '../../i18n'
 
 const SPOTLIGHT_OPTIONS: { label: string; value: string }[] = [
   { label: '\u2303 Space', value: 'Control+Space' },
@@ -37,22 +39,31 @@ const LAUNCH_MODE_OPTIONS: { value: LaunchMode; label: string; description: stri
 // Icons mirror each tab's own section header, so the rail and the content agree.
 // Claude Code is the exception: it holds four sections (account, launch mode,
 // rate usage, spend) and gets the CLI's own icon rather than any one of theirs.
-const SETTINGS_TABS: { id: SettingsTab; label: string; icon: LucideIcon }[] = [
-  { id: 'account', label: 'Account', icon: CircleUserRound },
-  { id: 'organization', label: 'Organization', icon: Building2 },
-  { id: 'repositories', label: 'Repositories', icon: FolderGit },
-  { id: 'claude-code', label: 'Claude Code', icon: SquareTerminal },
-  { id: 'appearance', label: 'Appearance', icon: Palette },
-  { id: 'features', label: 'Features', icon: Sparkles },
-  { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
-  { id: 'about', label: 'About', icon: Info },
+//
+// Message KEYS, not labels: this list is module scope, so a `t()` call here would
+// be evaluated once at import and pin the rail to whatever language the app
+// booted in. The labels are resolved in the render path instead.
+const SETTINGS_TABS: { id: SettingsTab; labelKey: MessageKey; icon: LucideIcon }[] = [
+  { id: 'account', labelKey: 'settings.tab.account', icon: CircleUserRound },
+  { id: 'organization', labelKey: 'settings.tab.organization', icon: Building2 },
+  { id: 'repositories', labelKey: 'settings.tab.repositories', icon: FolderGit },
+  { id: 'claude-code', labelKey: 'settings.tab.claudeCode', icon: SquareTerminal },
+  { id: 'appearance', labelKey: 'settings.tab.appearance', icon: Palette },
+  { id: 'language', labelKey: 'settings.tab.language', icon: Languages },
+  { id: 'features', labelKey: 'settings.tab.features', icon: Sparkles },
+  { id: 'shortcuts', labelKey: 'settings.tab.shortcuts', icon: Keyboard },
+  { id: 'about', labelKey: 'settings.tab.about', icon: Info },
 ]
 
-function formatTokensCompact(n: number): string {
-  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
-  return `${n}`
+// toFixed would pin the decimal separator to a point, so the mantissa goes
+// through toLocaleString: French wants "12,5M", not "12.5M".
+function formatTokensCompact(n: number, locale: string): string {
+  const scaled = (value: number, digits: number, unit: string) =>
+    `${value.toLocaleString(locale, { minimumFractionDigits: digits, maximumFractionDigits: digits })}${unit}`
+  if (n >= 1_000_000_000) return scaled(n / 1_000_000_000, 2, 'B')
+  if (n >= 1_000_000) return scaled(n / 1_000_000, 1, 'M')
+  if (n >= 1_000) return scaled(n / 1_000, 1, 'k')
+  return n.toLocaleString(locale)
 }
 
 // Human-readable label for a Claude seat tier / billing type.
@@ -169,6 +180,8 @@ function WelcomePage({ route }: { route: SettingsRoute }) {
   const { addRepository, updateSplitEnabled, updateSpotlight, updateLaunchMode } = useConfig()
   const orgs = useStore((s) => s.orgs)
   const activeOrg = useStore((s) => s.activeOrg)
+  const t = useT()
+  const locale = useLocale()
   // Deep-link support: another view can request a specific settings tab via the
   // store (e.g. the sidebar account menu → Organization). Initialise straight
   // from it so the requested tab paints on first render (no Profile → target
@@ -560,7 +573,7 @@ function WelcomePage({ route }: { route: SettingsRoute }) {
                 }`}
               >
                 <Icon className="w-4 h-4 shrink-0" />
-                <span className="truncate">{tab.label}</span>
+                <span className="truncate">{t(tab.labelKey)}</span>
               </button>
             )
           })}
@@ -795,8 +808,8 @@ function WelcomePage({ route }: { route: SettingsRoute }) {
                 ]).map(({ label, b }) => (
                   <Fragment key={label}>
                     <span className="text-text-secondary">{label}</span>
-                    <span className="font-mono text-right">{formatTokensCompact(b.tokens)}</span>
-                    <span className="font-mono text-right text-ink">~{formatUsd(b.costUsd)}</span>
+                    <span className="font-mono text-right">{formatTokensCompact(b.tokens, locale)}</span>
+                    <span className="font-mono text-right text-ink">~{formatUsd(b.costUsd, locale)}</span>
                   </Fragment>
                 ))}
               </div>
@@ -1120,6 +1133,9 @@ function WelcomePage({ route }: { route: SettingsRoute }) {
 
       {/* Appearance tab */}
       {contentTab === 'appearance' && <AppearancePage />}
+
+      {/* Language & Region tab */}
+      {contentTab === 'language' && <LanguagePage />}
 
       {/* Shortcuts tab */}
       {contentTab === 'shortcuts' && <div>

--- a/desktop/src/renderer/pages/Dashboard/index.tsx
+++ b/desktop/src/renderer/pages/Dashboard/index.tsx
@@ -6,6 +6,7 @@ import { useOrgUsageStats } from '../../hooks/useOrgUsageStats'
 import { useOrg } from '../../hooks/useOrg'
 import { ActivityHeatmap } from '../History/ActivityHeatmap'
 import { aggregateUsageTotals, aggregateUsageByMember, computeUsageHeatmap, formatUsd } from '../../utils/usageStats'
+import { useLocale } from '../../i18n'
 
 function formatDuration(ms: number): string {
   const totalMin = Math.round(ms / 60000)
@@ -35,6 +36,7 @@ function StatTile({ icon: Icon, label, value }: { icon: typeof Coins; label: str
 function UsageStatsSection() {
   const { rows, capped, loading } = useOrgUsageStats()
   const { members } = useOrg()
+  const locale = useLocale()
 
   const emailByOwner = useMemo(() => {
     const map = new Map<string, string>()
@@ -76,10 +78,10 @@ function UsageStatsSection() {
 
           {/* Summary tiles */}
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
-            <StatTile icon={Coins} label="Total cost" value={formatUsd(totals.costUsd)} />
-            <StatTile icon={Activity} label="Sessions" value={totals.sessions.toLocaleString('en-US')} />
-            <StatTile icon={Plus} label="Lines added" value={totals.linesAdded.toLocaleString('en-US')} />
-            <StatTile icon={Minus} label="Lines removed" value={totals.linesRemoved.toLocaleString('en-US')} />
+            <StatTile icon={Coins} label="Total cost" value={formatUsd(totals.costUsd, locale)} />
+            <StatTile icon={Activity} label="Sessions" value={totals.sessions.toLocaleString(locale)} />
+            <StatTile icon={Plus} label="Lines added" value={totals.linesAdded.toLocaleString(locale)} />
+            <StatTile icon={Minus} label="Lines removed" value={totals.linesRemoved.toLocaleString(locale)} />
             <StatTile icon={Clock} label="Total duration" value={formatDuration(totals.durationMs)} />
           </div>
 
@@ -98,7 +100,7 @@ function UsageStatsSection() {
                   <span className="text-xs text-text-secondary/60">
                     {m.sessions} {m.sessions === 1 ? 'session' : 'sessions'}
                   </span>
-                  <span className="text-ink/90 font-medium tabular-nums">{formatUsd(m.costUsd)}</span>
+                  <span className="text-ink/90 font-medium tabular-nums">{formatUsd(m.costUsd, locale)}</span>
                 </div>
               </div>
             ))}

--- a/desktop/src/renderer/pages/History/ActivityHeatmap.tsx
+++ b/desktop/src/renderer/pages/History/ActivityHeatmap.tsx
@@ -1,4 +1,5 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
+import { useLocale } from '../../i18n'
 
 interface ActivityHeatmapProps {
   heatmapData: Map<string, number>
@@ -12,13 +13,14 @@ const DAYS = 7
 const LABEL_WIDTH = 32
 const HEADER_HEIGHT = 16
 
-const DAY_LABELS: { row: number; label: string }[] = [
-  { row: 1, label: 'Mon' },
-  { row: 3, label: 'Wed' },
-  { row: 5, label: 'Fri' },
-]
+// Which grid rows carry a label — every other weekday, so they don't collide.
+// Row 0 is Monday. The NAMES are not here: they depend on the language, and this
+// is module scope, so anything derived here would freeze at the boot language.
+const DAY_LABEL_ROWS = [1, 3, 5]
 
-const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+// A week and a year to read names off. Any Monday-starting week and any year with
+// twelve months will do; 1 Jan 2024 happens to be a Monday.
+const REFERENCE_MONDAY = new Date(2024, 0, 1)
 
 const ACCENT = '#6366f1'
 const EMPTY_FILL = '#1c1c1f'
@@ -29,10 +31,6 @@ function getCellColor(count: number): string {
   if (count === 2) return `${ACCENT}4d` // ~0.3 opacity
   if (count <= 4) return `${ACCENT}8c` // ~0.55 opacity
   return `${ACCENT}d9` // ~0.85 opacity
-}
-
-function formatDateLabel(date: Date): string {
-  return date.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })
 }
 
 function toDateKey(date: Date): string {
@@ -48,6 +46,32 @@ interface TooltipState {
 
 export function ActivityHeatmap({ heatmapData }: ActivityHeatmapProps) {
   const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const locale = useLocale()
+
+  // Derived in the render path, not at module scope: a language switch must
+  // relabel the axes, and Intl gives the abbreviations the locale actually uses
+  // rather than a hand-written English list.
+  const dayLabels = useMemo(() => {
+    const format = new Intl.DateTimeFormat(locale, { weekday: 'short' })
+    return DAY_LABEL_ROWS.map((row) => {
+      const day = new Date(REFERENCE_MONDAY)
+      day.setDate(day.getDate() + row)
+      return { row, label: format.format(day) }
+    })
+  }, [locale])
+
+  const monthNames = useMemo(() => {
+    const format = new Intl.DateTimeFormat(locale, { month: 'short' })
+    return Array.from({ length: 12 }, (_, m) => format.format(new Date(2024, m, 1)))
+  }, [locale])
+
+  // Held rather than built per call: every one of the 364+ cells has its own
+  // mouseenter, and a `toLocaleDateString` there would resolve the locale and
+  // construct a formatter on each one.
+  const dateFormat = useMemo(
+    () => new Intl.DateTimeFormat(locale, { month: 'long', day: 'numeric' }),
+    [locale],
+  )
 
   // Build grid: right-aligned to today, spanning from the earliest entry
   const today = new Date()
@@ -80,7 +104,7 @@ export function ActivityHeatmap({ heatmapData }: ActivityHeatmapProps) {
     cellDate.setDate(cellDate.getDate() + w * 7)
     const month = cellDate.getMonth()
     if (month !== lastMonth) {
-      monthLabels.push({ week: w, label: MONTH_NAMES[month] })
+      monthLabels.push({ week: w, label: monthNames[month] })
       lastMonth = month
     }
   }
@@ -93,10 +117,10 @@ export function ActivityHeatmap({ heatmapData }: ActivityHeatmapProps) {
     setTooltip({
       x: rect.left + CELL_SIZE / 2,
       y: rect.top - 8,
-      date: formatDateLabel(date),
+      date: dateFormat.format(date),
       count,
     })
-  }, [])
+  }, [dateFormat])
 
   const handleMouseLeave = useCallback(() => {
     setTooltip(null)
@@ -124,7 +148,7 @@ export function ActivityHeatmap({ heatmapData }: ActivityHeatmapProps) {
           ))}
 
           {/* Day labels */}
-          {DAY_LABELS.map(({ row, label }) => (
+          {dayLabels.map(({ row, label }) => (
             <text
               key={`day-${row}`}
               x={0}

--- a/desktop/src/renderer/pages/History/index.tsx
+++ b/desktop/src/renderer/pages/History/index.tsx
@@ -4,6 +4,7 @@ import { useActivityHistory } from '../../hooks/useActivityHistory'
 import { useHistoryAnalytics } from '../../hooks/useHistoryAnalytics'
 import { ActivityHeatmap } from './ActivityHeatmap'
 import type { HistoryAction, HistoryEntry } from '../../../types'
+import { useLocale } from '../../i18n'
 
 const CARD_ANIM_MS = 150
 const CARD_STAGGER_MS = 50
@@ -23,9 +24,11 @@ const ACTION_CONFIG: Record<HistoryAction, { label: string; color: string; dot: 
   agent_closed: { label: 'Agent closed', color: 'bg-text-secondary', dot: 'bg-text-secondary' },
 }
 
-function formatTime(timestamp: number): string {
+// hour12 stays false in every language: this is a dense activity log, and a
+// 24-hour clock is what both locales read fastest here.
+function formatTime(timestamp: number, locale: string): string {
   const d = new Date(timestamp)
-  return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })
+  return d.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit', hour12: false })
 }
 
 function formatDuration(fromTs: number, toTs: number): string {
@@ -48,12 +51,13 @@ function RepoTag({ repo }: { repo: string }) {
 }
 
 function SingleEntryRow({ entry, isDimmed }: { entry: HistoryEntry; isDimmed: boolean }) {
+  const locale = useLocale()
   const config = ACTION_CONFIG[entry.action]
   return (
     <div className={`flex items-center gap-3 px-4 py-3 rounded-lg bg-surface-subtle border border-line-field transition-all duration-200 min-w-0 ${isDimmed ? 'opacity-30 blur-sm' : ''}`}>
       <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${config.dot}`} />
       <span className="text-xs text-text-secondary/60 font-mono flex-shrink-0">
-        {formatTime(entry.timestamp)}
+        {formatTime(entry.timestamp, locale)}
       </span>
       <span className="text-sm font-medium text-ink truncate min-w-0 flex-1">
         {entry.agentName}
@@ -75,6 +79,7 @@ function SingleEntryRow({ entry, isDimmed }: { entry: HistoryEntry; isDimmed: bo
 }
 
 export function HistoryPage() {
+  const locale = useLocale()
   const { entries, groups, loading } = useActivityHistory()
   const { heatmapData } = useHistoryAnalytics(entries)
   const hasEntries = groups.some(g => g.entries.length > 0)
@@ -221,8 +226,8 @@ export function HistoryPage() {
                 // entries are sorted newest-first; oldest = last element
                 const newestTs = tg.entries[0].timestamp
                 const oldestTs = tg.entries[tg.entries.length - 1].timestamp
-                const firstTime = formatTime(oldestTs)
-                const lastTime = formatTime(newestTs)
+                const firstTime = formatTime(oldestTs, locale)
+                const lastTime = formatTime(newestTs, locale)
                 const duration = formatDuration(oldestTs, newestTs)
 
                 return (
@@ -292,7 +297,7 @@ export function HistoryPage() {
                           >
                             <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${config.dot}`} />
                             <span className="text-xs text-text-secondary/60 font-mono flex-shrink-0">
-                              {formatTime(entry.timestamp)}
+                              {formatTime(entry.timestamp, locale)}
                             </span>
                             {entry.description && (
                               <span className="text-xs text-text-secondary/70 truncate min-w-0 flex-1">

--- a/desktop/src/renderer/pages/Skills/index.tsx
+++ b/desktop/src/renderer/pages/Skills/index.tsx
@@ -4,6 +4,7 @@ import { useSkills, type SkillInfo, type SkillDetail, type RepoSkillInfo } from 
 import { VSCodeIcon } from '../../components/agent-info-sidebar/icons'
 import { useTerminals } from '../../hooks/useTerminals'
 import { useStore } from '../../store'
+import { useLocale } from '../../i18n'
 
 const TOKEN_BUDGET = 4000
 const CHAR_BUDGET = 16000
@@ -11,13 +12,16 @@ const CHARS_PER_TOKEN = 4
 
 function BudgetBar({ label, value, max, unit, barColor }: { label: string; value: number; max: number; unit: string; barColor: string }) {
   const percentage = Math.min(Math.round((value / max) * 100), 100)
+  // A bare toLocaleString() follows the OS locale, which is not the language the
+  // app is showing — a French UI on an English machine would group with commas.
+  const locale = useLocale()
 
   return (
     <div className="flex-1 px-4 py-3 rounded-xl bg-surface-subtle border border-line-field">
       <div className="flex items-center justify-between mb-2">
         <span className="text-xs text-text-secondary/60">{label}</span>
         <span className="text-xs font-medium text-text-secondary">
-          {value.toLocaleString()} / {max.toLocaleString()} {unit}
+          {value.toLocaleString(locale)} / {max.toLocaleString(locale)} {unit}
         </span>
       </div>
       <div className="w-full h-2 rounded-full bg-surface overflow-hidden">

--- a/desktop/src/renderer/popover-main.tsx
+++ b/desktop/src/renderer/popover-main.tsx
@@ -2,10 +2,13 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { TrayPopover } from './pages/TrayPopover'
 import { initTheme } from './theme'
+import { initI18n } from './i18n'
 import './index.css'
 
-// Paint the stored theme before React renders anything.
+// Paint the stored theme and adopt the stored language before React renders
+// anything — both arrive as launch arguments, so the first frame is already right.
 initTheme()
+initI18n()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/desktop/src/renderer/quick-launch-main.tsx
+++ b/desktop/src/renderer/quick-launch-main.tsx
@@ -2,10 +2,13 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { QuickLaunch } from './pages/QuickLaunch'
 import { initTheme } from './theme'
+import { initI18n } from './i18n'
 import './index.css'
 
-// Paint the stored theme before React renders anything.
+// Paint the stored theme and adopt the stored language before React renders
+// anything — both arrive as launch arguments, so the first frame is already right.
 initTheme()
+initI18n()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/desktop/src/renderer/utils/usageStats.test.ts
+++ b/desktop/src/renderer/utils/usageStats.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { UsageStatRow } from '../../types'
-import { aggregateUsageTotals, aggregateUsageByMember, computeUsageHeatmap } from './usageStats'
+import { aggregateUsageTotals, aggregateUsageByMember, computeUsageHeatmap, formatUsd } from './usageStats'
 
 function row(overrides: Partial<UsageStatRow> = {}): UsageStatRow {
   return {
@@ -69,5 +69,24 @@ describe('computeUsageHeatmap', () => {
   it('skips rows with an unparseable timestamp', () => {
     const map = computeUsageHeatmap([row({ occurredAt: 'not-a-date' })])
     expect(map.size).toBe(0)
+  })
+})
+
+describe('formatUsd', () => {
+  it('collapses sub-cent amounts and shows cents otherwise', () => {
+    expect(formatUsd(0)).toBe('$0.00')
+    expect(formatUsd(0.004)).toBe('<$0.01')
+    expect(formatUsd(12.5)).toBe('$12.50')
+  })
+
+  it('groups thousands the way the active locale does', () => {
+    // Not cosmetic: a French reader reads "$12,500" as twelve dollars fifty.
+    // French uses a narrow no-break space (U+202F) as the group separator.
+    expect(formatUsd(12_500, 'en-US')).toBe('$12,500')
+    expect(formatUsd(12_500, 'fr-FR')).toBe('$12\u202f500')
+  })
+
+  it('defaults to en-US when no locale is passed', () => {
+    expect(formatUsd(12_500)).toBe('$12,500')
   })
 })

--- a/desktop/src/renderer/utils/usageStats.ts
+++ b/desktop/src/renderer/utils/usageStats.ts
@@ -1,9 +1,18 @@
-import type { UsageStatRow } from '../../types'
+import { localeOf } from '../../i18n'
+import { DEFAULT_LANGUAGE, type UsageStatRow } from '../../types'
 
-/** Format a USD amount for display: `<$0.01` under a cent, rounded thousands, else two decimals. */
-export function formatUsd(n: number): string {
+/**
+ * Format a USD amount for display: `<$0.01` under a cent, rounded thousands, else
+ * two decimals.
+ *
+ * The locale is a parameter rather than read from the language store because this
+ * is a plain function, not a component — a hook is impossible here. Callers pass
+ * `useLocale()`. It only affects the thousands grouping (a French reader expects
+ * `$12 500`, not `$12,500`); the `$` stays, since the amount genuinely is USD.
+ */
+export function formatUsd(n: number, locale: string = localeOf(DEFAULT_LANGUAGE)): string {
   if (n > 0 && n < 0.01) return '<$0.01'
-  if (n >= 1000) return `$${Math.round(n).toLocaleString('en-US')}`
+  if (n >= 1000) return `$${Math.round(n).toLocaleString(locale)}`
   return `$${n.toFixed(2)}`
 }
 

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -220,6 +220,37 @@ export function isValidTheme(value: unknown): value is ThemeId {
 }
 
 /**
+ * Languages the interface is available in, in the order the picker shows them.
+ * Adding one is an entry here plus its catalogue in src/i18n — the catalogue is
+ * typed against the English one, so TypeScript refuses a language whose
+ * translation is incomplete.
+ *
+ * This is the APPLICATION locale only. It has nothing to do with the per-repo
+ * `languages.{commit,pullRequest,…}` settings (which language Claude writes a
+ * commit message in) nor with profile.md's `languages`.
+ */
+export const LANGUAGE_IDS = ['en', 'fr'] as const
+
+export type LanguageId = (typeof LANGUAGE_IDS)[number]
+
+export const DEFAULT_LANGUAGE: LanguageId = 'en'
+
+/**
+ * The BCP-47 tag each language formats dates and numbers with. It lives here,
+ * next to the ids, because the main process needs it too — notifications are
+ * composed before any renderer exists. Typed as a total record, so a new
+ * language cannot be added without giving it a locale.
+ */
+export const LANGUAGE_LOCALE: Record<LanguageId, string> = {
+  en: 'en-US',
+  fr: 'fr-FR',
+}
+
+export function isValidLanguage(value: unknown): value is LanguageId {
+  return typeof value === 'string' && (LANGUAGE_IDS as readonly string[]).includes(value)
+}
+
+/**
  * Interface scale, as an Electron zoom factor. The steps are what the +/−
  * buttons and ⌘+ / ⌘− walk through; any value in range is accepted, since the
  * OS and the menu can land on one of their own.
@@ -252,6 +283,10 @@ export interface Config {
    * account onto a laptop with a different screen.
    */
   theme?: ThemeId
+  /** Absent = never chosen; the app applies DEFAULT_LANGUAGE. Like the theme, it
+   *  follows the account rather than the machine — reading the app in French is
+   *  a property of the person, not of the screen. */
+  language?: LanguageId
   splitEnabled?: boolean
   splitActive?: boolean
   autoStartAtLogin?: boolean
@@ -316,6 +351,7 @@ export type SettingsTab =
   | 'repositories'
   | 'claude-code'
   | 'appearance'
+  | 'language'
   | 'features'
   | 'shortcuts'
   | 'about'

--- a/supabase/migrations/20260726110000_user_settings_language.sql
+++ b/supabase/migrations/20260726110000_user_settings_language.sql
@@ -1,0 +1,30 @@
+-- Migration: user_settings.language
+--
+-- The desktop app's interface can now be English or French. The choice joins the
+-- other application-level preferences in user_settings so it follows the user
+-- from machine to machine rather than being a property of one install. NULL keeps
+-- its established meaning here: the user never chose, and the app applies its own
+-- default (en).
+--
+-- Note this is the INTERFACE language only. The per-repository `languages`
+-- settings (which language Claude writes a commit message or a PR in) live on
+-- the repositories table and are unrelated.
+--
+-- The CHECK is a shape, not a list — same reasoning as theme above it. Mirroring
+-- the enum the way launch_mode does would mean a migration for every language
+-- ever added, and a client running an older build already has to cope with a
+-- value it doesn't recognise (it re-validates on read and falls back to English).
+
+alter table public.user_settings
+  add column if not exists language text;
+
+alter table public.user_settings
+  drop constraint if exists user_settings_language_check;
+
+alter table public.user_settings
+  add constraint user_settings_language_check check (
+    language is null or language ~ '^[a-z]{2}$'
+  );
+
+comment on column public.user_settings.language is
+  'Chosen interface language (e.g. en, fr). NULL = never chosen; the app defaults.';


### PR DESCRIPTION
## Description

The desktop app was entirely hardcoded in English while the skills, the docs and most of the user base are bilingual. This adds an application language setting (English / French) with its own `Language & Region` settings section.

The change follows the theme pipeline as its template: constant + validator in `src/types.ts`, a local mirror in `appearance.json` read before the first window exists, a launch argument, IPC, a cloud column, and a `useConfig` hook. The message catalogue lives in `src/i18n/` and is deliberately environment-free (no `electron`, no `fs`, no `window`) so both the main process and the renderer can use it — and so it can be tested in a plain node environment. No i18n library: two locales, no lazy loading, and `Record<keyof typeof en, string>` gives key parity for free at compile time.

This PR delivers the infrastructure, every main-process string, the UI section, locale-aware formatting and the tests. The extraction of the ~500 remaining renderer strings is deferred to follow-up PRs, one batch per PR, as the issue prescribes.

## Related Issue

Closes #148

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **Types** (`src/types.ts`): `LANGUAGE_IDS`, `LanguageId`, `DEFAULT_LANGUAGE`, `isValidLanguage()`, and `LANGUAGE_LOCALE` as a total record (`en → en-US`, `fr → fr-FR`) so adding an id without a BCP-47 tag fails typecheck. Plus `Config.language?` and a `language` entry in `SettingsTab`.
- **Local mirror** (`main/appearance.ts`): the language is persisted in `appearance.json` alongside theme and zoom, re-validated on read, and exposed through `--magic-language=` in `appearanceArguments()` so all three windows inherit it at creation — no flash of English on a cold launch. `applyLanguage()` broadcasts only on change; `onLanguageChanged()` is backed by a local listener Set so `appearance.ts` imports neither the menu nor the tray.
- **Menu and tray rebuild**: unlike the theme, menu labels do not repaint. `applyLanguage()` therefore re-runs `createMenu()` and rebuilds the tray, on both the UI path and cloud hydration.
- **i18n modules**: `src/i18n/{index,en,fr}.ts` (pure, 66 keys), `main/i18n.ts` (language-bound wrapper for the main process), `renderer/i18n/index.ts` (a module-scope store shaped exactly like `hooks/useZoom.ts`, with `useLanguage`/`useT`/`useLocale`). `initI18n()` is called in all three renderer entry points and also sets `document.documentElement.lang`, so spellcheck, hyphenation and screen readers follow the UI.
- **IPC and cloud**: `config:updateLanguage` handler, `configApi.updateLanguage` + `languageApi` in the preload bridge, `user_settings.language` through `UserSettingsRow` / `USER_SETTINGS_COLUMNS` / `SETTINGS_KEYS` / `configToSettingsRow` / `applySettingsRow` (re-validated on read), and `applyLanguage()` in both `ensureHydrated()` and `rehydrate()`. New migration with a *shape* CHECK (`~ '^[a-z]{2}$'`), matching the reasoning documented in the theme migration.
- **Main-process strings**: 8 menu labels, 15 tray labels, all 4 notification sites and 5 native dialog strings now go through `t()`. The daily digest gets one catalogue entry per plural form plus translatable list separators, instead of an English `"s"` suffix and a hardcoded `" and "`.
- **New `Language & Region` section** (`pages/Config/LanguagePage.tsx`): a two-value picker using autonyms ("English" / "Français"), with copy stating explicitly that this is the interface language, distinct from the per-repo skill languages and from `profile.md`.
- **Locale-aware formatting**: the 7 hardcoded `'en-US'` locales are gone; `formatUsd` and `formatTokensCompact` take a locale; the heatmap's day and month names are derived through `Intl` in the render path rather than frozen at module scope; `Dashboard`, `History` and `Skills` follow the active locale.
- **Tests**: `src/i18n/i18n.test.ts` covers catalogue parity, placeholder parity, interpolation and fallbacks, the validator, `LANGUAGE_LOCALE` resolvability through `Intl`, and a filesystem-walking guard against re-introducing a hardcoded `'en-US'`. `CloudStore.test.ts` and `usageStats.test.ts` gain the corresponding cases.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

`npm run lint` → 0 errors (3 pre-existing warnings in `RepoPage.tsx`, untouched here). `npm test` → 354 tests across 30 files. `cd desktop && npm run typecheck` → clean. The app itself has not been launched — the scenarios below are for the reviewer.

### Test Steps

1. Run `npm run desktop`, then go to **Settings → Language & Region** and switch to "Français". The window, the settings pages and the terminal chrome must switch immediately, **with no reload**.
2. Open the **application menu** and the **tray menu**. Custom labels (File, Edit, View, Window, Actual Size, Zoom In/Out, Show Window, Settings, Changelog, Documentation, GitHub, Quit) must be in French. Electron `role:` items (Undo, Copy, Minimize, About…) stay in the OS language — see Additional Notes.
3. Quit the app completely and relaunch it. The first painted frame must already be French — no flash of English. The value comes from `~/.config/magic-slash/appearance.json`, which is read before the first window is created.
4. Open **Dashboard** and **History**. Dates ("Aujourd'hui — 26 juillet 2026"), the heatmap's day and month labels, and amounts (`12 500 $` with a narrow no-break space) must all follow the locale. Token counts must read `12,5M`, not `12.5M`.
5. Sign out and back in, or inspect `user_settings.language` directly: the choice must follow the account. A row with no language falls back to `en`.
6. Delete any key from `desktop/src/i18n/fr.ts` and run `cd desktop && npm run typecheck`. It must fail with TS2741 — that is the compile-time guarantee that French can never silently drift from English.

## Screenshots

Not attached — the visible change is a new settings section and a language switch, both covered by steps 1 and 2 above.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [x] I have updated CHANGELOG.md (if applicable)

Documentation is left unchecked on purpose: `docs/` has no settings reference page yet, so there is nothing to update for this section. Worth a `/magic:audit` pass once the renderer extraction batches land.

## Additional Notes

Things a reviewer should know:

- **Electron `role:` menu items and native dialog buttons follow `app.getLocale()`**, i.e. the OS, not this setting. On an English macOS with the app set to French, the menu will be part French, part English. This is intentional (documented in `fr.ts`) — overriding it would mean hand-translating what the OS already localizes correctly.
- **`language` was deliberately not added to `install/config-schema.json`**, which has `additionalProperties: false`. `theme` has the same omission, so adding `language` alone would be inconsistent. It is inert today (nothing consumes `config:validationErrors`), but the schema is drifting from `Config` with each of these PRs and deserves its own cleanup.
- **`applyTheme` in `hydrate.ts` is called unconditionally**, so a hydration returning a config with no theme resets the local mirror to the default. The same bug existed for the language and was fixed in `4d3632b` (hydration now only adopts a language the cloud actually carries); `theme` was left alone because its column predates this PR and changing its behaviour here would be out of scope. Worth its own fix.
- **The hydration path has no regression test**: `hydrate.ts` imports `../appearance`, which pulls in `electron`, and the suite runs in a plain node environment with no electron installed at the repo root. Testing it means mocking `../appearance`.
- **Renderer translation coverage is intentionally uneven** at this stage: `History`'s `ACTION_CONFIG` labels and one inline plural in `Dashboard` are still English. They belong to the deferred extraction batches, not to this PR.

The open question from the issue — whether the UI locale should become the default for `languages.discussion` — was settled as **no**. The two stay independent; only the new section's copy clarifies the distinction.
