### PR TITLE
[#153] Platform admin role + read-only back-office

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -95,6 +95,23 @@ User-scoped tables (own-rows-only RLS, independent of any org):
 | `user_settings`     | App preferences: Settings → Features, launch mode, Atlassian flag. |
 | `app_installations` | One row per (user, device): the app version that device runs.      |
 
+Neither org-scoped nor own-rows — a category of one:
+
+| Table              | Purpose                                                             |
+| ------------------ | ------------------------------------------------------------------- |
+| `platform_admins`  | Who operates the product. **Deny-all**: unreachable from the API.   |
+
+`platform_admins` is the only table with RLS enabled and **no policy at all**, on
+top of `revoke all … from anon, authenticated`. Both layers are deliberate: the
+revoke is what actually holds (Supabase grants `all` on new `public` tables to
+both roles by default, so RLS alone would leave `authenticated` holding `INSERT`),
+and the missing policy means adding one back cannot re-open it. Consequence,
+accepted rather than worked around: the **first platform admin cannot be created
+from within the application** — a human inserts the row from the Supabase
+dashboard, which runs as the table owner. There is no bootstrap RPC, because a
+self-service one is a "first caller becomes admin" hole. The identity is usable
+only through the read-only `admin_*` functions listed under Security model below.
+
 `user_settings` deliberately holds one **nullable** column per option. NULL means
 "the user never chose", which the desktop app distinguishes from `false` — e.g.
 history and the sidebar usage card are both ON when unset, while
@@ -120,8 +137,14 @@ the app is not running at all: there is no local listener to receive the call.
 `app_installations` is upserted by the desktop app on every launch (from the
 connectivity gate, once authed), so the version is refreshed at each start and
 after every auto-update. `app_version_updated_at` is trigger-maintained and moves
-only on a genuine version change. Fleet-wide "who runs which version" reporting
-goes through the service role, since RLS keeps each row private to its user.
+only on a genuine version change. RLS keeps each row private to its user, so
+fleet-wide "who runs which version" reporting goes through
+`admin_list_installations(uuid)` — a `SECURITY DEFINER` function gated on
+`is_platform_admin()` that returns an explicit column allowlist. No service-role
+key, and no widening of this table's policies. (The `--` comments inside
+`20260725100000_user_settings.sql` still say "service role": they predate
+`platform_admins` and are left as written, since a migration records the state of
+the world when it ran.)
 
 ## Security model
 
@@ -129,7 +152,21 @@ goes through the service role, since RLS keeps each row private to its user.
   isolation keyed on `org_id`: a user only ever sees rows for orgs they are a
   member of. User-scoped tables (`repository_paths`, `profiles`, `user_settings`,
   `app_installations`) are own-rows-only on every verb — not even org admins get
-  a read path.
+  a read path. The single exception is a **platform admin** (a row in
+  `platform_admins`), and it is not an exception in the policies: no policy was
+  widened and none contains `or is_platform_admin()`. Access is instead six
+  read-only `SECURITY DEFINER` functions — `admin_list_users()`,
+  `admin_list_installations(uuid)`, `admin_get_user(uuid)`,
+  `admin_list_user_orgs(uuid)`, `admin_list_user_agents(uuid)`,
+  `admin_list_user_repositories(uuid)` — each of which raises unless
+  `is_platform_admin()`, and each of whose `returns table` **is** the column
+  allowlist. `profiles.free_text`, `technical_level`, `communication_style` and
+  `languages` are returned by none of them. The reason for functions rather than a
+  wider policy: a policy grants every column of a table forever, including ones
+  added later, whereas an allowlist has to be edited — and shows up in the diff —
+  to grow. There are no admin writes, no impersonation and no audit log; the whole
+  surface is `select`-shaped, which is what makes the missing audit log
+  acceptable.
 - Membership checks go through `is_org_member(uuid)` / `is_org_admin(uuid)`,
   `SECURITY DEFINER` functions with a locked `search_path`. This avoids RLS
   recursion on `memberships` and is the single source of truth for access.

--- a/supabase/migrations/20260728090000_platform_admins.sql
+++ b/supabase/migrations/20260728090000_platform_admins.sql
@@ -1,0 +1,565 @@
+-- Migration: platform admins + read-only back-office RPCs (issue #153)
+--
+-- WHY a second kind of admin
+-- -----------------------------------------------------------------------------
+-- `membership_role = 'admin'` is an ORG role: it says "this person administers
+-- this tenant". Nothing in the schema until now describes the people who operate
+-- the PRODUCT itself and need to answer questions no tenant can — "which app
+-- version is the fleet on?", "did this user's device ever take the update?",
+-- "what does their settings row actually contain?". Support work has been done
+-- with the service_role key against the dashboard, which is unreviewable and
+-- all-powerful.
+--
+-- This migration introduces that identity as data (`platform_admins`) and gives
+-- it a NARROW, read-only surface: six `SECURITY DEFINER` functions, each with an
+-- explicit column allowlist in its `returns table`.
+--
+-- WHY NOT widen RLS
+-- -----------------------------------------------------------------------------
+-- The obvious shortcut — appending `or public.is_platform_admin()` to the
+-- `profiles` / `user_settings` / `app_installations` SELECT policies — is
+-- deliberately NOT taken. It would:
+--   * turn "own-rows-only" into a claim that is no longer true anywhere in the
+--     codebase, so every future reader of those policies has to re-derive who can
+--     actually see a row;
+--   * expose EVERY column of those tables forever, including `profiles.free_text`
+--     (free-form prose the user wrote about themselves) and anything added later,
+--     with no review step;
+--   * apply to writes the moment someone copies the pattern to a write policy.
+-- An RPC's `returns table` is the allowlist, and it is visible in the diff. Not a
+-- single existing policy is modified here. `profiles.free_text`,
+-- `technical_level`, `communication_style` and `languages` are returned by NO
+-- function below.
+--
+-- OUT OF SCOPE, on purpose: writes, an audit log of admin reads, product
+-- analytics, and impersonation. Everything here is `select`-shaped.
+
+-- ---------------------------------------------------------------------------
+-- platform_admins: who operates the product
+-- ---------------------------------------------------------------------------
+-- One row per platform admin. Membership in this table is the whole identity —
+-- there is no role column, because a second tier would need its own allowlist and
+-- there is exactly one tier today.
+create table if not exists public.platform_admins (
+  user_id uuid primary key references auth.users (id) on delete cascade,
+  created_at timestamptz not null default now()
+);
+
+-- No index: the primary key already serves the only lookup this table ever gets
+-- (`user_id = auth.uid()`, in is_platform_admin below).
+
+alter table public.platform_admins enable row level security;
+
+-- DENY-ALL, in two independent layers, and the revoke is the load-bearing one.
+-- Supabase's default privileges grant `all` on every new table in `public` to
+-- `anon` and `authenticated`, so a table with RLS enabled and no policy would
+-- still be a table the roles hold INSERT on — and "no policy" is a state a future
+-- migration could accidentally end. Revoking the privileges outright means the
+-- answer to "can authenticated grant itself platform admin?" is no at the GRANT
+-- layer, which is checked before RLS and cannot be re-opened by adding a policy.
+--
+-- Consequence, accepted rather than worked around: the FIRST platform admin
+-- cannot be created from within the application. There is no bootstrap RPC and no
+-- self-service path — a human inserts the row from the Supabase dashboard (which
+-- runs as the table owner and bypasses both layers). A bootstrap path is exactly
+-- the kind of "first caller wins" hole this table exists to avoid.
+revoke all on public.platform_admins from anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- is_platform_admin: the single gate every admin_* function calls
+-- ---------------------------------------------------------------------------
+-- SECURITY DEFINER because `authenticated` holds no privilege on
+-- `platform_admins` (see the revoke above) and must not: the role can ask the
+-- question without being able to read, let alone write, the answer. Same shape as
+-- is_org_member / is_org_admin — `language sql`, stable, locked search_path — so
+-- it is inlinable and cheap enough to call per statement.
+create or replace function public.is_platform_admin()
+returns boolean
+language sql
+security definer
+set search_path = public, pg_temp
+stable
+as $$
+  select exists (
+    select 1
+    from public.platform_admins pa
+    where pa.user_id = auth.uid()
+  );
+$$;
+
+-- Every function below revokes from `public, anon` rather than from `public`
+-- alone, which is one word more than the rest of this repo does. The reason:
+-- Supabase ships `alter default privileges in schema public grant all on
+-- functions to anon, authenticated, …`, so a new function in `public` arrives
+-- with an EXPLICIT execute grant to `anon` — and revoking from PUBLIC does not
+-- remove an explicit grant. The auth.uid() guard inside each function already
+-- refuses an anonymous caller, so this is defense in depth rather than a fix for
+-- a hole; on the crown-jewel function of this feature it is worth the word.
+revoke execute on function public.is_platform_admin() from public, anon;
+grant execute on function public.is_platform_admin() to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- admin_list_users: every user, with the app version resolved per user
+-- ---------------------------------------------------------------------------
+-- The fleet list. The driving relation is `auth.users` — NOT profiles, NOT
+-- user_settings, NOT app_installations. Driving off any of those would silently
+-- omit every user who never wrote that row: someone who signed up and never
+-- opened the profile wizard has no `profiles` row, someone who never touched a
+-- toggle has no `user_settings` row, and someone who never launched the desktop
+-- app has no `app_installations` row. A back-office that shows "most" users is
+-- worse than none, because nothing on screen says which ones are missing. Hence
+-- `auth.users` plus LEFT JOINs, and `coalesce(..., 0)` on every count.
+--
+-- The per-user aggregates are `left join lateral` rather than a group-by over a
+-- five-way join, so no count is inflated by another join's fan-out.
+--
+-- Soft-deleted users (`auth.users.deleted_at`) are excluded: they are gone from
+-- the product's point of view, and their rows cascade away on a real delete.
+--
+-- Columns are an allowlist. `profiles.name` and `profiles.role` are here because
+-- they identify the human in a support conversation; `free_text`,
+-- `technical_level`, `communication_style` and `languages` are not, and are not
+-- returned.
+create or replace function public.admin_list_users()
+returns table (
+  user_id             uuid,
+  email               text,
+  created_at          timestamptz,
+  last_sign_in_at     timestamptz,
+  name                text,
+  role                text,
+  device_count        bigint,
+  latest_app_version  text,
+  latest_last_seen_at timestamptz,
+  org_count           bigint,
+  agent_count         bigint,
+  active_agent_count  bigint
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'admin_list_users requires an authenticated user';
+  end if;
+
+  if not public.is_platform_admin() then
+    raise exception 'not a platform admin';
+  end if;
+
+  return query
+    select
+      u.id,
+      u.email::text,
+      u.created_at,
+      u.last_sign_in_at,
+      p.name,
+      p.role,
+      coalesce(dev.n_devices, 0),
+      latest.app_version,
+      latest.last_seen_at,
+      coalesce(orgs.n_orgs, 0),
+      coalesce(ag.n_agents, 0),
+      coalesce(ag.n_active_agents, 0)
+    from auth.users u
+    left join public.profiles p on p.user_id = u.id
+    left join lateral (
+      select count(*) as n_devices
+      from public.app_installations i
+      where i.user_id = u.id
+    ) dev on true
+    -- The version a user "runs" is the one on the device they used most
+    -- recently. A user with two machines on two versions is a real state, which
+    -- admin_list_installations reports per device; this column is the headline.
+    left join lateral (
+      select i.app_version, i.last_seen_at
+      from public.app_installations i
+      where i.user_id = u.id
+      order by i.last_seen_at desc
+      limit 1
+    ) latest on true
+    -- Counts every membership, archived orgs included: the back-office reports
+    -- what exists, not what the user can currently see. admin_list_user_orgs
+    -- returns archived_at so the drill-down can tell the two apart.
+    left join lateral (
+      select count(*) as n_orgs
+      from public.memberships m
+      where m.user_id = u.id
+    ) orgs on true
+    left join lateral (
+      select count(*) as n_agents,
+             count(*) filter (where a.archived_at is null) as n_active_agents
+      from public.agents a
+      where a.owner_id = u.id
+    ) ag on true
+    where u.deleted_at is null
+    order by u.created_at asc;
+end;
+$$;
+
+revoke execute on function public.admin_list_users() from public, anon;
+grant execute on function public.admin_list_users() to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- admin_list_installations: one row per DEVICE, whole fleet or one user
+-- ---------------------------------------------------------------------------
+-- `app_installations` is keyed (user, device), and every question the back-office
+-- asks about versions is a question about devices, not users: the version
+-- histogram, "who is still on an old build", the platform/arch breakdown, and
+-- "which machines have gone quiet" (`last_seen_at`) are all rollups of THIS
+-- result set, computed in the client from one round trip.
+--
+-- `p_user_id` null means the whole fleet; set, it scopes to one user and serves
+-- the drill-down's device list. One function rather than two because the row
+-- shape is identical — a second function would be the same allowlist maintained
+-- twice.
+--
+-- `device_name` is the machine's hostname, which own-rows RLS otherwise keeps
+-- private to its user. It is in the allowlist because "which of their three Macs
+-- is on the old version" is unanswerable without it.
+create or replace function public.admin_list_installations(p_user_id uuid default null)
+returns table (
+  user_id                uuid,
+  email                  text,
+  device_id              text,
+  device_name            text,
+  app_version            text,
+  platform               text,
+  arch                   text,
+  last_seen_at           timestamptz,
+  app_version_updated_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'admin_list_installations requires an authenticated user';
+  end if;
+
+  if not public.is_platform_admin() then
+    raise exception 'not a platform admin';
+  end if;
+
+  return query
+    select
+      i.user_id,
+      u.email::text,
+      i.device_id,
+      i.device_name,
+      i.app_version,
+      i.platform,
+      i.arch,
+      i.last_seen_at,
+      i.app_version_updated_at
+    from public.app_installations i
+    join auth.users u on u.id = i.user_id
+    where u.deleted_at is null
+      and (p_user_id is null or i.user_id = p_user_id)
+    order by i.last_seen_at desc;
+end;
+$$;
+
+revoke execute on function public.admin_list_installations(uuid) from public, anon;
+grant execute on function public.admin_list_installations(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- admin_get_user: one user's identity + their full settings row
+-- ---------------------------------------------------------------------------
+-- The drill-down header. Returns at most one row, and none at all for an unknown
+-- or soft-deleted id — the caller renders "not found" rather than an empty shell.
+--
+-- The 17 `user_settings` columns are listed one by one, which is the point: the
+-- allowlist is the signature. When a column is added to `user_settings`, showing
+-- it in the back-office is a deliberate edit here, not an automatic consequence.
+-- `history_enabled` is absent because 20260727170000 dropped it.
+--
+-- From `profiles`, ONLY `name` and `role`. Excluded, each on purpose:
+--   * `free_text`            — free-form prose the user wrote about themselves.
+--   * `technical_level`      — outside the ticket's allowlist.
+--   * `communication_style`  — outside the ticket's allowlist.
+--   * `languages`            — outside the ticket's allowlist too. It is the
+--     tamest of the four and would have been easy to wave through, which is
+--     exactly why it is named here: the allowlist is the ticket's, not the
+--     author's judgement of what seems harmless.
+-- Nothing here reads `configs.data`: it is an opaque per-org blob whose keys are
+-- not enumerable, so it cannot be allowlisted.
+create or replace function public.admin_get_user(p_user_id uuid)
+returns table (
+  user_id                       uuid,
+  email                         text,
+  created_at                    timestamptz,
+  last_sign_in_at               timestamptz,
+  name                          text,
+  role                          text,
+  usage_card_enabled            boolean,
+  usage_card_minimized          boolean,
+  usage_logs_enabled            boolean,
+  daily_digest_enabled          boolean,
+  split_enabled                 boolean,
+  split_active                  boolean,
+  pr_reviews_enabled            boolean,
+  pr_reviews_poll_interval_ms   integer,
+  pr_reviews_auto_launch_skills boolean,
+  spotlight_enabled             boolean,
+  spotlight_shortcut            text,
+  auto_start_at_login           boolean,
+  launch_mode                   text,
+  atlassian_integration_enabled boolean,
+  theme                         text,
+  language                      text,
+  sync_claude_theme             boolean
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'admin_get_user requires an authenticated user';
+  end if;
+
+  if not public.is_platform_admin() then
+    raise exception 'not a platform admin';
+  end if;
+
+  return query
+    select
+      u.id,
+      u.email::text,
+      u.created_at,
+      u.last_sign_in_at,
+      p.name,
+      p.role,
+      s.usage_card_enabled,
+      s.usage_card_minimized,
+      s.usage_logs_enabled,
+      s.daily_digest_enabled,
+      s.split_enabled,
+      s.split_active,
+      s.pr_reviews_enabled,
+      s.pr_reviews_poll_interval_ms,
+      s.pr_reviews_auto_launch_skills,
+      s.spotlight_enabled,
+      s.spotlight_shortcut,
+      s.auto_start_at_login,
+      s.launch_mode,
+      s.atlassian_integration_enabled,
+      s.theme,
+      s.language,
+      s.sync_claude_theme
+    from auth.users u
+    left join public.profiles p on p.user_id = u.id
+    left join public.user_settings s on s.user_id = u.id
+    where u.id = p_user_id
+      and u.deleted_at is null;
+end;
+$$;
+
+revoke execute on function public.admin_get_user(uuid) from public, anon;
+grant execute on function public.admin_get_user(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- admin_list_user_orgs: which tenants a user belongs to, and as what
+-- ---------------------------------------------------------------------------
+-- Archived orgs are INCLUDED, with `archived_at` exposed so the drill-down can
+-- render them as such. The is_org_member helper filters archived orgs out of
+-- every tenant read path (20260723120000), which is right for members and wrong
+-- here: "their org was archived last month" is precisely the answer a support
+-- question needs, and hiding it would make the org count in admin_list_users
+-- disagree with this list.
+create or replace function public.admin_list_user_orgs(p_user_id uuid)
+returns table (
+  org_id      uuid,
+  name        text,
+  role        public.membership_role,
+  archived_at timestamptz,
+  created_at  timestamptz
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'admin_list_user_orgs requires an authenticated user';
+  end if;
+
+  if not public.is_platform_admin() then
+    raise exception 'not a platform admin';
+  end if;
+
+  return query
+    select m.org_id, o.name, m.role, o.archived_at, m.created_at
+    from public.memberships m
+    join public.organizations o on o.id = m.org_id
+    where m.user_id = p_user_id
+    order by m.created_at asc;
+end;
+$$;
+
+revoke execute on function public.admin_list_user_orgs(uuid) from public, anon;
+grant execute on function public.admin_list_user_orgs(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- admin_list_user_agents: the user's agents, archived ones included
+-- ---------------------------------------------------------------------------
+-- Filtered on `owner_id`, not on org: an agent belongs to its owner, and its
+-- `org_id` is DERIVED from the repositories it works on (20260727160000), so it
+-- is null for an agent on personal repos only. Filtering by org would drop those.
+--
+-- Archived agents are included — closing an agent soft-deletes it
+-- (20260727140000) and "they closed it three weeks ago" is an answer, not noise.
+-- `repo_names` is aggregated from agent_repositories rather than read from
+-- `agents.repositories`, which holds absolute filesystem PATHS on the owner's
+-- machine and is meaningless to anyone else. The paths themselves are not
+-- returned: they are local layout, not product state.
+create or replace function public.admin_list_user_agents(p_user_id uuid)
+returns table (
+  id          uuid,
+  name        text,
+  ticket_id   text,
+  status      text,
+  branch_name text,
+  base_branch text,
+  org_id      uuid,
+  shared      boolean,
+  archived_at timestamptz,
+  created_at  timestamptz,
+  repo_names  text[]
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'admin_list_user_agents requires an authenticated user';
+  end if;
+
+  if not public.is_platform_admin() then
+    raise exception 'not a platform admin';
+  end if;
+
+  return query
+    select
+      a.id,
+      a.name,
+      a.ticket_id,
+      a.status,
+      a.branch_name,
+      a.base_branch,
+      a.org_id,
+      a.shared,
+      a.archived_at,
+      a.created_at,
+      coalesce(linked.repo_names, '{}'::text[])
+    from public.agents a
+    left join lateral (
+      select array_agg(r.name order by r.name) as repo_names
+      from public.agent_repositories ar
+      join public.repositories r on r.id = ar.repo_id
+      where ar.agent_id = a.id
+    ) linked on true
+    where a.owner_id = p_user_id
+    order by a.created_at desc;
+end;
+$$;
+
+revoke execute on function public.admin_list_user_agents(uuid) from public, anon;
+grant execute on function public.admin_list_user_agents(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- admin_list_user_repositories: the repos a user can reach, personal and team
+-- ---------------------------------------------------------------------------
+-- Two sources in one list, because "which repositories does this person work
+-- with" has one answer and the split is an implementation detail of ownership:
+--   * personal repos they own (`owner_id = p_user_id`, `org_id` null), and
+--   * team repos of every org they are a member of — which they did not create
+--     but do see.
+-- This is deliberately NOT identical to what the repositories SELECT policy
+-- grants them: that policy gates on `is_org_member(org_id)`, which excludes
+-- archived orgs, whereas this RPC reads `memberships` raw and so also returns
+-- repos of orgs since archived. Consistent with the archived-included choice on
+-- `admin_list_user_agents` — a back-office that hid archived history would be
+-- lying about what the account has.
+-- `org_name` is joined in so the two are distinguishable on screen without a
+-- second lookup; a null org_id renders as personal.
+--
+-- `repository_paths` is NOT joined: a path is a per-machine local binding, and
+-- knowing where on someone's disk a checkout lives answers no product question.
+-- `keywords` is included because it is what routes an agent to a repo, so an
+-- empty list explains a support report of "it never picks the right repo".
+create or replace function public.admin_list_user_repositories(p_user_id uuid)
+returns table (
+  id         uuid,
+  name       text,
+  org_id     uuid,
+  org_name   text,
+  keywords   text[],
+  created_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'admin_list_user_repositories requires an authenticated user';
+  end if;
+
+  if not public.is_platform_admin() then
+    raise exception 'not a platform admin';
+  end if;
+
+  return query
+    select r.id, r.name, r.org_id, o.name, r.keywords, r.created_at
+    from public.repositories r
+    left join public.organizations o on o.id = r.org_id
+    -- The membership set is a property of the USER, not of the row being tested, so
+    -- it is stated once as an uncorrelated `in` rather than as an `exists` re-run
+    -- per repository. A null `r.org_id` never matches it, which is the personal-repo
+    -- case already covered by the owner_id branch.
+    where r.owner_id = p_user_id
+       or r.org_id in (
+         select m.org_id
+         from public.memberships m
+         where m.user_id = p_user_id
+       )
+    order by o.name asc nulls first, r.name asc;
+end;
+$$;
+
+revoke execute on function public.admin_list_user_repositories(uuid) from public, anon;
+grant execute on function public.admin_list_user_repositories(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Documentation
+-- ---------------------------------------------------------------------------
+comment on table public.platform_admins is
+  'Who operates the product, as opposed to a tenant (that is memberships.role). '
+  'DENY-ALL by design: RLS is enabled with NO policy AND every privilege is '
+  'revoked from anon and authenticated, so the table is unreachable from the API '
+  'in either direction. The first row is inserted BY HAND from the Supabase '
+  'dashboard — there is deliberately no bootstrap path in the application, since '
+  'a self-service one would be a "first caller becomes admin" hole. The only way '
+  'to use this identity is the read-only public.admin_* functions.';
+
+comment on column public.platform_admins.user_id is
+  'The admin. Membership in this table IS the whole grant — there is no role '
+  'column, because a second tier would need its own column allowlist.';
+
+-- Correct the catalog comment set by 20260725100000: fleet-wide reporting no
+-- longer requires the service role. (The plain `--` comments in that migration
+-- are not catalog objects and cannot be amended from here; supabase/README.md
+-- carries the correction for those.)
+comment on table public.app_installations is
+  'One row per (user, device) recording the app version that device runs, '
+  'upserted by the desktop app on every launch once authenticated. '
+  'app_version_updated_at is trigger-maintained and marks when that device last '
+  'changed version. Private to its user (own-rows RLS); fleet-wide version '
+  'reporting goes through public.admin_list_installations(uuid), which is gated '
+  'on public.is_platform_admin() and returns an explicit column allowlist — no '
+  'service-role key, and no widening of this table''s policies.';

--- a/supabase/tests/platform_admin.test.sql
+++ b/supabase/tests/platform_admin.test.sql
@@ -1,0 +1,363 @@
+-- pgTAP: the platform-admin identity and its read-only back-office RPCs.
+--
+-- Covers 20260728090000_platform_admins.sql. Three things are proven here, in
+-- this order, because they are the three ways this feature could be wrong:
+--
+--   1. A non-admin authenticated caller is refused by EVERY admin_* function.
+--      Six functions, six assertions — a guard that exists on five of six is a
+--      hole, so none is taken on faith.
+--   2. `platform_admins` is unreachable from the API, and `anon` can execute
+--      none of these functions. Both are asserted through has_*_privilege rather
+--      than by attempting the call: a statement that throws proves only that
+--      SOMETHING refused it, and "RLS denied it" and "the role never held the
+--      privilege" are different guarantees. The privilege is the one that cannot
+--      be re-opened by adding a policy.
+--   3. An admin sees 100% of users — including one seeded with NO `profiles` and
+--      NO `user_settings` row, which is what a query driven off either of those
+--      tables would silently drop.
+--
+-- Same impersonation caveat as every other suite: pgTAP runs as the table OWNER,
+-- which BYPASSES RLS, so seeding happens as the owner and each assertion sets
+-- `role authenticated` + a `request.jwt.claims` sub so auth.uid() resolves.
+
+begin;
+select plan(38);
+
+-- ---------------------------------------------------------------------------
+-- Seed as the table owner (RLS bypassed).
+--   u1 (1111) — the platform admin. Deliberately owns nothing: an operator is
+--               not a customer, and their own counts must come back as zero.
+--   u2 (2222) — an ordinary user with a full footprint: profile, settings, one
+--               org membership, one device, two agents (one archived), two repos.
+--   u3 (3333) — signed up and never came back: NO profiles row, NO user_settings
+--               row, no device, no org, no agent. The AC2 canary.
+-- ---------------------------------------------------------------------------
+insert into auth.users (instance_id, id, aud, role, email, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000', '11111111-1111-1111-1111-111111111111', 'authenticated', 'authenticated', 'u1@example.com', now() - interval '3 days', now()),
+  ('00000000-0000-0000-0000-000000000000', '22222222-2222-2222-2222-222222222222', 'authenticated', 'authenticated', 'u2@example.com', now() - interval '2 days', now()),
+  ('00000000-0000-0000-0000-000000000000', '33333333-3333-3333-3333-333333333333', 'authenticated', 'authenticated', 'u3@example.com', now() - interval '1 day', now());
+
+-- The bootstrap the application cannot perform: a row inserted as the owner,
+-- exactly as a human does it from the Supabase dashboard.
+insert into public.platform_admins (user_id)
+values ('11111111-1111-1111-1111-111111111111');
+
+insert into public.organizations (id, name, created_by)
+values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Org One', '22222222-2222-2222-2222-222222222222');
+
+insert into public.memberships (org_id, user_id, role)
+values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', 'admin');
+
+-- free_text is seeded ON PURPOSE: the AC8 assertions below are meaningless if
+-- the column is empty in the fixture.
+insert into public.profiles (user_id, name, role, technical_level, communication_style, languages, free_text)
+values ('22222222-2222-2222-2222-222222222222', 'Bob', 'product', 'beginner', 'concise', '{fr}', 'private prose about myself');
+
+insert into public.user_settings (user_id, theme, language, usage_card_enabled, launch_mode)
+values ('22222222-2222-2222-2222-222222222222', 'dark', 'fr', true, 'plan');
+
+insert into public.app_installations (user_id, device_id, device_name, app_version, platform, arch)
+values ('22222222-2222-2222-2222-222222222222', 'device-1', 'bob-mbp', '0.54.1', 'darwin', 'arm64');
+
+-- One team repo and one personal repo, both u2's.
+insert into public.repositories (id, owner_id, org_id, name, keywords)
+values
+  ('c0000000-0000-0000-0000-00000000000a', '22222222-2222-2222-2222-222222222222', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'team-repo', '{api}'),
+  ('c0000000-0000-0000-0000-0000000000cc', '22222222-2222-2222-2222-222222222222', null,                                   'perso-repo', '{}');
+
+-- Agents are inserted without an org — org_id is derived from the attachment
+-- below (20260727160000). One is archived, to prove the drill-down keeps it.
+insert into public.agents (id, org_id, owner_id, name, ticket_id, status, branch_name, archived_at)
+values
+  ('a0000000-0000-0000-0000-000000000001', null, '22222222-2222-2222-2222-222222222222', 'Live agent',   'PER-1', 'in review', 'feature/per-1', null),
+  ('a0000000-0000-0000-0000-000000000002', null, '22222222-2222-2222-2222-222222222222', 'Closed agent', 'PER-2', 'merged',    'feature/per-2', now());
+
+insert into public.agent_repositories (agent_id, repo_id)
+values ('a0000000-0000-0000-0000-000000000001', 'c0000000-0000-0000-0000-00000000000a');
+
+-- ===========================================================================
+-- 1. A non-admin authenticated caller is refused everywhere (AC1, AC7).
+-- ===========================================================================
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"22222222-2222-2222-2222-222222222222"}';
+
+-- 1. The gate itself says no.
+select ok(
+  not public.is_platform_admin(),
+  'is_platform_admin is false for an ordinary user'
+);
+
+-- 2..7. Every admin_* function refuses that same caller. `p_user_id` is set to
+-- the caller's OWN id on purpose: the guard must fire even when the request is
+-- for data the caller is otherwise entitled to see.
+select throws_ok(
+  $sql$ select public.admin_list_users() $sql$,
+  'not a platform admin',
+  'admin_list_users rejects a non-admin'
+);
+
+select throws_ok(
+  $sql$ select public.admin_list_installations(null) $sql$,
+  'not a platform admin',
+  'admin_list_installations rejects a non-admin'
+);
+
+select throws_ok(
+  $sql$ select public.admin_get_user('22222222-2222-2222-2222-222222222222') $sql$,
+  'not a platform admin',
+  'admin_get_user rejects a non-admin'
+);
+
+select throws_ok(
+  $sql$ select public.admin_list_user_orgs('22222222-2222-2222-2222-222222222222') $sql$,
+  'not a platform admin',
+  'admin_list_user_orgs rejects a non-admin'
+);
+
+select throws_ok(
+  $sql$ select public.admin_list_user_agents('22222222-2222-2222-2222-222222222222') $sql$,
+  'not a platform admin',
+  'admin_list_user_agents rejects a non-admin'
+);
+
+select throws_ok(
+  $sql$ select public.admin_list_user_repositories('22222222-2222-2222-2222-222222222222') $sql$,
+  'not a platform admin',
+  'admin_list_user_repositories rejects a non-admin'
+);
+
+-- ===========================================================================
+-- 8. No session at all: the auth.uid() guard fires before the admin check.
+-- ===========================================================================
+reset role;
+set local role authenticated;
+set local request.jwt.claims = '{}';
+
+select throws_ok(
+  $sql$ select public.admin_list_users() $sql$,
+  'admin_list_users requires an authenticated user',
+  'admin_list_users rejects a caller with no session'
+);
+
+-- ===========================================================================
+-- 9..12. platform_admins grants NOTHING to authenticated (AC6).
+-- ===========================================================================
+-- Read back as the owner: querying another role's privileges requires membership
+-- in it, and the point of these four is the GRANT layer, not RLS.
+reset role;
+
+select ok(
+  not has_table_privilege('authenticated', 'public.platform_admins', 'insert'),
+  'authenticated holds no INSERT privilege on platform_admins'
+);
+
+select ok(
+  not has_table_privilege('authenticated', 'public.platform_admins', 'update'),
+  'authenticated holds no UPDATE privilege on platform_admins'
+);
+
+select ok(
+  not has_table_privilege('authenticated', 'public.platform_admins', 'delete'),
+  'authenticated holds no DELETE privilege on platform_admins'
+);
+
+-- Not required by the ticket, but a SELECT grant would leak the operator roster
+-- to every signed-in user, so it is pinned too.
+select ok(
+  not has_table_privilege('authenticated', 'public.platform_admins', 'select'),
+  'authenticated holds no SELECT privilege on platform_admins'
+);
+
+-- ===========================================================================
+-- 13..19. anon cannot execute anything under `admin_*`, nor the gate itself.
+-- ===========================================================================
+-- Postgres grants EXECUTE to PUBLIC by default, so `revoke execute … from public`
+-- is the only thing standing between an unauthenticated PostgREST call and the
+-- auth.uid() guard inside each function. It is asserted at the privilege layer
+-- for the same reason as the table grants above, and swept from the catalog so a
+-- seventh admin_* function added later is covered without editing this test.
+select ok(
+  not has_function_privilege('anon', 'public.is_platform_admin()', 'execute'),
+  'anon holds no EXECUTE privilege on is_platform_admin'
+);
+
+select ok(
+  not has_function_privilege('anon', p.oid, 'execute'),
+  'anon holds no EXECUTE privilege on ' || p.proname
+)
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+  and p.proname like 'admin\_%'
+order by p.proname;
+
+-- ===========================================================================
+-- 20..36. The admin path.
+-- ===========================================================================
+set local role authenticated;
+set local request.jwt.claims = '{"sub":"11111111-1111-1111-1111-111111111111"}';
+
+-- 20. The gate recognises the seeded admin.
+select ok(public.is_platform_admin(), 'is_platform_admin is true for a seeded admin');
+
+-- 21. All three users come back — 100% of the fleet (AC2).
+select is(
+  (select count(*) from public.admin_list_users()),
+  3::bigint,
+  'admin_list_users returns every user'
+);
+
+-- 22. Including the one with no profiles and no user_settings row, which is what
+--     a query driven off either table would have dropped.
+select ok(
+  exists (
+    select 1 from public.admin_list_users()
+    where user_id = '33333333-3333-3333-3333-333333333333'
+  ),
+  'admin_list_users includes a user with no profiles and no user_settings row'
+);
+
+-- 23. That user's counts are 0, not null — a null would render as blank rather
+--     than as "none".
+select is(
+  (select device_count from public.admin_list_users()
+   where user_id = '33333333-3333-3333-3333-333333333333'),
+  0::bigint,
+  'a user with no device counts as 0, not null'
+);
+
+-- 24. The app version is resolved per user from their most recent device (AC2).
+select is(
+  (select latest_app_version from public.admin_list_users()
+   where user_id = '22222222-2222-2222-2222-222222222222'),
+  '0.54.1',
+  'admin_list_users resolves the app version from the latest device'
+);
+
+-- 25. Org membership is counted.
+select is(
+  (select org_count from public.admin_list_users()
+   where user_id = '22222222-2222-2222-2222-222222222222'),
+  1::bigint,
+  'admin_list_users counts org memberships'
+);
+
+-- 26. Agents are counted in full…
+select is(
+  (select agent_count from public.admin_list_users()
+   where user_id = '22222222-2222-2222-2222-222222222222'),
+  2::bigint,
+  'admin_list_users counts every agent, archived included'
+);
+
+-- 27. …and separately excluding the archived one.
+select is(
+  (select active_agent_count from public.admin_list_users()
+   where user_id = '22222222-2222-2222-2222-222222222222'),
+  1::bigint,
+  'admin_list_users counts active agents separately'
+);
+
+-- 28. The whole fleet, one row per device.
+select is(
+  (select count(*) from public.admin_list_installations(null)),
+  1::bigint,
+  'admin_list_installations(null) returns the whole fleet'
+);
+
+-- 29. Scoped to one user.
+select is(
+  (select device_name from public.admin_list_installations('22222222-2222-2222-2222-222222222222')),
+  'bob-mbp',
+  'admin_list_installations scopes to one user'
+);
+
+-- 30. …and that scoping actually excludes the others.
+select is(
+  (select count(*) from public.admin_list_installations('11111111-1111-1111-1111-111111111111')),
+  0::bigint,
+  'admin_list_installations returns nothing for a user with no device'
+);
+
+-- 31. The drill-down header: name and role from profiles, nothing else.
+select is(
+  (select name || ' / ' || role from public.admin_get_user('22222222-2222-2222-2222-222222222222')),
+  'Bob / product',
+  'admin_get_user returns the profile name and role'
+);
+
+-- 32. And the settings row, column by column (one sample stands for the 17).
+select is(
+  (select theme from public.admin_get_user('22222222-2222-2222-2222-222222222222')),
+  'dark',
+  'admin_get_user returns the user_settings columns'
+);
+
+-- 33. A user with no profiles and no user_settings row still yields a row, with
+--     nulls — driven off auth.users, so the page renders instead of 404ing.
+select is(
+  (select count(*) from public.admin_get_user('33333333-3333-3333-3333-333333333333')),
+  1::bigint,
+  'admin_get_user returns a row for a user with no profile and no settings'
+);
+
+-- 34. Orgs, with the role in each.
+select is(
+  (select name || ' / ' || role::text from public.admin_list_user_orgs('22222222-2222-2222-2222-222222222222')),
+  'Org One / admin',
+  'admin_list_user_orgs returns the org and the role in it'
+);
+
+-- 35. Agents include the archived one, with their repositories resolved by name.
+select is(
+  (select repo_names from public.admin_list_user_agents('22222222-2222-2222-2222-222222222222')
+   where id = 'a0000000-0000-0000-0000-000000000001'),
+  array['team-repo'],
+  'admin_list_user_agents resolves repository names from agent_repositories'
+);
+
+-- 36. Repositories: the personal one and the team one, in a single list.
+select is(
+  (select count(*) from public.admin_list_user_repositories('22222222-2222-2222-2222-222222222222')),
+  2::bigint,
+  'admin_list_user_repositories returns personal and team repositories'
+);
+
+-- ===========================================================================
+-- 37..38. The column allowlist holds: no admin_* function exposes free_text (AC8).
+-- ===========================================================================
+-- Asserted against the SIGNATURE, not against a result set. A row-level check
+-- ("no row contains the seeded prose") passes for any fixture where the column
+-- happens to be empty; pg_get_function_result reads the declared return type, so
+-- it fails the moment a column is added to an allowlist — which is the event this
+-- is meant to catch.
+reset role;
+
+select ok(
+  pg_get_function_result('public.admin_get_user(uuid)'::regprocedure) not like '%free_text%',
+  'admin_get_user does not return profiles.free_text'
+);
+
+-- The same guarantee for every admin_* function at once, and for the three other
+-- profiles columns held back with it. Written as a catalog sweep so a SEVENTH
+-- function added later is covered without editing this test.
+select ok(
+  not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.proname like 'admin\_%'
+      and (
+        pg_get_function_result(p.oid) like '%free_text%'
+        or pg_get_function_result(p.oid) like '%technical_level%'
+        or pg_get_function_result(p.oid) like '%communication_style%'
+        or pg_get_function_result(p.oid) like '%languages%'
+      )
+  ),
+  'no admin_* function returns free_text, technical_level, communication_style or languages'
+);
+
+select * from finish();
+rollback;

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -35,6 +35,12 @@ npm run dev                        # http://localhost:3000
 - `/organization` — org detail: members (via `list_org_members`), role, org switcher
 - `/account` — identity, Claude profile, and the machines you signed in from
 - `/repository/[id]` — per-repository settings
+- `/admin` — platform back-office (read-only): the version distribution across the
+  whole fleet, devices behind the rest, the platform/arch breakdown, devices gone
+  quiet, and every user. Reachable only by a platform admin — the nav entry is not
+  rendered for anyone else and the page redirects to `/dashboard`
+- `/admin/[userId]` — one user, read-only: profile, their whole `user_settings`
+  row, devices, orgs, agents (archived included) and repositories
 - `/invite/[token]` — public invitation funnel: preview org → sign up (or sign in)
   → accept the invitation (then a link to download the desktop app)
 
@@ -51,6 +57,17 @@ npm run dev                        # http://localhost:3000
   `lib/settings.ts` for display and only writes a column the user touched.
 - `app_installations` — read-only here; the desktop upserts one row per machine
   on every launch, which is what `/application` and `/account` report on.
+- `rpc('is_platform_admin')` — whether the caller operates the platform. Used to
+  decide whether the `Admin` nav entry is drawn; the gate itself is re-checked in
+  the database by each RPC below, so this only governs discovery.
+- `rpc('admin_list_users')`, `rpc('admin_list_installations', { p_user_id })`,
+  `rpc('admin_get_user', { p_user_id })`, `rpc('admin_list_user_orgs', { p_user_id })`,
+  `rpc('admin_list_user_agents', { p_user_id })`,
+  `rpc('admin_list_user_repositories', { p_user_id })` — the `/admin` pages. All
+  `SECURITY DEFINER`, all read-only, each raising unless the caller has a
+  `platform_admins` row, and each returning an explicit column allowlist rather
+  than a table. `profiles.free_text` is returned by none of them. No RLS policy was
+  widened to make these work — see `supabase/README.md` → Security model.
 
 ## Deploy (Vercel)
 

--- a/webapp/app/admin/[userId]/page.tsx
+++ b/webapp/app/admin/[userId]/page.tsx
@@ -1,0 +1,290 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, Bot, Building2, FolderGit2, Laptop, SlidersHorizontal, UserRound } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { useRequirePlatformAdmin } from '@/lib/session'
+import {
+  getUser,
+  listInstallations,
+  listUserAgents,
+  listUserOrgs,
+  listUserRepositories,
+  SETTING_LABELS,
+  type AdminAgent,
+  type AdminInstallation,
+  type AdminOrg,
+  type AdminRepository,
+  type AdminUserDetail,
+} from '@/lib/admin'
+import { formatAbsoluteDate, formatDevicePlatform, formatRelative } from '@/lib/installations'
+import { AppShell } from '@/components/AppShell'
+import { SettingRow, SettingsCard } from '@/components/SettingRow'
+import { Badge, Card, FullPageLoader, SectionHeader } from '@/components/ui'
+
+/**
+ * One user, as the platform sees them: identity, their whole `user_settings` row,
+ * their devices, orgs, agents and repositories.
+ *
+ * Strictly read-only. There is no form, no control and no mutation on this page —
+ * the five RPCs it calls are all `select`-shaped, and `lib/admin.ts` exports no
+ * writer. Support reads this to understand a report; changing anything is the
+ * user's own job in their own app, which is the boundary that makes a back-office
+ * without an audit log defensible.
+ *
+ * A user with no `profiles` row and no `user_settings` row still renders: the
+ * RPCs are driven off `auth.users`, and "never chose" is shown as such rather than
+ * being papered over with the app's defaults.
+ */
+
+/**
+ * How one settings value reads. NULL is rendered as "never chosen" rather than as
+ * the default the app would apply: the difference is the whole point of the
+ * nullable columns, and collapsing it here would make the page lie about what is
+ * stored.
+ */
+function formatSetting(value: string | number | boolean | null): { text: string; unset: boolean } {
+  if (value === null || value === undefined) return { text: 'never chosen', unset: true }
+  if (typeof value === 'boolean') return { text: value ? 'on' : 'off', unset: false }
+  return { text: String(value), unset: false }
+}
+
+/** Header row of the identity card. */
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs text-muted">{label}</p>
+      <p className="mt-0.5 truncate font-display text-sm font-bold text-ink">{value}</p>
+    </div>
+  )
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-muted">{children}</p>
+}
+
+/**
+ * The four lists below — devices, orgs, agents, repositories — are the same card
+ * with the same three states, and only the rows differ. Written out four times, the
+ * count pill, the loading branch and the divider classes are four places to keep in
+ * step; here each section supplies just its icon, its empty sentence and its row.
+ *
+ * `items === null` means "not fetched yet", mirroring the `useState<T[] | null>`
+ * the page holds each list in.
+ */
+function ListSection<T>({
+  icon,
+  title,
+  items,
+  empty,
+  row,
+}: {
+  icon: LucideIcon
+  title: string
+  items: T[] | null
+  empty: string
+  row: (item: T) => React.ReactNode
+}) {
+  return (
+    <section>
+      <SectionHeader
+        icon={icon}
+        title={title}
+        action={items ? <span className="text-xs text-muted">{items.length}</span> : null}
+      />
+      <Card className="p-5">
+        {items === null ? (
+          <Empty>Loading…</Empty>
+        ) : items.length === 0 ? (
+          <Empty>{empty}</Empty>
+        ) : (
+          <ul className="divide-y divide-black/5">{items.map(row)}</ul>
+        )}
+      </Card>
+    </section>
+  )
+}
+
+export default function AdminUserDetailPage() {
+  const params = useParams<{ userId: string }>()
+  const userId = params.userId
+  const { session, pending } = useRequirePlatformAdmin()
+
+  // undefined = not fetched yet, null = fetched and there is no such user.
+  const [user, setUser] = useState<AdminUserDetail | null | undefined>(undefined)
+  const [devices, setDevices] = useState<AdminInstallation[] | null>(null)
+  const [orgs, setOrgs] = useState<AdminOrg[] | null>(null)
+  const [agents, setAgents] = useState<AdminAgent[] | null>(null)
+  const [repos, setRepos] = useState<AdminRepository[] | null>(null)
+
+  // Keyed on the viewer's id rather than the session object, which a token refresh
+  // replaces for the same person — otherwise all five reads below re-fire hourly
+  // for an identity that did not change.
+  const viewerId = session?.user.id
+
+  useEffect(() => {
+    if (pending || !viewerId || !userId) return
+    getUser(userId).then(setUser)
+    listInstallations(userId).then(setDevices)
+    listUserOrgs(userId).then(setOrgs)
+    listUserAgents(userId).then(setAgents)
+    listUserRepositories(userId).then(setRepos)
+  }, [pending, viewerId, userId])
+
+  if (pending || !session) return <FullPageLoader />
+
+  return (
+    <AppShell email={session.user.email ?? undefined}>
+      <Link
+        href="/admin"
+        className="inline-flex items-center gap-2 text-sm font-medium text-muted transition-colors hover:text-ink"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Platform
+      </Link>
+
+      {user === undefined ? (
+        <p className="mt-8 text-sm text-muted">Loading…</p>
+      ) : user === null ? (
+        <p className="mt-8 text-sm text-muted">No such user, or the account has been deleted.</p>
+      ) : (
+        <>
+          <h1 className="mt-6 truncate font-display text-4xl font-black leading-tight tracking-tight text-ink">
+            {user.email ?? user.userId}
+          </h1>
+
+          <div className="mt-10 space-y-8">
+            {/* ── Who they are (name and role only — see the RPC allowlist) ── */}
+            <section>
+              <SectionHeader icon={UserRound} title="Profile" />
+              <Card className="grid gap-5 p-5 sm:grid-cols-2 lg:grid-cols-4">
+                <Fact label="Name" value={user.name ?? 'No profile'} />
+                <Fact label="Role" value={user.role ?? '—'} />
+                <Fact label="Signed up" value={formatAbsoluteDate(user.createdAt)} />
+                <Fact label="Last sign-in" value={formatAbsoluteDate(user.lastSignInAt)} />
+              </Card>
+            </section>
+
+            {/* ── The whole user_settings row, in reading order ───────────── */}
+            <SettingsCard icon={SlidersHorizontal} title="App settings">
+              {SETTING_LABELS.map(({ field, label }) => {
+                const { text, unset } = formatSetting(user.settings[field])
+                return (
+                  <SettingRow key={field} label={label}>
+                    <span className={`font-mono text-xs ${unset ? 'text-muted/60' : 'text-ink'}`}>{text}</span>
+                  </SettingRow>
+                )
+              })}
+            </SettingsCard>
+
+            {/* ── Devices, with the version each one runs ─────────────────── */}
+            <ListSection
+              icon={Laptop}
+              title="Devices"
+              items={devices}
+              empty="Never launched the desktop app."
+              row={(d) => (
+                <li key={d.deviceId} className="flex items-center gap-4 py-3 first:pt-0 last:pb-0">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-ink">
+                      {d.deviceName ?? 'Unknown device'}
+                    </p>
+                    <p className="mt-0.5 truncate text-xs text-muted">
+                      {[
+                        formatDevicePlatform(d),
+                        `last seen ${formatRelative(d.lastSeenAt)}`,
+                        d.appVersionUpdatedAt
+                          ? `on this version since ${formatRelative(d.appVersionUpdatedAt)}`
+                          : null,
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </p>
+                  </div>
+                  <Badge tone="accent">v{d.appVersion}</Badge>
+                </li>
+              )}
+            />
+
+            {/* ── Orgs, archived ones included ────────────────────────────── */}
+            <ListSection
+              icon={Building2}
+              title="Organizations"
+              items={orgs}
+              empty="Not a member of any organization."
+              row={(o) => (
+                <li key={o.orgId} className="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-ink">{o.name}</p>
+                    <p className="mt-0.5 truncate text-xs text-muted">
+                      member since {formatAbsoluteDate(o.createdAt)}
+                    </p>
+                  </div>
+                  {o.archivedAt && <Badge tone="red">archived</Badge>}
+                  <Badge tone={o.role === 'admin' ? 'purple' : 'neutral'}>{o.role}</Badge>
+                </li>
+              )}
+            />
+
+            {/* ── Agents, archived ones included ──────────────────────────── */}
+            <ListSection
+              icon={Bot}
+              title="Agents"
+              items={agents}
+              empty="No agent yet."
+              row={(a) => (
+                <li key={a.id} className="flex items-start gap-3 py-3 first:pt-0 last:pb-0">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-ink">
+                      {a.ticketId ? `${a.ticketId} — ${a.name}` : a.name}
+                    </p>
+                    <p className="mt-0.5 truncate text-xs text-muted">
+                      {[
+                        a.repoNames.length > 0 ? a.repoNames.join(', ') : 'no repository linked',
+                        a.branchName
+                          ? a.baseBranch
+                            ? `${a.branchName} → ${a.baseBranch}`
+                            : a.branchName
+                          : null,
+                        `created ${formatAbsoluteDate(a.createdAt)}`,
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </p>
+                  </div>
+                  {a.shared && <Badge tone="purple">shared</Badge>}
+                  {a.archivedAt && <Badge tone="neutral">archived</Badge>}
+                  {a.status && <Badge tone="accent">{a.status}</Badge>}
+                </li>
+              )}
+            />
+
+            {/* ── Repositories: their own, plus their orgs' team repos ────── */}
+            <ListSection
+              icon={FolderGit2}
+              title="Repositories"
+              items={repos}
+              empty="No repository configured."
+              row={(r) => (
+                <li key={r.id} className="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-ink">{r.name}</p>
+                    <p className="mt-0.5 truncate text-xs text-muted">
+                      {[
+                        r.keywords.length > 0 ? r.keywords.join(', ') : 'no keyword',
+                        `added ${formatAbsoluteDate(r.createdAt)}`,
+                      ].join(' · ')}
+                    </p>
+                  </div>
+                  <Badge tone={r.orgId ? 'accent' : 'neutral'}>{r.orgName ?? 'personal'}</Badge>
+                </li>
+              )}
+            />
+          </div>
+        </>
+      )}
+    </AppShell>
+  )
+}

--- a/webapp/app/admin/[userId]/page.tsx
+++ b/webapp/app/admin/[userId]/page.tsx
@@ -126,11 +126,37 @@ export default function AdminUserDetailPage() {
 
   useEffect(() => {
     if (pending || !viewerId || !userId) return
-    getUser(userId).then(setUser)
-    listInstallations(userId).then(setDevices)
-    listUserOrgs(userId).then(setOrgs)
-    listUserAgents(userId).then(setAgents)
-    listUserRepositories(userId).then(setRepos)
+
+    // Five independent reads that resolve in any order, against state that
+    // survives a route change: without the two guards below, navigating from one
+    // user to another renders TWO people as one. Resetting first clears the
+    // previous user's rows instead of leaving them on screen under the new
+    // user's name; `cancelled` drops responses for the id we already left, so a
+    // slow listUserAgents for A cannot overwrite the fast one for B. Mixed-up
+    // identity is exactly the failure a back-office must not have — nothing on
+    // the page would say the agents belong to someone else.
+    setUser(undefined)
+    setDevices(null)
+    setOrgs(null)
+    setAgents(null)
+    setRepos(null)
+
+    let cancelled = false
+    const apply =
+      <T,>(set: (value: T) => void) =>
+      (value: T) => {
+        if (!cancelled) set(value)
+      }
+
+    getUser(userId).then(apply(setUser))
+    listInstallations(userId).then(apply(setDevices))
+    listUserOrgs(userId).then(apply(setOrgs))
+    listUserAgents(userId).then(apply(setAgents))
+    listUserRepositories(userId).then(apply(setRepos))
+
+    return () => {
+      cancelled = true
+    }
   }, [pending, viewerId, userId])
 
   if (pending || !session) return <FullPageLoader />

--- a/webapp/app/admin/page.tsx
+++ b/webapp/app/admin/page.tsx
@@ -1,0 +1,308 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { AlertTriangle, Cpu, Laptop, LayoutList, MoonStar, Users } from 'lucide-react'
+import { useRequirePlatformAdmin } from '@/lib/session'
+import {
+  bucketByVersion,
+  countBy,
+  listInstallations,
+  listUsers,
+  outdatedInstallations,
+  QUIET_DAYS,
+  quietInstallations,
+  type AdminInstallation,
+  type AdminUser,
+  type CountBucket,
+} from '@/lib/admin'
+import { formatRelative, highestVersion } from '@/lib/installations'
+import { AppShell } from '@/components/AppShell'
+import { Badge, Card, FullPageLoader, SectionHeader, type BadgeTone } from '@/components/ui'
+
+/**
+ * The platform back-office: every user, what they run, and what they own.
+ *
+ * Read-only, by construction rather than by convention — the six RPCs behind it
+ * are all `select`-shaped and there is no write helper in `lib/admin.ts`. No
+ * existing RLS policy was widened to build this page; each RPC is `SECURITY
+ * DEFINER` with an explicit column allowlist in its signature, gated on
+ * `is_platform_admin()`.
+ *
+ * Two round trips serve the whole page: one for the users, one for every device in
+ * the fleet. The four rollups below (version histogram, outdated devices,
+ * platform/arch breakdown, quiet devices) are all computed from that same device
+ * list, so asking the database four aggregate questions would be four queries for
+ * data already in hand.
+ */
+
+/** Bars thinner than this are invisible, which reads as "no devices" — not the same thing. */
+const MIN_BAR_PERCENT = 2
+
+/** Empty-state copy in the shape every card here uses. */
+function Empty({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-muted">{children}</p>
+}
+
+/** One horizontal bar: label, bar, count. No chart library — a div is a bar. */
+function Bar({ label, count, total }: { label: string; count: number; total: number }) {
+  const percent = total === 0 ? 0 : (count / total) * 100
+  return (
+    <div className="flex items-center gap-3 py-1.5">
+      <span className="w-24 shrink-0 truncate font-mono text-xs text-ink">{label}</span>
+      <span className="h-2.5 min-w-0 flex-1 overflow-hidden rounded-full bg-black/[0.05]">
+        <span
+          className="block h-full rounded-full bg-accent"
+          style={{ width: `${Math.max(percent, MIN_BAR_PERCENT)}%` }}
+        />
+      </span>
+      <span className="w-20 shrink-0 text-right text-xs text-muted">
+        {count} · {Math.round(percent)}%
+      </span>
+    </div>
+  )
+}
+
+/** Platform and arch use the same shape, so they share one renderer. */
+function Breakdown({ buckets, total }: { buckets: CountBucket[]; total: number }) {
+  if (buckets.length === 0) return <Empty>No device has reported yet.</Empty>
+  return (
+    <div>
+      {buckets.map((b) => (
+        <Bar key={b.value} label={b.value} count={b.count} total={total} />
+      ))}
+    </div>
+  )
+}
+
+/** "bob-mbp · bob@example.com" — the two things that identify a device on sight. */
+function deviceLabel(device: AdminInstallation): string {
+  return [device.deviceName ?? 'Unknown device', device.email ?? device.userId].join(' · ')
+}
+
+/**
+ * One device in the "outdated" and "quiet" lists. Both answer "which machine, how
+ * long ago", differing only in badge tone and detail line, so the row is written
+ * once rather than as two copies that drift on the next padding change.
+ */
+function DeviceRow({
+  device,
+  tone,
+  children,
+}: {
+  device: AdminInstallation
+  tone: BadgeTone
+  children: React.ReactNode
+}) {
+  return (
+    <li className="flex items-center gap-4 py-3 first:pt-0 last:pb-0">
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-ink">{deviceLabel(device)}</p>
+        <p className="mt-0.5 truncate text-xs text-muted">{children}</p>
+      </div>
+      <Badge tone={tone}>v{device.appVersion}</Badge>
+    </li>
+  )
+}
+
+export default function Admin() {
+  const { session, pending } = useRequirePlatformAdmin()
+
+  const [users, setUsers] = useState<AdminUser[] | null>(null)
+  const [devices, setDevices] = useState<AdminInstallation[] | null>(null)
+
+  // Keyed on the user id rather than the session object, which a token refresh
+  // replaces for the same person — re-fetching the whole fleet hourly for an
+  // unchanged identity is work nobody asked for.
+  const userId = session?.user.id
+
+  useEffect(() => {
+    if (pending || !userId) return
+    listUsers().then(setUsers)
+    listInstallations().then(setDevices)
+  }, [pending, userId])
+
+  if (pending || !session) return <FullPageLoader />
+
+  const fleet = devices ?? []
+  const versions = bucketByVersion(fleet)
+  const outdated = outdatedInstallations(fleet)
+  // The version the fleet is measured against — the highest any device reports,
+  // which is not necessarily the latest release (nothing here knows that).
+  const newest = highestVersion(fleet)
+  const quiet = quietInstallations(fleet, Date.now())
+
+  return (
+    <AppShell email={session.user.email ?? undefined}>
+      <h1 className="font-display text-5xl font-black leading-none tracking-tight text-ink">Platform</h1>
+      <p className="mt-3 text-sm text-muted">
+        Every account, what it runs and what it owns. Read-only — nothing on these pages writes.
+      </p>
+
+      <div className="mt-10 space-y-8">
+        {/* ── Version distribution, per DEVICE ───────────────────────────── */}
+        <section>
+          <SectionHeader
+            icon={LayoutList}
+            title="App versions"
+            action={
+              devices ? (
+                <span className="text-xs text-muted">
+                  {fleet.length} device{fleet.length === 1 ? '' : 's'}
+                </span>
+              ) : null
+            }
+          />
+          <Card className="p-5">
+            {devices === null ? (
+              <Empty>Loading…</Empty>
+            ) : versions.length === 0 ? (
+              <Empty>No device has launched the app yet.</Empty>
+            ) : (
+              <div>
+                {versions.map((v) => (
+                  <Bar key={v.version} label={`v${v.version}`} count={v.count} total={fleet.length} />
+                ))}
+              </div>
+            )}
+          </Card>
+        </section>
+
+        {/* ── Behind the rest of the fleet ────────────────────────────────── */}
+        <section>
+          <SectionHeader
+            icon={AlertTriangle}
+            title="Outdated devices"
+            action={
+              devices ? <span className="text-xs text-muted">{outdated.length}</span> : null
+            }
+          />
+          <Card className="p-5">
+            {devices === null ? (
+              <Empty>Loading…</Empty>
+            ) : outdated.length === 0 ? (
+              <Empty>
+                {fleet.length === 0
+                  ? 'No device has launched the app yet.'
+                  : `Every device is on v${newest}.`}
+              </Empty>
+            ) : (
+              <ul className="divide-y divide-black/5">
+                {outdated.map((d) => (
+                  <DeviceRow key={`${d.userId}-${d.deviceId}`} device={d} tone="yellow">
+                    last seen {formatRelative(d.lastSeenAt)}
+                    {d.appVersionUpdatedAt && ` · updated ${formatRelative(d.appVersionUpdatedAt)}`}
+                  </DeviceRow>
+                ))}
+              </ul>
+            )}
+          </Card>
+        </section>
+
+        {/* ── What the fleet runs on ──────────────────────────────────────── */}
+        <div className="grid gap-8 sm:grid-cols-2">
+          <section>
+            <SectionHeader icon={Laptop} title="Platforms" />
+            <Card className="p-5">
+              {devices === null ? (
+                <Empty>Loading…</Empty>
+              ) : (
+                <Breakdown buckets={countBy(fleet, 'platform')} total={fleet.length} />
+              )}
+            </Card>
+          </section>
+
+          <section>
+            <SectionHeader icon={Cpu} title="Architectures" />
+            <Card className="p-5">
+              {devices === null ? (
+                <Empty>Loading…</Empty>
+              ) : (
+                <Breakdown buckets={countBy(fleet, 'arch')} total={fleet.length} />
+              )}
+            </Card>
+          </section>
+        </div>
+
+        {/* ── Inactivity, straight off last_seen_at ───────────────────────── */}
+        <section>
+          <SectionHeader
+            icon={MoonStar}
+            title={`Quiet for ${QUIET_DAYS}+ days`}
+            action={devices ? <span className="text-xs text-muted">{quiet.length}</span> : null}
+          />
+          <Card className="p-5">
+            {devices === null ? (
+              <Empty>Loading…</Empty>
+            ) : quiet.length === 0 ? (
+              <Empty>
+                {fleet.length === 0
+                  ? 'No device has launched the app yet.'
+                  : `Every device has launched the app in the last ${QUIET_DAYS} days.`}
+              </Empty>
+            ) : (
+              <ul className="divide-y divide-black/5">
+                {quiet.map((d) => (
+                  <DeviceRow key={`${d.userId}-${d.deviceId}`} device={d} tone="neutral">
+                    last seen {formatRelative(d.lastSeenAt)}
+                  </DeviceRow>
+                ))}
+              </ul>
+            )}
+          </Card>
+        </section>
+
+        {/* ── Everyone, including the accounts that never got started ─────── */}
+        <section>
+          <SectionHeader
+            icon={Users}
+            title="Users"
+            action={users ? <span className="text-xs text-muted">{users.length}</span> : null}
+          />
+          <Card className="p-5">
+            {users === null ? (
+              <Empty>Loading…</Empty>
+            ) : users.length === 0 ? (
+              <Empty>No account yet.</Empty>
+            ) : (
+              <ul className="divide-y divide-black/5">
+                {users.map((u) => (
+                  <li key={u.userId}>
+                    <Link
+                      href={`/admin/${u.userId}`}
+                      className="-mx-2 flex items-center gap-4 rounded-xl px-2 py-3 transition-colors hover:bg-canvas"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-ink">
+                          {u.email ?? u.userId}
+                        </p>
+                        <p className="mt-0.5 truncate text-xs text-muted">
+                          {[
+                            u.name ?? 'No profile',
+                            `${u.deviceCount} device${u.deviceCount === 1 ? '' : 's'}`,
+                            `${u.orgCount} org${u.orgCount === 1 ? '' : 's'}`,
+                            `${u.activeAgentCount}/${u.agentCount} agent${u.agentCount === 1 ? '' : 's'}`,
+                            u.latestLastSeenAt
+                              ? `seen ${formatRelative(u.latestLastSeenAt)}`
+                              : 'never seen',
+                          ].join(' · ')}
+                        </p>
+                      </div>
+                      {u.latestAppVersion ? (
+                        <Badge tone={u.latestAppVersion === newest ? 'accent' : 'yellow'}>
+                          v{u.latestAppVersion}
+                        </Badge>
+                      ) : (
+                        <Badge tone="neutral">never launched</Badge>
+                      )}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Card>
+        </section>
+      </div>
+    </AppShell>
+  )
+}

--- a/webapp/components/TopNav.tsx
+++ b/webapp/components/TopNav.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { AppWindow, Building2, ChevronDown, LogOut, UserRound } from 'lucide-react'
+import { AppWindow, Building2, ChevronDown, LogOut, ShieldCheck, UserRound } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { isPlatformAdmin } from '@/lib/admin'
 import { getSupabase } from '@/lib/supabase'
 
 /**
@@ -13,10 +15,19 @@ import { getSupabase } from '@/lib/supabase'
  * account menu, which is the only remaining way to reach them.
  */
 
-const MENU_LINKS = [
+interface MenuLink {
+  href: string
+  label: string
+  icon: LucideIcon
+  /** Rendered only for a platform admin — see the filter in TopNav below. */
+  platformAdminOnly?: boolean
+}
+
+const MENU_LINKS: MenuLink[] = [
   { href: '/application', label: 'Application', icon: AppWindow },
   { href: '/organization', label: 'Organization', icon: Building2 },
   { href: '/account', label: 'Account', icon: UserRound },
+  { href: '/admin', label: 'Admin', icon: ShieldCheck, platformAdminOnly: true },
 ]
 
 const MENU_ITEM =
@@ -26,6 +37,31 @@ export function TopNav({ email }: { email?: string }) {
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+
+  /**
+   * Whether to offer the back-office at all. Asked here rather than passed in as
+   * a prop, because the answer belongs to the nav and nowhere else: threading it
+   * through AppShell would put a platform concern in the signature of all five
+   * pages that render this chrome, none of which has any other reason to know.
+   *
+   * Non-discoverability only. `/admin` guards itself with useRequirePlatformAdmin
+   * and every admin_* RPC re-checks in the database, so this decides whether the
+   * entry is drawn, never whether the data can be read. Defaults to false, so the
+   * entry never appears while the answer is in flight.
+   */
+  const [platformAdmin, setPlatformAdmin] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    isPlatformAdmin().then((ok) => {
+      if (!cancelled) setPlatformAdmin(ok)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const links = MENU_LINKS.filter((link) => !link.platformAdminOnly || platformAdmin)
 
   // Close on an outside click or Escape — the two ways out people expect.
   useEffect(() => {
@@ -75,7 +111,7 @@ export function TopNav({ email }: { email?: string }) {
               role="menu"
               className="absolute right-0 top-full mt-2 w-52 overflow-hidden rounded-2xl border border-black/5 bg-white p-1 shadow-xl shadow-black/5"
             >
-              {MENU_LINKS.map(({ href, label, icon: Icon }) => (
+              {links.map(({ href, label, icon: Icon }) => (
                 <Link
                   key={href}
                   href={href}

--- a/webapp/lib/admin.test.ts
+++ b/webapp/lib/admin.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest'
+import {
+  bucketByVersion,
+  countBy,
+  outdatedInstallations,
+  QUIET_DAYS,
+  quietInstallations,
+  UNKNOWN_VALUE,
+  type AdminInstallation,
+} from './admin'
+
+/**
+ * The back-office's four rollups: arithmetic over the fleet, where being wrong
+ * looks exactly like being right.
+ *
+ * Everything else in `lib/admin.ts` is an RPC call and a field rename. Those are
+ * NOT type-checked — the Supabase client is untyped here (no generated
+ * `database.types.ts`), so `data as AdminUserRpcRow[]` is a cast over `any` and
+ * a field wired to the wrong column compiles cleanly. The migration's
+ * `returns table` and the `…RpcRow` interfaces are kept in agreement by hand;
+ * the pgTAP suite is what pins the SQL side.
+ */
+
+function device(overrides: Partial<AdminInstallation> = {}): AdminInstallation {
+  return {
+    userId: 'u1',
+    email: 'u1@example.com',
+    deviceId: 'd1',
+    deviceName: 'mbp',
+    appVersion: '0.54.1',
+    platform: 'darwin',
+    arch: 'arm64',
+    lastSeenAt: '2026-07-28T10:00:00.000Z',
+    appVersionUpdatedAt: '2026-07-20T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('bucketByVersion', () => {
+  it('returns nothing for an empty fleet', () => {
+    expect(bucketByVersion([])).toEqual([])
+  })
+
+  it('counts devices per version, newest version first', () => {
+    const buckets = bucketByVersion([
+      device({ deviceId: 'd1', appVersion: '0.53.0' }),
+      device({ deviceId: 'd2', appVersion: '0.54.1' }),
+      device({ deviceId: 'd3', appVersion: '0.54.1' }),
+      device({ deviceId: 'd4', appVersion: '0.9.0' }),
+    ])
+    expect(buckets).toEqual([
+      { version: '0.54.1', count: 2 },
+      { version: '0.53.0', count: 1 },
+      { version: '0.9.0', count: 1 },
+    ])
+  })
+
+  it('counts devices rather than users, so two machines of one person count twice', () => {
+    expect(
+      bucketByVersion([
+        device({ deviceId: 'd1', appVersion: '0.54.1' }),
+        device({ deviceId: 'd2', appVersion: '0.54.1' }),
+      ]),
+    ).toEqual([{ version: '0.54.1', count: 2 }])
+  })
+
+  it('orders two spellings that compare equal deterministically', () => {
+    // compareVersions is numeric-component-only, so 0.54 and 0.54.0 tie; the
+    // string tiebreak must produce the same order every run.
+    const buckets = bucketByVersion([
+      device({ deviceId: 'd1', appVersion: '0.54' }),
+      device({ deviceId: 'd2', appVersion: '0.54.0' }),
+    ])
+    expect(buckets.map((b) => b.version)).toEqual(['0.54.0', '0.54'])
+  })
+})
+
+describe('outdatedInstallations', () => {
+  it('returns nothing for an empty fleet', () => {
+    expect(outdatedInstallations([])).toEqual([])
+  })
+
+  it('returns nothing when every device is on the same version', () => {
+    expect(
+      outdatedInstallations([
+        device({ deviceId: 'd1', appVersion: '0.54.1' }),
+        device({ deviceId: 'd2', appVersion: '0.54.1' }),
+      ]),
+    ).toEqual([])
+  })
+
+  it('returns the devices behind the highest observed version', () => {
+    const outdated = outdatedInstallations([
+      device({ deviceId: 'd1', appVersion: '0.54.1' }),
+      device({ deviceId: 'd2', appVersion: '0.53.9' }),
+      device({ deviceId: 'd3', appVersion: '0.9.0' }),
+    ])
+    expect(outdated.map((d) => d.deviceId)).toEqual(['d2', 'd3'])
+  })
+
+  it('compares numerically, not as strings', () => {
+    // '0.9.0' > '0.54.1' lexicographically, which is the bug this guards.
+    const outdated = outdatedInstallations([
+      device({ deviceId: 'd1', appVersion: '0.9.0' }),
+      device({ deviceId: 'd2', appVersion: '0.54.1' }),
+    ])
+    expect(outdated.map((d) => d.deviceId)).toEqual(['d1'])
+  })
+
+  it('treats versions that compare equal as up to date', () => {
+    expect(
+      outdatedInstallations([
+        device({ deviceId: 'd1', appVersion: '0.54' }),
+        device({ deviceId: 'd2', appVersion: '0.54.0' }),
+      ]),
+    ).toEqual([])
+  })
+})
+
+describe('countBy', () => {
+  it('returns nothing for an empty fleet', () => {
+    expect(countBy([], 'platform')).toEqual([])
+  })
+
+  it('groups by platform, most common first', () => {
+    expect(
+      countBy(
+        [
+          device({ deviceId: 'd1', platform: 'darwin' }),
+          device({ deviceId: 'd2', platform: 'linux' }),
+          device({ deviceId: 'd3', platform: 'darwin' }),
+        ],
+        'platform',
+      ),
+    ).toEqual([
+      { value: 'darwin', count: 2 },
+      { value: 'linux', count: 1 },
+    ])
+  })
+
+  it('breaks a tie alphabetically so the order is stable between renders', () => {
+    expect(
+      countBy(
+        [
+          device({ deviceId: 'd1', arch: 'x64' }),
+          device({ deviceId: 'd2', arch: 'arm64' }),
+        ],
+        'arch',
+      ),
+    ).toEqual([
+      { value: 'arm64', count: 1 },
+      { value: 'x64', count: 1 },
+    ])
+  })
+
+  it('buckets a missing or blank value as unknown instead of dropping the device', () => {
+    const buckets = countBy(
+      [
+        device({ deviceId: 'd1', platform: null }),
+        device({ deviceId: 'd2', platform: '  ' }),
+        device({ deviceId: 'd3', platform: 'darwin' }),
+      ],
+      'platform',
+    )
+    expect(buckets).toEqual([
+      { value: UNKNOWN_VALUE, count: 2 },
+      { value: 'darwin', count: 1 },
+    ])
+    // The buckets always sum to the fleet size.
+    expect(buckets.reduce((n, b) => n + b.count, 0)).toBe(3)
+  })
+})
+
+describe('quietInstallations', () => {
+  const NOW = new Date('2026-07-28T10:00:00.000Z').getTime()
+  const DAY = 24 * 60 * 60 * 1000
+  const daysAgo = (n: number) => new Date(NOW - n * DAY).toISOString()
+
+  it('returns nothing for an empty fleet', () => {
+    expect(quietInstallations([], NOW)).toEqual([])
+  })
+
+  it('returns the devices unseen for longer than the threshold', () => {
+    const quiet = quietInstallations(
+      [
+        device({ deviceId: 'd1', lastSeenAt: daysAgo(1) }),
+        device({ deviceId: 'd2', lastSeenAt: daysAgo(30) }),
+        device({ deviceId: 'd3', lastSeenAt: daysAgo(90) }),
+      ],
+      NOW,
+    )
+    expect(quiet.map((d) => d.deviceId)).toEqual(['d2', 'd3'])
+  })
+
+  it('keeps a device seen exactly on the threshold out of the list', () => {
+    // The boundary is the difference between "quiet" and "reported this morning,
+    // a fortnight ago" — strictly older, so the threshold day itself is fine.
+    expect(quietInstallations([device({ lastSeenAt: daysAgo(QUIET_DAYS) })], NOW)).toEqual([])
+    expect(
+      quietInstallations([device({ deviceId: 'd9', lastSeenAt: daysAgo(QUIET_DAYS + 1) })], NOW),
+    ).toHaveLength(1)
+  })
+
+  it('does not treat a device last seen in the future as quiet', () => {
+    // Clock skew on the reporting machine, not an absent device.
+    expect(quietInstallations([device({ lastSeenAt: daysAgo(-2) })], NOW)).toEqual([])
+  })
+})

--- a/webapp/lib/admin.ts
+++ b/webapp/lib/admin.ts
@@ -1,4 +1,3 @@
-import { compareVersions, highestVersion } from './installations'
 import type { Role } from './orgs'
 import type { UserSettings } from './settings'
 import { getSupabase } from './supabase'
@@ -400,104 +399,21 @@ export async function listUserRepositories(userId: string): Promise<AdminReposit
   return (data as AdminRepositoryRpcRow[]).map(toRepository)
 }
 
-// ── Rollups (pure) ───────────────────────────────────────────────────────────
+// ── Rollups (pure) ─────────────────────────────────────────────
 
 /**
- * These four are deliberately pure and dependency-free — no Supabase, no React, no
- * Date.now() (the one that needs the clock takes it as an argument). They are the
- * only logic on the back-office that can be wrong in a way a screenshot would not
- * reveal, so they are unit-tested (`admin.test.ts`) rather than inlined into the
- * component that renders them.
+ * The four fleet rollups live in `./adminRollups`, which imports nothing but
+ * `./versions`. They are kept out of this module because the root vitest run
+ * covers `webapp/lib/**` while CI installs only the root's dependencies: a test
+ * importing from here would fail to resolve `@supabase/supabase-js` before
+ * running a single assertion. Re-exported so callers keep one import site.
  */
-
-export interface VersionBucket {
-  version: string
-  count: number
-}
-
-export interface CountBucket {
-  value: string
-  count: number
-}
-
-/** Which device-shape fields the breakdown can group on. */
-export type BreakdownKey = 'platform' | 'arch'
-
-/** Label used for a device that never reported a platform or an arch. */
-export const UNKNOWN_VALUE = 'unknown'
-
-/**
- * Devices per version, newest version first — the fleet histogram.
- *
- * Counts DEVICES, not users: "62% of the fleet is on 0.54.1" is a statement about
- * machines, and a user with two of them contributes twice because both need the
- * update. Ordering is by version rather than by count so the bars read as a
- * timeline and the tail of old builds stays on the same side of the chart between
- * releases.
- */
-export function bucketByVersion(installations: AdminInstallation[]): VersionBucket[] {
-  const counts = new Map<string, number>()
-  for (const i of installations) {
-    counts.set(i.appVersion, (counts.get(i.appVersion) ?? 0) + 1)
-  }
-  return [...counts.entries()]
-    .map(([version, count]) => ({ version, count }))
-    // compareVersions is coarse (numeric components only), so two spellings of
-    // the same version can tie; the string comparison keeps the order stable
-    // instead of leaving it to the sort implementation.
-    .sort((a, b) => compareVersions(b.version, a.version) || b.version.localeCompare(a.version))
-}
-
-/**
- * The devices not on the highest version any device reports.
- *
- * "Highest observed", not "latest released": nothing here knows what has shipped,
- * and a fleet where every machine is one release behind would report itself fully
- * up to date. That is the honest limit of this signal, and it is still the useful
- * one — it answers "who is behind the others", which is what a support question
- * asks. Empty in, empty out; a single-version fleet has no outdated devices.
- */
-export function outdatedInstallations(installations: AdminInstallation[]): AdminInstallation[] {
-  const highest = highestVersion(installations)
-  if (highest === null) return []
-  return installations.filter((i) => compareVersions(i.appVersion, highest) < 0)
-}
-
-/**
- * Devices grouped by `platform` or `arch`, most common first. A missing value
- * becomes `unknown` rather than being dropped, so the buckets always sum to the
- * fleet size — a breakdown that quietly omits rows invites the wrong conclusion.
- *
- * Ties break alphabetically, so two equal buckets do not swap places between
- * renders.
- */
-export function countBy(installations: AdminInstallation[], key: BreakdownKey): CountBucket[] {
-  const counts = new Map<string, number>()
-  for (const i of installations) {
-    const value = i[key]?.trim() || UNKNOWN_VALUE
-    counts.set(value, (counts.get(value) ?? 0) + 1)
-  }
-  return [...counts.entries()]
-    .map(([value, count]) => ({ value, count }))
-    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value))
-}
-
-/** A device unseen for this long is worth surfacing on its own. */
-export const QUIET_DAYS = 14
-
-/**
- * The devices that have not launched the app in `days`.
- *
- * `now` is a parameter rather than a `Date.now()` read so this stays pure like its
- * three siblings above — and so it is testable, which matters more here than for
- * any of them: a flipped comparison or a wrong unit renders as a plausible-looking
- * list of names, with nothing on screen to say it is wrong.
- */
-export function quietInstallations(
-  installations: AdminInstallation[],
-  now: number,
-  days = QUIET_DAYS,
-): AdminInstallation[] {
-  const cutoff = days * 24 * 60 * 60 * 1000
-  return installations.filter((i) => now - new Date(i.lastSeenAt).getTime() > cutoff)
-}
+export {
+  bucketByVersion,
+  countBy,
+  outdatedInstallations,
+  quietInstallations,
+  QUIET_DAYS,
+  UNKNOWN_VALUE,
+} from './adminRollups'
+export type { BreakdownKey, CountBucket, FleetDevice, VersionBucket } from './adminRollups'

--- a/webapp/lib/admin.ts
+++ b/webapp/lib/admin.ts
@@ -1,0 +1,503 @@
+import { compareVersions, highestVersion } from './installations'
+import type { Role } from './orgs'
+import type { UserSettings } from './settings'
+import { getSupabase } from './supabase'
+
+/**
+ * The platform back-office data layer — read-only, and narrow on purpose.
+ *
+ * Every read here goes through a `SECURITY DEFINER` RPC whose `returns table` is
+ * an explicit column allowlist (see
+ * `supabase/migrations/20260728090000_platform_admins.sql`). None of the
+ * underlying tables is readable from this role: `profiles`, `user_settings` and
+ * `app_installations` are own-rows-only on every verb and no policy was widened
+ * to add this feature, so `getSupabase().from('profiles')` would return the
+ * caller's own row and nothing else no matter who is asking. The RPC is not a
+ * convenience wrapper over a table read — it is the only path that exists.
+ *
+ * There is deliberately no write helper in this file. The back-office looks; it
+ * does not touch. Granting platform admin is a manual INSERT from the Supabase
+ * dashboard, because `platform_admins` grants `authenticated` nothing at all.
+ */
+
+// ── Shapes ───────────────────────────────────────────────────────────────────
+
+/** One row of the fleet list: a user plus the rollups shown next to them. */
+export interface AdminUser {
+  userId: string
+  email: string | null
+  createdAt: string | null
+  lastSignInAt: string | null
+  name: string | null
+  role: string | null
+  deviceCount: number
+  latestAppVersion: string | null
+  latestLastSeenAt: string | null
+  orgCount: number
+  agentCount: number
+  activeAgentCount: number
+}
+
+/**
+ * One DEVICE. The whole version story is per device, not per user: a person with
+ * a laptop on the current build and a desktop three versions behind is two rows
+ * here and one row (the most recent device) in `AdminUser`.
+ */
+export interface AdminInstallation {
+  userId: string
+  email: string | null
+  deviceId: string
+  deviceName: string | null
+  appVersion: string
+  platform: string | null
+  arch: string | null
+  lastSeenAt: string
+  appVersionUpdatedAt: string | null
+}
+
+/**
+ * All 17 `user_settings` columns, as the desktop app stores them. Every one is
+ * nullable and NULL is a third state distinct from false — it means the user
+ * never chose, and the app applies its own default. Nothing here normalises a
+ * null away: "never chose" is exactly what a support question needs to see.
+ *
+ * Extends the 10 fields `lib/settings.ts` already names (the ones the webapp lets
+ * a user edit) rather than restating them, so a column rename is one edit and not
+ * two camelCase lists that must silently agree. The 7 added below are the ones
+ * `UserSettings` deliberately omits: per-machine properties and transient view
+ * state, which the back-office reports precisely because it cannot edit them.
+ */
+export interface AdminUserSettings extends UserSettings {
+  usageCardMinimized: boolean | null
+  splitActive: boolean | null
+  spotlightEnabled: boolean | null
+  spotlightShortcut: string | null
+  autoStartAtLogin: boolean | null
+  atlassianIntegrationEnabled: boolean | null
+  syncClaudeTheme: boolean | null
+}
+
+/** Reading order and labels for the settings list. Also the field allowlist. */
+export const SETTING_LABELS: { field: keyof AdminUserSettings; label: string }[] = [
+  { field: 'theme', label: 'Theme' },
+  { field: 'language', label: 'Interface language' },
+  { field: 'syncClaudeTheme', label: 'Sync Claude Code theme' },
+  { field: 'launchMode', label: 'Claude Code launch mode' },
+  { field: 'usageCardEnabled', label: 'Usage card' },
+  { field: 'usageCardMinimized', label: 'Usage card minimized' },
+  { field: 'usageLogsEnabled', label: 'Usage logs (GDPR opt-in)' },
+  { field: 'dailyDigestEnabled', label: 'Daily digest' },
+  { field: 'splitEnabled', label: 'Split view' },
+  { field: 'splitActive', label: 'Split view active' },
+  { field: 'prReviewsEnabled', label: 'PR review watcher' },
+  { field: 'prReviewsPollIntervalMs', label: 'PR review poll interval' },
+  { field: 'prReviewsAutoLaunchSkills', label: 'PR review auto-launch skills' },
+  { field: 'spotlightEnabled', label: 'Spotlight' },
+  { field: 'spotlightShortcut', label: 'Spotlight shortcut' },
+  { field: 'autoStartAtLogin', label: 'Start at login' },
+  { field: 'atlassianIntegrationEnabled', label: 'Atlassian integration' },
+]
+
+/** The drill-down header: who they are, plus their whole settings row. */
+export interface AdminUserDetail {
+  userId: string
+  email: string | null
+  createdAt: string | null
+  lastSignInAt: string | null
+  name: string | null
+  role: string | null
+  settings: AdminUserSettings
+}
+
+export interface AdminOrg {
+  orgId: string
+  name: string
+  role: Role
+  archivedAt: string | null
+  createdAt: string | null
+}
+
+export interface AdminAgent {
+  id: string
+  name: string
+  ticketId: string | null
+  status: string | null
+  branchName: string | null
+  baseBranch: string | null
+  orgId: string | null
+  shared: boolean
+  archivedAt: string | null
+  createdAt: string | null
+  repoNames: string[]
+}
+
+export interface AdminRepository {
+  id: string
+  name: string
+  orgId: string | null
+  orgName: string | null
+  keywords: string[]
+  createdAt: string | null
+}
+
+// ── RPC row shapes (snake_case, mirroring each returns table) ─────────────────
+
+interface AdminUserRpcRow {
+  user_id: string
+  email: string | null
+  created_at: string | null
+  last_sign_in_at: string | null
+  name: string | null
+  role: string | null
+  device_count: number
+  latest_app_version: string | null
+  latest_last_seen_at: string | null
+  org_count: number
+  agent_count: number
+  active_agent_count: number
+}
+
+interface AdminInstallationRpcRow {
+  user_id: string
+  email: string | null
+  device_id: string
+  device_name: string | null
+  app_version: string
+  platform: string | null
+  arch: string | null
+  last_seen_at: string
+  app_version_updated_at: string | null
+}
+
+interface AdminUserDetailRpcRow {
+  user_id: string
+  email: string | null
+  created_at: string | null
+  last_sign_in_at: string | null
+  name: string | null
+  role: string | null
+  usage_card_enabled: boolean | null
+  usage_card_minimized: boolean | null
+  usage_logs_enabled: boolean | null
+  daily_digest_enabled: boolean | null
+  split_enabled: boolean | null
+  split_active: boolean | null
+  pr_reviews_enabled: boolean | null
+  pr_reviews_poll_interval_ms: number | null
+  pr_reviews_auto_launch_skills: boolean | null
+  spotlight_enabled: boolean | null
+  spotlight_shortcut: string | null
+  auto_start_at_login: boolean | null
+  launch_mode: string | null
+  atlassian_integration_enabled: boolean | null
+  theme: string | null
+  language: string | null
+  sync_claude_theme: boolean | null
+}
+
+interface AdminOrgRpcRow {
+  org_id: string
+  name: string
+  role: Role
+  archived_at: string | null
+  created_at: string | null
+}
+
+interface AdminAgentRpcRow {
+  id: string
+  name: string
+  ticket_id: string | null
+  status: string | null
+  branch_name: string | null
+  base_branch: string | null
+  org_id: string | null
+  shared: boolean
+  archived_at: string | null
+  created_at: string | null
+  repo_names: string[] | null
+}
+
+interface AdminRepositoryRpcRow {
+  id: string
+  name: string
+  org_id: string | null
+  org_name: string | null
+  keywords: string[] | null
+  created_at: string | null
+}
+
+// ── Mappers ──────────────────────────────────────────────────────────────────
+
+function toUser(r: AdminUserRpcRow): AdminUser {
+  return {
+    userId: r.user_id,
+    email: r.email,
+    createdAt: r.created_at,
+    lastSignInAt: r.last_sign_in_at,
+    name: r.name,
+    role: r.role,
+    deviceCount: r.device_count,
+    latestAppVersion: r.latest_app_version,
+    latestLastSeenAt: r.latest_last_seen_at,
+    orgCount: r.org_count,
+    agentCount: r.agent_count,
+    activeAgentCount: r.active_agent_count,
+  }
+}
+
+function toInstallation(r: AdminInstallationRpcRow): AdminInstallation {
+  return {
+    userId: r.user_id,
+    email: r.email,
+    deviceId: r.device_id,
+    deviceName: r.device_name,
+    appVersion: r.app_version,
+    platform: r.platform,
+    arch: r.arch,
+    lastSeenAt: r.last_seen_at,
+    appVersionUpdatedAt: r.app_version_updated_at,
+  }
+}
+
+function toUserDetail(r: AdminUserDetailRpcRow): AdminUserDetail {
+  return {
+    userId: r.user_id,
+    email: r.email,
+    createdAt: r.created_at,
+    lastSignInAt: r.last_sign_in_at,
+    name: r.name,
+    role: r.role,
+    settings: {
+      usageCardEnabled: r.usage_card_enabled,
+      usageCardMinimized: r.usage_card_minimized,
+      usageLogsEnabled: r.usage_logs_enabled,
+      dailyDigestEnabled: r.daily_digest_enabled,
+      splitEnabled: r.split_enabled,
+      splitActive: r.split_active,
+      prReviewsEnabled: r.pr_reviews_enabled,
+      prReviewsPollIntervalMs: r.pr_reviews_poll_interval_ms,
+      prReviewsAutoLaunchSkills: r.pr_reviews_auto_launch_skills,
+      spotlightEnabled: r.spotlight_enabled,
+      spotlightShortcut: r.spotlight_shortcut,
+      autoStartAtLogin: r.auto_start_at_login,
+      launchMode: r.launch_mode,
+      atlassianIntegrationEnabled: r.atlassian_integration_enabled,
+      theme: r.theme,
+      language: r.language,
+      syncClaudeTheme: r.sync_claude_theme,
+    },
+  }
+}
+
+function toOrg(r: AdminOrgRpcRow): AdminOrg {
+  return {
+    orgId: r.org_id,
+    name: r.name,
+    role: r.role,
+    archivedAt: r.archived_at,
+    createdAt: r.created_at,
+  }
+}
+
+function toAgent(r: AdminAgentRpcRow): AdminAgent {
+  return {
+    id: r.id,
+    name: r.name,
+    ticketId: r.ticket_id,
+    status: r.status,
+    branchName: r.branch_name,
+    baseBranch: r.base_branch,
+    orgId: r.org_id,
+    shared: r.shared,
+    archivedAt: r.archived_at,
+    createdAt: r.created_at,
+    repoNames: r.repo_names ?? [],
+  }
+}
+
+function toRepository(r: AdminRepositoryRpcRow): AdminRepository {
+  return {
+    id: r.id,
+    name: r.name,
+    orgId: r.org_id,
+    orgName: r.org_name,
+    keywords: r.keywords ?? [],
+    createdAt: r.created_at,
+  }
+}
+
+// ── Reads ────────────────────────────────────────────────────────────────────
+
+/**
+ * Whether the signed-in user operates the platform.
+ *
+ * The database is the authority: every `admin_*` RPC re-checks this itself and
+ * raises, so a caller who forced this to true client-side would still get nothing
+ * back. That is what makes it safe to use for hiding the nav entry — the answer
+ * gates DISCOVERY, not access.
+ *
+ * Falls back to false on any error, which is the safe direction: a network blip
+ * hides an admin's own back-office rather than showing a stranger's.
+ */
+export async function isPlatformAdmin(): Promise<boolean> {
+  const { data, error } = await getSupabase().rpc('is_platform_admin')
+  if (error) return false
+  return data === true
+}
+
+/** Every user, with their app version resolved from their most recent device. */
+export async function listUsers(): Promise<AdminUser[]> {
+  const { data, error } = await getSupabase().rpc('admin_list_users')
+  if (error || !data) return []
+  return (data as AdminUserRpcRow[]).map(toUser)
+}
+
+/**
+ * Devices. Omit `userId` for the whole fleet — which is one round trip for the
+ * version histogram, the outdated list, the platform breakdown and the
+ * inactivity signal, since all four are rollups of the same rows.
+ */
+export async function listInstallations(userId?: string): Promise<AdminInstallation[]> {
+  const { data, error } = await getSupabase().rpc('admin_list_installations', {
+    p_user_id: userId ?? null,
+  })
+  if (error || !data) return []
+  return (data as AdminInstallationRpcRow[]).map(toInstallation)
+}
+
+/**
+ * One user's identity and settings, or null when the id is unknown. The RPC is
+ * driven off `auth.users`, so a user who never wrote a profile or a settings row
+ * still comes back — with nulls, which is the honest answer.
+ */
+export async function getUser(userId: string): Promise<AdminUserDetail | null> {
+  const { data, error } = await getSupabase().rpc('admin_get_user', { p_user_id: userId })
+  if (error || !data) return null
+  const rows = data as AdminUserDetailRpcRow[]
+  return rows.length > 0 ? toUserDetail(rows[0]) : null
+}
+
+/** The orgs a user belongs to, archived ones included (`archivedAt` says which). */
+export async function listUserOrgs(userId: string): Promise<AdminOrg[]> {
+  const { data, error } = await getSupabase().rpc('admin_list_user_orgs', { p_user_id: userId })
+  if (error || !data) return []
+  return (data as AdminOrgRpcRow[]).map(toOrg)
+}
+
+/** The agents a user owns, archived ones included, newest first. */
+export async function listUserAgents(userId: string): Promise<AdminAgent[]> {
+  const { data, error } = await getSupabase().rpc('admin_list_user_agents', { p_user_id: userId })
+  if (error || !data) return []
+  return (data as AdminAgentRpcRow[]).map(toAgent)
+}
+
+/** The repositories a user can reach: their own, plus their orgs' team repos. */
+export async function listUserRepositories(userId: string): Promise<AdminRepository[]> {
+  const { data, error } = await getSupabase().rpc('admin_list_user_repositories', {
+    p_user_id: userId,
+  })
+  if (error || !data) return []
+  return (data as AdminRepositoryRpcRow[]).map(toRepository)
+}
+
+// ── Rollups (pure) ───────────────────────────────────────────────────────────
+
+/**
+ * These four are deliberately pure and dependency-free — no Supabase, no React, no
+ * Date.now() (the one that needs the clock takes it as an argument). They are the
+ * only logic on the back-office that can be wrong in a way a screenshot would not
+ * reveal, so they are unit-tested (`admin.test.ts`) rather than inlined into the
+ * component that renders them.
+ */
+
+export interface VersionBucket {
+  version: string
+  count: number
+}
+
+export interface CountBucket {
+  value: string
+  count: number
+}
+
+/** Which device-shape fields the breakdown can group on. */
+export type BreakdownKey = 'platform' | 'arch'
+
+/** Label used for a device that never reported a platform or an arch. */
+export const UNKNOWN_VALUE = 'unknown'
+
+/**
+ * Devices per version, newest version first — the fleet histogram.
+ *
+ * Counts DEVICES, not users: "62% of the fleet is on 0.54.1" is a statement about
+ * machines, and a user with two of them contributes twice because both need the
+ * update. Ordering is by version rather than by count so the bars read as a
+ * timeline and the tail of old builds stays on the same side of the chart between
+ * releases.
+ */
+export function bucketByVersion(installations: AdminInstallation[]): VersionBucket[] {
+  const counts = new Map<string, number>()
+  for (const i of installations) {
+    counts.set(i.appVersion, (counts.get(i.appVersion) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .map(([version, count]) => ({ version, count }))
+    // compareVersions is coarse (numeric components only), so two spellings of
+    // the same version can tie; the string comparison keeps the order stable
+    // instead of leaving it to the sort implementation.
+    .sort((a, b) => compareVersions(b.version, a.version) || b.version.localeCompare(a.version))
+}
+
+/**
+ * The devices not on the highest version any device reports.
+ *
+ * "Highest observed", not "latest released": nothing here knows what has shipped,
+ * and a fleet where every machine is one release behind would report itself fully
+ * up to date. That is the honest limit of this signal, and it is still the useful
+ * one — it answers "who is behind the others", which is what a support question
+ * asks. Empty in, empty out; a single-version fleet has no outdated devices.
+ */
+export function outdatedInstallations(installations: AdminInstallation[]): AdminInstallation[] {
+  const highest = highestVersion(installations)
+  if (highest === null) return []
+  return installations.filter((i) => compareVersions(i.appVersion, highest) < 0)
+}
+
+/**
+ * Devices grouped by `platform` or `arch`, most common first. A missing value
+ * becomes `unknown` rather than being dropped, so the buckets always sum to the
+ * fleet size — a breakdown that quietly omits rows invites the wrong conclusion.
+ *
+ * Ties break alphabetically, so two equal buckets do not swap places between
+ * renders.
+ */
+export function countBy(installations: AdminInstallation[], key: BreakdownKey): CountBucket[] {
+  const counts = new Map<string, number>()
+  for (const i of installations) {
+    const value = i[key]?.trim() || UNKNOWN_VALUE
+    counts.set(value, (counts.get(value) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value))
+}
+
+/** A device unseen for this long is worth surfacing on its own. */
+export const QUIET_DAYS = 14
+
+/**
+ * The devices that have not launched the app in `days`.
+ *
+ * `now` is a parameter rather than a `Date.now()` read so this stays pure like its
+ * three siblings above — and so it is testable, which matters more here than for
+ * any of them: a flipped comparison or a wrong unit renders as a plausible-looking
+ * list of names, with nothing on screen to say it is wrong.
+ */
+export function quietInstallations(
+  installations: AdminInstallation[],
+  now: number,
+  days = QUIET_DAYS,
+): AdminInstallation[] {
+  const cutoff = days * 24 * 60 * 60 * 1000
+  return installations.filter((i) => now - new Date(i.lastSeenAt).getTime() > cutoff)
+}

--- a/webapp/lib/adminRollups.test.ts
+++ b/webapp/lib/adminRollups.test.ts
@@ -6,12 +6,17 @@ import {
   QUIET_DAYS,
   quietInstallations,
   UNKNOWN_VALUE,
-  type AdminInstallation,
-} from './admin'
+  type FleetDevice,
+} from './adminRollups'
 
 /**
  * The back-office's four rollups: arithmetic over the fleet, where being wrong
  * looks exactly like being right.
+ *
+ * Imported from `./adminRollups` rather than `./admin` on purpose. This suite runs
+ * in the ROOT vitest project, which does not install `webapp/`'s dependencies, so
+ * reaching `lib/admin.ts` — and through it `lib/supabase.ts` — fails to resolve
+ * `@supabase/supabase-js` before a single assertion runs.
  *
  * Everything else in `lib/admin.ts` is an RPC call and a field rename. Those are
  * NOT type-checked — the Supabase client is untyped here (no generated
@@ -21,17 +26,18 @@ import {
  * the pgTAP suite is what pins the SQL side.
  */
 
-function device(overrides: Partial<AdminInstallation> = {}): AdminInstallation {
+/** `deviceId` is not read by any rollup; it is here so assertions can name a row. */
+interface TestDevice extends FleetDevice {
+  deviceId: string
+}
+
+function device(overrides: Partial<TestDevice> = {}): TestDevice {
   return {
-    userId: 'u1',
-    email: 'u1@example.com',
     deviceId: 'd1',
-    deviceName: 'mbp',
     appVersion: '0.54.1',
     platform: 'darwin',
     arch: 'arm64',
     lastSeenAt: '2026-07-28T10:00:00.000Z',
-    appVersionUpdatedAt: '2026-07-20T10:00:00.000Z',
     ...overrides,
   }
 }

--- a/webapp/lib/adminRollups.ts
+++ b/webapp/lib/adminRollups.ts
@@ -1,0 +1,122 @@
+/**
+ * The back-office's four fleet rollups.
+ *
+ * Deliberately free of any Supabase import so it stays a pure, testable module —
+ * the same reason `teamRows.ts` is, and a load-bearing one here: the root vitest
+ * run includes `webapp/lib/**` but CI installs only the root's dependencies, so a
+ * test that reaches `lib/supabase.ts` fails to resolve `@supabase/supabase-js`
+ * before a single assertion runs. `lib/admin.ts` re-exports everything below, so
+ * callers keep importing from there.
+ *
+ * These four are the only logic on the back-office that can be wrong in a way a
+ * screenshot would not reveal, which is why they are unit-tested
+ * (`adminRollups.test.ts`) rather than inlined into the components that render
+ * them. No React, no Supabase, and no `Date.now()` — the one that needs the clock
+ * takes it as an argument.
+ */
+
+import { compareVersions, highestVersion } from './versions'
+
+/**
+ * The device fields these rollups actually read. Structurally typed and generic
+ * so `AdminInstallation` (or anything else carrying these four) goes in and comes
+ * back out unchanged, without this module importing the Supabase-backed type.
+ */
+export interface FleetDevice {
+  appVersion: string
+  platform: string | null
+  arch: string | null
+  lastSeenAt: string
+}
+
+export interface VersionBucket {
+  version: string
+  count: number
+}
+
+export interface CountBucket {
+  value: string
+  count: number
+}
+
+/** Which device-shape fields the breakdown can group on. */
+export type BreakdownKey = 'platform' | 'arch'
+
+/** Label used for a device that never reported a platform or an arch. */
+export const UNKNOWN_VALUE = 'unknown'
+
+/**
+ * Devices per version, newest version first — the fleet histogram.
+ *
+ * Counts DEVICES, not users: "62% of the fleet is on 0.54.1" is a statement about
+ * machines, and a user with two of them contributes twice because both need the
+ * update. Ordering is by version rather than by count so the bars read as a
+ * timeline and the tail of old builds stays on the same side of the chart between
+ * releases.
+ */
+export function bucketByVersion(installations: FleetDevice[]): VersionBucket[] {
+  const counts = new Map<string, number>()
+  for (const i of installations) {
+    counts.set(i.appVersion, (counts.get(i.appVersion) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .map(([version, count]) => ({ version, count }))
+    // compareVersions is coarse (numeric components only), so two spellings of
+    // the same version can tie; the string comparison keeps the order stable
+    // instead of leaving it to the sort implementation.
+    .sort((a, b) => compareVersions(b.version, a.version) || b.version.localeCompare(a.version))
+}
+
+/**
+ * The devices not on the highest version any device reports.
+ *
+ * "Highest observed", not "latest released": nothing here knows what has shipped,
+ * and a fleet where every machine is one release behind would report itself fully
+ * up to date. That is the honest limit of this signal, and it is still the useful
+ * one — it answers "who is behind the others", which is what a support question
+ * asks. Empty in, empty out; a single-version fleet has no outdated devices.
+ */
+export function outdatedInstallations<T extends FleetDevice>(installations: T[]): T[] {
+  const highest = highestVersion(installations)
+  if (highest === null) return []
+  return installations.filter((i) => compareVersions(i.appVersion, highest) < 0)
+}
+
+/**
+ * Devices grouped by `platform` or `arch`, most common first. A missing value
+ * becomes `unknown` rather than being dropped, so the buckets always sum to the
+ * fleet size — a breakdown that quietly omits rows invites the wrong conclusion.
+ *
+ * Ties break alphabetically, so two equal buckets do not swap places between
+ * renders.
+ */
+export function countBy(installations: FleetDevice[], key: BreakdownKey): CountBucket[] {
+  const counts = new Map<string, number>()
+  for (const i of installations) {
+    const value = i[key]?.trim() || UNKNOWN_VALUE
+    counts.set(value, (counts.get(value) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value))
+}
+
+/** A device unseen for this long is worth surfacing on its own. */
+export const QUIET_DAYS = 14
+
+/**
+ * The devices that have not launched the app in `days`.
+ *
+ * `now` is a parameter rather than a `Date.now()` read so this stays pure like its
+ * three siblings above — and so it is testable, which matters more here than for
+ * any of them: a flipped comparison or a wrong unit renders as a plausible-looking
+ * list of names, with nothing on screen to say it is wrong.
+ */
+export function quietInstallations<T extends FleetDevice>(
+  installations: T[],
+  now: number,
+  days = QUIET_DAYS,
+): T[] {
+  const cutoff = days * 24 * 60 * 60 * 1000
+  return installations.filter((i) => now - new Date(i.lastSeenAt).getTime() > cutoff)
+}

--- a/webapp/lib/installations.ts
+++ b/webapp/lib/installations.ts
@@ -103,35 +103,9 @@ export function formatDevicePlatform(device: { platform: string | null; arch: st
 }
 
 /**
- * Compares two version strings by their numeric components. Coarse on purpose:
- * a pre-release suffix (`0.54.1-beta.2`) compares as its leading number, which
- * is enough to answer "is this machine behind another one?" — the only question
- * asked of it.
- *
- * Exported because the back-office (`lib/admin.ts`) asks the same question of the
- * whole fleet. A second implementation there would be the same coarseness decided
- * twice, and the two would drift the first time one of them learned about
- * pre-release suffixes.
+ * Version comparison lives in `./versions`, which imports nothing — the root
+ * vitest run covers `webapp/lib/**` without installing `webapp/`'s dependencies,
+ * so anything a test reaches must not pull in the Supabase client this module
+ * imports. Re-exported here because this is where callers already look for it.
  */
-export function compareVersions(a: string, b: string): number {
-  const pa = a.split('.')
-  const pb = b.split('.')
-  for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
-    const na = parseInt(pa[i] ?? '0', 10) || 0
-    const nb = parseInt(pb[i] ?? '0', 10) || 0
-    if (na !== nb) return na - nb
-  }
-  return 0
-}
-
-/**
- * The newest version any of these machines runs, or null when there are none.
- *
- * Structurally typed for the same reason `compareVersions` is exported: the
- * back-office asks this of the whole fleet (`AdminInstallation`) and `/application`
- * asks it of one user's machines (`Installation`). One answer, one definition.
- */
-export function highestVersion(installs: { appVersion: string }[]): string | null {
-  if (installs.length === 0) return null
-  return installs.reduce((best, i) => (compareVersions(i.appVersion, best) > 0 ? i.appVersion : best), installs[0].appVersion)
-}
+export { compareVersions, highestVersion } from './versions'

--- a/webapp/lib/installations.ts
+++ b/webapp/lib/installations.ts
@@ -56,6 +56,20 @@ const MINUTE = 60_000
 const HOUR = 60 * MINUTE
 const DAY = 24 * HOUR
 
+/**
+ * Absolute date, for the lifecycle moments where "3 months ago" reads as vague.
+ * Null or unparseable input renders as an em dash — the back-office shows a lot of
+ * nullable timestamps, and "—" is the honest label for "never".
+ *
+ * `formatRelative` falls through to this once a date is too old for a relative
+ * label, so the app has one absolute date format rather than one per caller.
+ */
+export function formatAbsoluteDate(iso: string | null): string {
+  const t = iso === null ? NaN : new Date(iso).getTime()
+  if (Number.isNaN(t)) return '—'
+  return new Date(t).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
 /** Coarse "time ago" label. Precision beyond a day is not useful here. */
 export function formatRelative(iso: string): string {
   const then = new Date(iso).getTime()
@@ -74,12 +88,18 @@ export function formatRelative(iso: string): string {
   }
   const d = Math.floor(diff / DAY)
   if (d < 30) return `${d} day${d === 1 ? '' : 's'} ago`
-  return new Date(then).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+  return formatAbsoluteDate(iso)
 }
 
-/** "darwin · arm64" — omits whichever half is missing. */
-export function formatDevicePlatform(install: Installation): string {
-  return [install.platform, install.arch].filter(Boolean).join(' · ')
+/**
+ * "darwin · arm64" — omits whichever half is missing.
+ *
+ * Takes the two fields it reads rather than an `Installation`, so the back-office's
+ * `AdminInstallation` (same device, a different set of columns) shares the
+ * separator and the omit-the-missing-half rule instead of restating them.
+ */
+export function formatDevicePlatform(device: { platform: string | null; arch: string | null }): string {
+  return [device.platform, device.arch].filter(Boolean).join(' · ')
 }
 
 /**
@@ -87,8 +107,13 @@ export function formatDevicePlatform(install: Installation): string {
  * a pre-release suffix (`0.54.1-beta.2`) compares as its leading number, which
  * is enough to answer "is this machine behind another one?" — the only question
  * asked of it.
+ *
+ * Exported because the back-office (`lib/admin.ts`) asks the same question of the
+ * whole fleet. A second implementation there would be the same coarseness decided
+ * twice, and the two would drift the first time one of them learned about
+ * pre-release suffixes.
  */
-function compareVersions(a: string, b: string): number {
+export function compareVersions(a: string, b: string): number {
   const pa = a.split('.')
   const pb = b.split('.')
   for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
@@ -99,8 +124,14 @@ function compareVersions(a: string, b: string): number {
   return 0
 }
 
-/** The newest version any of these machines runs, or null when there are none. */
-export function highestVersion(installs: Installation[]): string | null {
+/**
+ * The newest version any of these machines runs, or null when there are none.
+ *
+ * Structurally typed for the same reason `compareVersions` is exported: the
+ * back-office asks this of the whole fleet (`AdminInstallation`) and `/application`
+ * asks it of one user's machines (`Installation`). One answer, one definition.
+ */
+export function highestVersion(installs: { appVersion: string }[]): string | null {
   if (installs.length === 0) return null
   return installs.reduce((best, i) => (compareVersions(i.appVersion, best) > 0 ? i.appVersion : best), installs[0].appVersion)
 }

--- a/webapp/lib/session.ts
+++ b/webapp/lib/session.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import type { Session } from '@supabase/supabase-js'
+import { isPlatformAdmin } from './admin'
 import { getSupabase } from './supabase'
 
 /** Where each half of the guard sends people. */
@@ -33,26 +34,40 @@ export function useSession() {
 }
 
 /**
+ * The redirect half of every guard on this page, expressed once: when `ok` is
+ * definitively false the visitor is sent to `destination`, and `pending` stays true
+ * through the redirect so a caller rendering a placeholder never paints a frame of
+ * the page it is about to leave — no login form flashing at someone already signed
+ * in, no back-office chrome for someone on their way to the dashboard.
+ *
+ * `undefined` means "not known yet", which is why the condition is tri-state rather
+ * than a boolean: "not an admin" and "we have not asked yet" both suppress the
+ * page, but only one of them redirects.
+ */
+function useRedirectUnless(ok: boolean | undefined, destination: string) {
+  const router = useRouter()
+  const rejected = ok === false
+
+  useEffect(() => {
+    if (!rejected) return
+    router.replace(destination)
+  }, [rejected, destination, router])
+
+  return ok === undefined || rejected
+}
+
+/**
  * Sends the visitor away when the session doesn't match what the page is for,
  * in either direction: signed-in pages bounce guests to the login page, and the
  * login page bounces signed-in users to the dashboard.
- *
- * `pending` covers both "still reading the session" and "redirect in flight", so
- * a caller that renders a placeholder while it is true never paints the wrong
- * page for a frame — no login form flashing at someone already signed in.
  */
 function useSessionGuard(requireSession: boolean) {
-  const router = useRouter()
   const { session, loading } = useSession()
 
-  const mismatched = !loading && (requireSession ? !session : !!session)
+  const matches = loading ? undefined : requireSession === !!session
+  const pending = useRedirectUnless(matches, requireSession ? LOGIN_PATH : HOME_PATH)
 
-  useEffect(() => {
-    if (!mismatched) return
-    router.replace(requireSession ? LOGIN_PATH : HOME_PATH)
-  }, [mismatched, requireSession, router])
-
-  return { session, pending: loading || mismatched }
+  return { session, pending }
 }
 
 /** Guard for signed-in pages: no session → off to the login page. */
@@ -63,4 +78,47 @@ export function useRequireSession() {
 /** Guard for the login page: already signed in → off to the dashboard. */
 export function useRequireGuest() {
   return useSessionGuard(false)
+}
+
+/**
+ * Guard for the platform back-office: a session AND a `platform_admins` row.
+ * Anyone else is sent to the dashboard — not to the login page, since they are
+ * signed in perfectly legitimately, just not for this.
+ *
+ * Two checks, ONE `pending` flag. Exposing them separately would let a caller
+ * render the page during the window where the session has resolved but the admin
+ * answer has not, which is a frame of back-office chrome for someone who is about
+ * to be redirected. `pending` stays true until both have landed.
+ *
+ * This is a discovery gate, not the access control. Every `admin_*` RPC re-checks
+ * `is_platform_admin()` in the database and raises, so defeating this hook in the
+ * console gets you an empty page and a row of errors — which is why it is safe to
+ * decide it client-side at all.
+ */
+export function useRequirePlatformAdmin() {
+  const { session, pending: sessionPending } = useRequireSession()
+  // undefined = not asked yet (the question needs a session first).
+  const [admin, setAdmin] = useState<boolean | undefined>(undefined)
+
+  // Keyed on the user id, not the session object: a token refresh hands back a new
+  // object for the same person, and re-asking on every refresh would be a round
+  // trip for an answer that cannot have changed. A DIFFERENT id, on the other hand,
+  // must drop the previous person's answer rather than render the page with it.
+  const userId = session?.user.id
+
+  useEffect(() => {
+    if (!userId) return
+    let cancelled = false
+    setAdmin(undefined)
+    isPlatformAdmin().then((ok) => {
+      if (!cancelled) setAdmin(ok)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [userId])
+
+  const adminPending = useRedirectUnless(admin, HOME_PATH)
+
+  return { session, pending: sessionPending || adminPending }
 }

--- a/webapp/lib/versions.ts
+++ b/webapp/lib/versions.ts
@@ -1,0 +1,46 @@
+/**
+ * Version comparison for app builds reported by the desktop app.
+ *
+ * Deliberately free of any Supabase import so it stays a pure, testable module —
+ * same reason `teamRows.ts` is. `lib/installations.ts` re-exports both functions,
+ * so nothing that already imports them from there has to change; the split exists
+ * so `lib/adminRollups.ts` can reach them without dragging the Supabase client
+ * into the root vitest run, which does not install `webapp/`'s dependencies.
+ */
+
+/**
+ * Compares two version strings by their numeric components. Coarse on purpose:
+ * a pre-release suffix (`0.54.1-beta.2`) compares as its leading number, which
+ * is enough to answer "is this machine behind another one?" — the only question
+ * asked of it.
+ *
+ * One definition, because the back-office asks the same question of the whole
+ * fleet as `/application` does of one user's machines. A second implementation
+ * would be the same coarseness decided twice, and the two would drift the first
+ * time one of them learned about pre-release suffixes.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.')
+  const pb = b.split('.')
+  for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
+    const na = parseInt(pa[i] ?? '0', 10) || 0
+    const nb = parseInt(pb[i] ?? '0', 10) || 0
+    if (na !== nb) return na - nb
+  }
+  return 0
+}
+
+/**
+ * The newest version any of these machines runs, or null when there are none.
+ *
+ * Structurally typed for the same reason `compareVersions` is shared: the
+ * back-office asks this of the whole fleet (`AdminInstallation`) and
+ * `/application` asks it of one user's machines (`Installation`).
+ */
+export function highestVersion(installs: { appVersion: string }[]): string | null {
+  if (installs.length === 0) return null
+  return installs.reduce(
+    (best, i) => (compareVersions(i.appVersion, best) > 0 ? i.appVersion : best),
+    installs[0].appVersion,
+  )
+}


### PR DESCRIPTION
## Description

Adds a **platform-level** admin identity and a read-only back-office listing every user, the app version each of their devices runs, their settings, agents and organizations.

Access to cross-user data goes through **6 narrow `SECURITY DEFINER` RPCs**, each declaring an explicit `returns table (...)` so the exposed column surface is reviewable in this diff. **No existing RLS policy is modified** — the alternative (appending `or is_platform_admin()` to the `profiles` / `user_settings` / `app_installations` policies) was rejected because it would expose every column of those tables forever, including `profiles.free_text`, with no review step.

The admin identity is a separate table rather than a boolean on `profiles`/`user_settings`: those are user-writable, so a flag there would put privilege escalation inside a write path the user already controls.

## Related Issue

Fixes #153

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

**`supabase/migrations/20260728090000_platform_admins.sql`** (new)

- `public.platform_admins (user_id)` — RLS enabled, **no policy**, plus an explicit `revoke all ... from anon, authenticated`. The revoke is the load-bearing half: Supabase's default privileges grant `all` on every new `public` table to those roles, so RLS-with-no-policy alone would still leave `authenticated` holding `INSERT`. Answering "can a signed-in user grant themselves platform admin?" at the GRANT layer means no policy added later can re-open it.
- `public.is_platform_admin()` — `language sql`, `security definer`, `stable`, locked `search_path`; same shape as `is_org_member()` / `is_org_admin()`.
- 6 read-only RPCs, all mirroring the `list_org_members` template (locked `search_path`, `auth.uid()` guard, then the admin guard, both via bare `raise exception`):
  - `admin_list_users()` — the fleet list. Drives off `auth.users` with `left join lateral` aggregates, **not** off `profiles`/`user_settings`/`app_installations`: driving off any of those would silently omit users who never wrote that row, and a back-office showing "most" users is worse than none because nothing on screen says which are missing.
  - `admin_list_installations(p_user_id uuid default null)` — one row per device; `null` = whole fleet, set = one user. Serves the histogram, the outdated list, the platform/arch breakdown, the inactivity signal *and* the drill-down.
  - `admin_get_user(uuid)`, `admin_list_user_orgs(uuid)`, `admin_list_user_agents(uuid)` (archived included), `admin_list_user_repositories(uuid)`.
- `revoke execute ... from public, anon` — one word more than the rest of the repo does. Supabase also sets default privileges `on functions` to `anon`, and revoking from `PUBLIC` does **not** remove an explicit grant. Verified by control experiment (see Additional Notes).
- Column allowlist: `profiles.free_text`, `technical_level`, `communication_style` and `languages` are returned by **no** function.

**`supabase/tests/platform_admin.test.sql`** (new) — pgTAP, 38 assertions.

**webapp**

- `lib/admin.ts` (new) — RPC wrappers with `…RpcRow` interfaces + mappers, following `lib/orgs.ts`. Plus four pure rollups (`bucketByVersion`, `outdatedInstallations`, `countBy`, `quietInstallations`) kept dependency-free so vitest covers them.
- `lib/admin.test.ts` (new) — 17 unit tests on those rollups, including empty input, version ties and a future-dated device.
- `app/admin/page.tsx` (new) — fleet view. Version histogram per device (Tailwind divs, no chart library added), devices on an outdated version, platform/arch breakdown, quiet devices, and a user list linking to the drill-down.
- `app/admin/[userId]/page.tsx` (new) — read-only drill-down: profile, the 17 settings, devices with per-device version and `app_version_updated_at`, orgs with role, agents including archived, repositories.
- `lib/session.ts` — adds `useRequirePlatformAdmin()`. The redirect + `pending` mechanism it shares with `useSessionGuard` was factored into `useRedirectUnless()`, so the "never paint a frame of the page you're leaving" invariant lives in one place.
- `components/TopNav.tsx` — the `Admin` entry is filtered out for non-admins. `TopNav` asks `is_platform_admin()` itself; `AppShell` and the 5 pages that render it are untouched.
- `lib/installations.ts` — `compareVersions` exported, `highestVersion` / `formatDevicePlatform` widened structurally, `formatAbsoluteDate` extracted, so the new pages reuse them instead of re-deriving "newest version" two more ways.

**Docs** — `supabase/README.md` documents the platform exception in `## Security model` (which asserted "not even org admins get a read path"), corrects the "goes through the service role" claim, and gives `platform_admins` its own line in `## Tables` since it is neither org-scoped nor own-rows. `webapp/README.md` lists the two new routes and the 6 RPCs.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

`npm test` — 40 files, 516 tests pass. `npm run typecheck` and `npm run lint` in `webapp/` — clean. `npm run lint` at the root — 0 errors (3 pre-existing `no-explicit-any` warnings in `desktop/src/`, untouched by this PR).

`supabase test db` could **not** be run: the local Supabase stack refuses to start on a pre-existing data-volume version mismatch (`data directory was initialized by PostgreSQL version 17, which is not compatible with this version 15.8`) — unrelated to this change. The suite was instead verified in a throwaway `postgres:16` container with a Supabase-faithful scaffold (both `alter default privileges ... on tables` **and** `on functions` to `anon`/`authenticated`), all 24 migrations applied in order: **38/38 pass**, migration idempotent on a second apply. Please re-run `supabase test db` once the local stack is repaired.

### Test Steps

1. Apply the migration: `supabase db push` (or `supabase db reset`). Expect `20260728090000_platform_admins.sql` to apply cleanly.
2. Run the suite: `supabase test db` → expect `platform_admin.test.sql` green, 38/38.
3. **Bootstrap the first admin by hand** — Supabase dashboard → SQL Editor → `insert into public.platform_admins (user_id) values ('<your auth user id>');`. This is deliberately impossible from the app: there is no bootstrap RPC and `authenticated` holds no `INSERT` privilege.
4. `cd webapp && npm run dev`, sign in with that account → an **Admin** entry appears in the account dropdown, and `/admin` shows the fleet: a version histogram whose bars sum to the device count, the outdated-device and quiet-device lists, the platform/arch breakdown, and the user list.
5. Click any user → `/admin/<id>` shows profile, the 17 settings (a never-chosen flag reads "never chosen", not "off"), devices with their version, orgs with role, agents including archived ones, and repositories. Confirm nothing on the page is editable.
6. Sign in with a **non-admin** account → the Admin entry is gone from the menu, and navigating directly to `/admin` redirects to `/dashboard` without rendering admin content.
7. Optional, from the SQL editor as a non-admin JWT: `select public.admin_list_users();` → expect `ERROR: not a platform admin`.

## Screenshots

Not included — the local Supabase stack is down (see Testing), so the pages cannot be rendered against real data without hand-seeding a database. Worth adding before merge if a reviewer can bring a stack up.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

**Why `revoke execute ... from public, anon` deviates from the repo convention.** Under a Supabase-faithful scaffold, a control function created with the repo's usual `revoke execute ... from public;` still leaves `anon` holding `EXECUTE`:

```
 zz_control  | {postgres=X/postgres,anon=X/postgres,authenticated=X/postgres,...} | anon_exec = t
 zz_hardened | {postgres=X/postgres,authenticated=X/postgres,...}                 | anon_exec = f
```

The `auth.uid()` guard inside each function already refuses an anonymous caller, so this is defense in depth rather than a fix for a leak — but it means **the repo's existing RPCs (`list_org_members`, `get_org_shared_config`, …) very likely leave `anon` with `EXECUTE` too**. Worth a follow-up sweep; deliberately not touched here.

**AC3 is UX, not a boundary.** Nav filtering plus a client-side `router.replace` leaves the route and its JS bundle fetchable by any signed-in user. The RPC guards are the real boundary, which is why they are what the pgTAP suite pins.

**Known limits, deliberate.**

- No pagination or `LIMIT` on `admin_list_users()` / `admin_list_installations(null)`: the whole fleet is returned and rendered. Fine at today's scale; it is the first ceiling this back-office will hit.
- Reads swallow errors and return `[]`/`null` (consistent with the rest of `webapp/lib/`), so a failed RPC renders as an empty fleet rather than an error. More consequential here than elsewhere.
- The mapper layer is untested and unverifiable by `tsc`: with no generated `database.types.ts`, `data as AdminUserRpcRow[]` is a cast over `any`, so agreement between the migration's `returns table` and the `…RpcRow` interfaces is kept by hand.
- `outdatedInstallations` measures against the **highest observed** version, not the latest release — nothing in the schema knows what has shipped, so a uniformly-behind fleet reports itself current.

**Privacy posture.** `profiles`, `user_settings` and `app_installations` were populated under an own-rows-only promise with no opt-in (the `usage_logs_enabled` opt-in governs telemetry collection only). Reading them from a back-office changes that promise; the column allowlist is the mitigation, but the privacy policy should follow. Out of scope here.

**Out of scope, per the issue.** Writes and the `admin_audit_log` they require; the organizations list and product analytics (blocked in practice — `usage_events` / `skill_invocations` are not being written correctly today); impersonation. The per-user telemetry panel from the issue's action plan was also cut by decision, since it would ship a permanently empty view.

**Two loose ends for the maintainer.**

1. `commitlint` warns on both commit scopes: `supabase` and `webapp` are not in `scope-enum` (severity `1`, so CI is not blocked). That list, in `commitlint.config.js` and `CLAUDE.md`, predates both directories.
2. `CHANGELOG.md` is left unchecked above — the root `package.json` version looks release-automated, so the entry is left to whoever cuts the release.
