### PR TITLE
[#156] Detect and follow a ticket's UI/UX design references

### DIFF
--- a/desktop/src/main/hooks/claude-hooks-config.ts
+++ b/desktop/src/main/hooks/claude-hooks-config.ts
@@ -71,6 +71,7 @@ const MAGIC_SLASH_PERMISSIONS = [
   // Atlassian MCP tools
   'mcp__atlassian__getAccessibleAtlassianResources',
   'mcp__atlassian__getJiraIssue',
+  'mcp__atlassian__getJiraIssueRemoteIssueLinks',
   'mcp__atlassian__getTransitionsForJiraIssue',
   'mcp__atlassian__transitionJiraIssue',
   'mcp__atlassian__addCommentToJiraIssue',

--- a/install/install.sh
+++ b/install/install.sh
@@ -628,6 +628,9 @@ else
     'Bash(bun *)'
     'Bash(jq *)'
     'Bash(gh *)'
+    # WebFetch is deliberately NOT pre-approved: /magic:start declares it in allowed-tools to resolve
+    # public design URLs, but an unscoped grant would widen every future session for a rare path.
+    # The user is prompted on the first fetch instead.
   )
 
   # Atlassian MCP tools (only if enabled)
@@ -635,6 +638,7 @@ else
     MAGIC_SLASH_PERMS+=(
       'mcp__atlassian__getAccessibleAtlassianResources'
       'mcp__atlassian__getJiraIssue'
+      'mcp__atlassian__getJiraIssueRemoteIssueLinks'
       'mcp__atlassian__getTransitionsForJiraIssue'
       'mcp__atlassian__transitionJiraIssue'
       'mcp__atlassian__addCommentToJiraIssue'

--- a/skills/evals/eval_set.json
+++ b/skills/evals/eval_set.json
@@ -264,5 +264,19 @@
     "expected_skill": "magic:commit",
     "notes": "Commit with git flag — should still trigger commit skill",
     "difficulty": "medium"
+  },
+  {
+    "id": 39,
+    "query": "je démarre PROJ-321, c'est un ticket frontend avec une maquette",
+    "expected_skill": "magic:start",
+    "notes": "French start intent on a frontend ticket — mockup vocabulary must not deflect it away from start",
+    "difficulty": "medium"
+  },
+  {
+    "id": 40,
+    "query": "tu penses quoi de la maquette de la page settings ? le layout du modal me semble bizarre",
+    "expected_skill": null,
+    "notes": "Design vocabulary with no ticket ID and no start intent — UI keywords alone must not fire magic:start",
+    "difficulty": "hard"
   }
 ]

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -374,7 +374,15 @@ Check the ticket (title, description, labels, components, attachment metadata, r
 
 **If a signal is detected**: Read `references/design-context.md` to resolve the references and write `.magic/design-brief.md` in each worktree. The brief must exist before the plan is written in Step 5.2.
 
-**If no signal is detected** (e.g. backend-only labels `backend`, `api`, `db`, `infra`, `ci` with no Tier 1 or Tier 2 hit): skip this step entirely. Do not read `references/design-context.md`, do not write a brief, and leave the `Design fidelity` axis of Step 5.5.2 at `N/A`.
+**If no signal is detected** (e.g. backend-only labels `backend`, `api`, `db`, `infra`, `ci` with no Tier 1 or Tier 2 hit): do not read `references/design-context.md`, do not write a brief, and leave the `Design fidelity` axis of Step 5.5.2 at `N/A`.
+
+One thing still has to happen on this path. A worktree reused via Step 4.0 may already hold a brief from an earlier ticket, and every downstream prompt keys off "when `.magic/design-brief.md` exists" — so a leftover file would make sub-agents follow a mockup that has nothing to do with this task, and make the critic grade against it. Delete it before continuing:
+
+```bash
+rm -f .magic/design-brief.md
+```
+
+Run it in each worktree, and mention the deletion to the user if the file was there — a brief disappearing is worth one line, not silence.
 
 ### 5.1: Codebase exploration (conditional)
 

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -2,7 +2,7 @@
 name: magic:start
 description: This skill should be used when the user mentions a ticket ID like "PROJ-123", "#456", says "start", "commencer", "travailler sur", "je vais bosser sur", "begin work on", "work on ticket", "work on issue", "démarre", "démarrer", or indicates they want to start working on a specific task.
 argument-hint: <TICKET-ID>
-allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, mcp__atlassian__*, mcp__github__*
+allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, WebFetch, Agent, AskUserQuestion, mcp__atlassian__*, mcp__github__*
 ---
 
 # magic-slash v0.59.3 - /start
@@ -16,6 +16,7 @@ Follow each step in order. Each step builds on the previous one.
 - `references/messages.md` — All bilingual messages (MSG_*). Read relevant sections as needed (not the whole file at once).
 - `references/node-setup.md` — Node.js version manager detection. Read before installing dependencies (Step 4.3).
 - `references/plan-template-{type}-{lang}.md` — Implementation plan template. Read the matching file (`single`/`fullstack` + `en`/`fr`) in Step 5.2.
+- `references/design-context.md` — Design reference detection, resolution and the `.magic/design-brief.md` artifact. Read in Step 5.0, only when a UI signal is detected.
 - `references/glossary.md` — EN/FR terminology for git concepts. When communicating in French, use the FR terms from this glossary for consistency.
 - `references/api.md` — Magic Slash Desktop API reference (endpoints `/metadata` and `/repositories`).
 
@@ -80,7 +81,17 @@ Analyze `$ARGUMENTS`:
 
 Use `mcp__atlassian__getJiraIssue` to retrieve ticket details. If you don't know the `cloudId`, use `mcp__atlassian__getAccessibleAtlassianResources` first.
 
-If the MCP call fails (timeout, auth error), retry once. If it fails again, ask the user to provide the ticket title and description manually so the workflow can continue.
+Pass an explicit `fields` array so design references are never dropped:
+
+```json
+["summary","description","issuetype","status","labels","components","attachment"]
+```
+
+`attachment` is metadata only (`filename`, `mimeType`, `content`) and is what Step 5.0 needs to spot an image attachment. Comments are **not** requested here: they are retrieved later, and only if Step 5.0 detects a UI signal (see `references/design-context.md` §2.1), so a backend ticket never pays for its comment thread.
+
+In parallel, also call `mcp__atlassian__getJiraIssueRemoteIssueLinks` for the same issue: a Figma file is very often attached as a remote link rather than pasted in the description. Extract `object.url` and `object.title` from each entry and keep them for Step 5.0.
+
+If the MCP call fails (timeout, auth error), retry once. If it fails again, ask the user to provide the ticket title and description manually so the workflow can continue. A failure on the remote links call is never blocking: continue without them.
 
 → Continue to Step 2.5, then Step 2.6, then Step 2.7.
 
@@ -109,6 +120,18 @@ Use `mcp__github__get_issue` for each repo — launch all calls in parallel for 
 - **No issue found**: Display `MSG_NO_ISSUE_FOUND`.
 - **Single issue**: Use it. Scope = that repo.
 - **Multiple issues**: Use `AskUserQuestion` with the list of issues as options. Display `MSG_GITHUB_MULTI_ISSUE` as the question text.
+
+### 2B.5: Scan the comments for design references
+
+A Figma link is often dropped in a follow-up comment rather than in the issue body, so Tier 2 detection in Step 5.0 needs to see one. Fetching the whole thread would put it in context on every ticket, backend included — so filter it in the shell instead, and let only the matches through:
+
+```bash
+gh issue view {number} --repo {owner}/{repo} --comments 2>/dev/null \
+  | grep -ioE '(figma\.com|\.fig\b|design/|mockups?/|[a-z0-9_./-]+\.(html|css|styles\.ts))[^[:space:]]*' \
+  | sort -u | head -20
+```
+
+On a ticket with no design reference this prints nothing, so it costs nothing — and empty output is the nominal backend case, not a failure. (`grep` exits 1 when it matches nothing, but the pipeline's status is `head`'s, so the command still succeeds.) If `gh` is unavailable or fails, continue with the issue body alone. The full thread is never retrieved here: `references/design-context.md` §2.1 reads it later, once a signal has actually fired.
 
 → Continue to Step 2.5, then Step 2.6, then Step 2.7.
 
@@ -341,6 +364,18 @@ Create a `CLAUDE.local.md` in each worktree using `MSG_MULTI_REPO_CONTEXT` from 
 
 Display `MSG_TASK_SUMMARY` (or `MSG_TASK_SUMMARY_FULLSTACK` for multi-repo).
 
+### 5.0: Design context (conditional)
+
+Check the ticket (title, description, labels, components, attachment metadata, remote links, and the filtered comment matches from Step 2B.5) for a UI signal. Full comment threads are not available yet: they are fetched in `references/design-context.md` §2.1 once a signal has fired.
+
+- **Tier 1** — a label or component in {`frontend`, `front`, `ui`, `ux`, `design`, `css`, `web`}: sufficient alone.
+- **Tier 2** — a resolvable reference: repo-relative path to `.html`/`.css`/a spec `.md`/a `*.styles.ts`, a `figma.com` URL, an image attachment, a `design/` or `mockups/` folder, a `.fig` file: sufficient alone.
+- **Tier 3** — at least **two** of these keywords: `maquette`, `mockup`, `design`, `écran`/`screen`, `composant`/`component`, `bouton`/`button`, `modal`, `layout`, `responsive`, `style`.
+
+**If a signal is detected**: Read `references/design-context.md` to resolve the references and write `.magic/design-brief.md` in each worktree. The brief must exist before the plan is written in Step 5.2.
+
+**If no signal is detected** (e.g. backend-only labels `backend`, `api`, `db`, `infra`, `ci` with no Tier 1 or Tier 2 hit): skip this step entirely. Do not read `references/design-context.md`, do not write a brief, and leave the `Design fidelity` axis of Step 5.5.2 at `N/A`.
+
 ### 5.1: Codebase exploration (conditional)
 
 Evaluate whether codebase exploration is needed before launching a sub-agent.
@@ -356,8 +391,11 @@ Evaluate whether codebase exploration is needed before launching a sub-agent.
 - The ticket references components whose location or structure you don't know
 - The change spans multiple modules or layers
 - It's a full-stack task (multi-repo)
+- A design brief exists (step 5.0 wrote `.magic/design-brief.md`) — the mockup's markup and classes must be located in the codebase
 
 **If exploration is needed**: Launch an `Agent` (subagent_type=`Explore`) to explore the codebase. Request a structured summary: (1) project structure & framework, (2) config & stack, (3) existing patterns with file paths, (4) impacted files with current state, (5) cross-repo interactions if full-stack. Target 5-15 files, return summary only — not raw file contents. Use the sub-agent's returned summary to create the implementation plan in step 5.2.
+
+If `.magic/design-brief.md` exists, add to the prompt: read it first (give the absolute path) and report which existing components, styles or tokens match the referenced design.
 
 **If exploration is skipped**: Proceed directly to step 5.2, building the implementation plan from the ticket information alone.
 
@@ -369,15 +407,18 @@ Read the matching plan template from `references/plan-template-{type}-{lang}.md`
 
 Keep the plan focused: aim for **3-7 implementation steps**, each with 2-3 concrete actions. A plan that's too detailed wastes context; too vague and the implementation drifts.
 
+The template carries a design-context section (`### Design context` / `### Contexte design`). If `.magic/design-brief.md` exists, fill it in and name each resolved reference explicitly (e.g. the mockup file path) so the plan can be checked against it. If no brief exists, drop the section.
+
 ### 5.2.3: Plan review (via sub-agent)
 
-Launch an `Agent` to review the implementation plan. Provide: ticket summary (ID, title, description, acceptance criteria), codebase exploration summary (from step 5.1), and the full proposed plan.
+Launch an `Agent` to review the implementation plan. Provide: ticket summary (ID, title, description, acceptance criteria), codebase exploration summary (from step 5.1), and the full proposed plan. When `.magic/design-brief.md` exists, give its absolute path and instruct the agent to read it.
 
 The agent reviews the plan on these axes:
 - **Completeness**: Does the plan cover all acceptance criteria?
 - **Step ordering**: Are dependencies between steps respected?
 - **Missing files**: Are there impacted files forgotten (tests, types, migrations, configs)?
 - **Over-engineering**: Does the plan do more than what the ticket asks for?
+- **Design fidelity** (only when a brief exists): Does the plan reference each resolved design reference explicitly, and does it reuse the mockup's markup and classes instead of inventing a layout?
 
 The agent returns a short list of actionable suggestions, or explicitly states the plan looks good.
 
@@ -414,7 +455,7 @@ Never start implementation without explicit user approval.
 
 Display `MSG_PROGRESS_SOLO` (with step 1/1 since the sub-agent handles all steps).
 
-Launch an `Agent` with: ticket summary (ID, title, 2-3 sentence goal), acceptance criteria, full plan (verbatim), worktree path, constraints (no commits, use `Edit`/`Write`, follow patterns). For full-stack: list all paths, implement backend first. Review sub-agent output after completion.
+Launch an `Agent` with: ticket summary (ID, title, 2-3 sentence goal), acceptance criteria, full plan (verbatim), worktree path, constraints (no commits, use `Edit`/`Write`, follow patterns). For full-stack: list all paths, implement backend first. If `.magic/design-brief.md` exists, instruct the agent to read it first at its absolute path and to follow its `Mandatory rule` section (reuse the mockup's markup and classes). Review sub-agent output after completion.
 
 #### 5.4B: Multi-agent mode
 
@@ -425,6 +466,7 @@ Each subagent prompt includes (keep it concise — summary, not the full ticket 
 - Acceptance criteria (if any)
 - Assigned plan steps (copy the relevant steps verbatim from the plan)
 - Worktree path to work in
+- If `.magic/design-brief.md` exists: its absolute path in that worktree, with the instruction to read it before writing any UI code and to follow its `Mandatory rule` section
 - Constraints: no commits, follow project patterns, use `Edit`/`Write`
 - Note: subagents have access to Bash, Read, Write, Edit, Glob, Grep only (no MCP tools)
 
@@ -447,7 +489,7 @@ git ls-files --others --exclude-standard
 
 2. If no files changed, skip this step silently.
 3. Display `MSG_SIMPLIFY`.
-4. Launch an `Agent` with: worktree path, changed files list (only these modifiable), instruction to invoke `/simplify` (may explore full codebase but modify only changed files).
+4. Launch an `Agent` with: worktree path, changed files list (only these modifiable), instruction to invoke `/simplify` (may explore full codebase but modify only changed files). If `.magic/design-brief.md` exists, give its absolute path as read-only context: simplification must not drop markup or classes required by the mockup.
 5. If no issues found, continue silently.
 
 ### 5.5: Confidence assessment and final summary
@@ -472,6 +514,7 @@ The confidence evaluation is performed by an **independent critic agent** — a 
 - The diff: output of `git diff HEAD` in the worktree + list of untracked files
 - The rubric below (axes, calibration, scoring formula)
 - The worktree path (so it can read files for context — but it must not modify any file)
+- The full content of `.magic/design-brief.md` when it exists (inlined, not just the path) — the critic has never seen the plan, so the brief is its only way to judge design fidelity
 
 **What the critic agent does NOT receive**:
 - The implementation plan
@@ -486,6 +529,7 @@ The confidence evaluation is performed by an **independent critic agent** — a 
 - **Test coverage**: Were tests added/updated when the project has a test suite?
 - **Edge cases**: Were error handling and boundary conditions considered?
 - **Scope adherence**: Did the implementation stay within the ticket scope?
+- **Design fidelity**: Does the implementation match the design brief (markup, classes, tokens)? `N/A` by default — this axis is active only when `.magic/design-brief.md` exists.
 
 For each axis, assign one of: **MET** | **PARTIALLY MET** | **NOT MET** | **N/A**
 
@@ -495,6 +539,7 @@ For each axis, assign one of: **MET** | **PARTIALLY MET** | **NOT MET** | **N/A*
 - **Test coverage**: MET = tests added or updated covering the main paths and at least one edge case; PARTIALLY MET = tests cover the happy path but miss edge cases or error scenarios.
 - **Edge cases**: MET = error handling and boundary conditions are explicitly handled (null checks, empty states, limits); PARTIALLY MET = common errors handled but some boundary conditions left unguarded.
 - **Scope adherence**: MET = implementation stays strictly within the ticket scope with no unrelated changes; PARTIALLY MET = minor tangential cleanup included alongside the scoped work.
+- **Design fidelity**: MET = the markup, classes and tokens of the brief's source of truth are reused as-is; PARTIALLY MET = the visual intent is followed but part of the markup or several tokens were reinvented.
 
 **Minimum axis rule**: if fewer than 3 axes are non-N/A, cap the maximum score at **8** — too few axes provide insufficient signal for a perfect score.
 
@@ -512,6 +557,13 @@ For each axis, assign one of: **MET** | **PARTIALLY MET** | **NOT MET** | **N/A*
 
 After selecting the base score from the table, apply one adjustment: if the majority of remaining axes (excluding the NOT MET ones) are MET rather than PARTIALLY MET, add +1 to the score (max 10). Note: the minimum axis rule cap is applied after this adjustment.
 
+**Design fidelity guards** (the score table itself is unchanged):
+
+- If `.magic/design-brief.md` exists **and its `Source of truth` table has at least one row**, the `Design fidelity` axis **cannot** be rated `N/A`: rate it MET, PARTIALLY MET or NOT MET. A fraudulent `N/A` would hide an ignored mockup behind a 10/10.
+- If a brief exists but its `Source of truth` table is empty (every reference was unresolvable — typically a Jira screenshot on a ticket that is not really a UI task), the axis returns to `N/A`. There is nothing to be faithful to, so no cap applies and no auto-fix iteration is spent on an unfixable axis.
+- If a brief exists and `Design fidelity` is `PARTIALLY MET`, cap the final score at **7**. Without this cap, condition 2 yields 9 — above the ≥ 8 exit threshold of the auto-fix loop — and a half-ignored mockup would pass.
+- **Precedence of the caps, in this order**: (1) base score from the table, (2) the `+1` adjustment, (3) the PARTIALLY MET design cap, (4) the minimum axis rule cap. Each step applies to the result of the previous one.
+
 **Critic mindset**: approach the evaluation as an external code reviewer who has never seen this code before. A score of 6 with clear attention points is more useful than an inflated 9. When in doubt between two ratings for an axis, choose the lower one.
 
 **Expected output format** from the critic agent (structured text, not JSON):
@@ -523,6 +575,7 @@ AXIS RESULTS:
 - Test coverage: {MET|PARTIALLY MET|NOT MET|N/A} — {one-sentence justification}
 - Edge cases: {MET|PARTIALLY MET|NOT MET|N/A} — {one-sentence justification}
 - Scope adherence: {MET|PARTIALLY MET|NOT MET|N/A} — {one-sentence justification}
+- Design fidelity: {MET|PARTIALLY MET|NOT MET|N/A} — {one-sentence justification}
 
 SCORE: {number}/10
 
@@ -550,6 +603,8 @@ LOOP:
        - The diff collected in step 1
        - The full evaluation rubric above (axes, calibration, scoring, output format)
        - The worktree path (read-only access for context)
+       - The content of .magic/design-brief.md when it exists (inlined; otherwise state that no brief
+         exists, so the Design fidelity axis is N/A)
        - Instruction: "You are an independent code reviewer. You have NOT seen the implementation
          plan or any prior conversation. Evaluate the diff against the ticket requirements using
          ONLY the rubric provided. Do not modify any file."
@@ -588,6 +643,9 @@ LOOP:
   9. Launch a fix Agent with:
      - The worktree path
      - The list of modifiable files (only files changed during implementation)
+     - When .magic/design-brief.md exists: its absolute path, read-only and never modifiable, with the
+       instruction to read it before touching UI code (it is git-excluded, so it is never in the
+       modifiable-files list and must be named explicitly)
      - A precise description of the selected attention point to fix
      - Instruction: "Do no harm — fix only the described issue; do not alter unrelated code or degrade any axis that currently passes"
 

--- a/skills/magic-start/references/design-context.md
+++ b/skills/magic-start/references/design-context.md
@@ -1,0 +1,211 @@
+# Design Context Resolution
+
+Read this file only when Step 5.0 has detected a UI signal on the ticket.
+It explains how to find the ticket's design references, resolve them, write `.magic/design-brief.md`,
+and degrade explicitly when a reference cannot be resolved.
+
+## 1. UI signal detection
+
+Detection is owned by Step 5.0 of `SKILL.md`, which is loaded on every run and decides whether to read this file
+at all: it holds the Tier 1/2/3 rules and the backend-only non-trigger, and is the only place they are evaluated.
+Reaching this file means a signal already fired — do not re-run the detection.
+
+## 2. Extracting and ranking references
+
+### 2.1 Where to look
+
+| Source | How to read it |
+| --- | --- |
+| Jira description | `fields.description` from Step 2A |
+| Jira attachments | `fields.attachment[]` from Step 2A — use `filename`, `mimeType`, `content` |
+| Jira remote links | `getJiraIssueRemoteIssueLinks`, called in Step 2A — extract `object.url` and `object.title` |
+| Jira comments | fetch now: `mcp__atlassian__getJiraIssue` with `fields: ["comment"]` → `fields.comment.comments` |
+| GitHub issue body | `mcp__github__get_issue` from Step 2B |
+| GitHub issue comments | fetch now: `gh issue view {number} --repo {owner}/{repo} --comments` (no MCP tool exists) |
+
+Full comment threads are fetched here rather than in Step 2A/2B precisely because this file is reached only on a ticket
+with a UI signal: a backend ticket therefore consumes no comment thread at all.
+A `gh` failure is non-blocking — if `gh` fails or is unavailable, continue with the issue body alone.
+
+**Known limitation, Jira only.** Step 2B.5 shell-filters GitHub comments, so a GitHub reference living *only* in a
+comment still fires Tier 2. There is no equivalent for Jira: an MCP response cannot be filtered before it enters the
+context, so Jira comments are read only after a signal has fired. A design reference that exists *solely* in a Jira
+comment, on a ticket with no Tier 1 label and no Tier 3 keyword, is therefore missed. Say so rather than guessing.
+
+Scan each source **only** to extract design references.
+Never inline a whole comment thread into your context: keep the references, drop everything else.
+
+### 2.2 Rank ladder
+
+Rank every extracted reference from the strongest source of truth to the weakest:
+
+1. **HTML/CSS mockup in the repo** — the HTML+CSS *is* the spec; read the source, never render it in a browser
+2. **Versioned design spec** — a spec `.md` or a `*.styles.ts` cited as the visual model, as a repo-relative path
+3. **Figma** — a `figma.com` URL, found in the description, in a comment, or as a remote link
+4. **Screenshot / image** — a Jira attachment, an inline `blob:` image, or a local image file
+5. **Prose** — last resort, when no artefact exists
+
+When two references disagree, the higher rank wins, and note the conflict in the brief.
+
+### 2.3 Inline `blob:` URLs
+
+An image pasted directly into a Jira description shows up in the markdown as:
+
+```text
+![](blob:https://media.staging.atl-paas.net/?type=file&localId=b25a39f748ad&id=3788fc50-…&width=1381&height=804)
+```
+
+This is a client-side reference and is not fetchable.
+Never attempt to fetch a `blob:` URL with any tool.
+Correlate it with `attachment[]` (by order, by count, or by filename) and treat it as an inaccessible screenshot (§3).
+
+Once the reference list is established, display `MSG_DESIGN_REFS_FOUND` from `references/messages.md`,
+filling `{ref_list}` with one line per reference, in the shape documented next to that message — the only place
+that carries both the EN and FR status wording.
+
+## 3. Resolution by type
+
+| Reference type | Tool | Action |
+| --- | --- | --- |
+| HTML/CSS mockup in the repo | `Read` | Read the HTML **and** its CSS in full; markup and classes are the spec |
+| Versioned spec `.md` or `*.styles.ts` | `Read` | Read the file and extract the tokens it defines |
+| Local image file in the repo | `Read` | `Read` renders local images, so the image is genuinely seen |
+| Public URL (Figma, hosted mockup, design doc) | `WebFetch` | Fetch it; on auth wall or 404, unresolved (§5) |
+| Jira image attachment or inline `blob:` image | none | **NOT RESOLVABLE** — go straight to §5.1 (report + record) |
+
+Locate the mockup's CSS from its own `<link rel="stylesheet">` and `<style>` tags rather than guessing the path.
+For a large mockup (or a large stylesheet), do not retain the whole file: extract the design tokens and the markup
+subtree of the components the ticket actually touches.
+
+Before declaring a repo-relative path unresolved, `Glob` its basename — the path is often just stale or mistyped.
+In a multi-repo task, glob the sibling worktrees too: a full-stack ticket routinely cites a mockup that lives in the
+other repo.
+Only when the basename matches nowhere is the reference unresolved with reason `path not found` (§5.1).
+
+Never open a mockup in a browser and never screenshot it: the source is the specification.
+For a Figma URL, expect most files to be private — a `WebFetch` failure is the normal outcome, not an error to retry.
+
+### 3.1 A Jira image attachment cannot be seen — verified
+
+There is **no path** by which a Jira image can be downloaded so that `Read` sees it: `curl` on the attachment
+`content` URL returns **HTTP 403**, no Atlassian credential is reachable from the shell (the OAuth session lives
+inside the MCP server), and `mcp__atlassian__fetch` accepts **only ARIs** (`ari:cloud:jira:…:issue/…`).
+
+Do not attempt `curl`, `WebFetch`, or `mcp__atlassian__fetch` on an attachment URL, and never tell the user a
+download path exists.
+Every Jira image attachment goes to the reporting branch of §5: its inaccessibility is reported to the user,
+and the reference is recorded as unresolved in the brief.
+
+## 4. Writing the brief
+
+### 4.1 Exclude `.magic/` from git first
+
+Run this once per repo, before writing the brief (so once per worktree in a multi-repo task):
+
+```bash
+EX="$(git rev-parse --git-path info/exclude)"; mkdir -p "$(dirname "$EX")"; touch "$EX"
+grep -qxF '.magic/' "$EX" || { [ -s "$EX" ] && [ -n "$(tail -c1 "$EX")" ] && printf '\n' >> "$EX"; printf '.magic/\n' >> "$EX"; }
+```
+
+The command is idempotent: `grep -qxF` makes any later run a no-op.
+The newline guard is not cosmetic: if `info/exclude` does not end with a newline, a plain append produces
+`node_modules.magic/`, `.magic/` is then **not** ignored, and the `git add -A` of `/magic:commit` commits the brief.
+`git rev-parse --git-path info/exclude` resolves to the common dir's `info/exclude` inside a linked worktree,
+which is the correct target — git does not read a per-worktree `info/exclude`.
+
+The brief is a working artefact: it must never be committed.
+
+### 4.2 Format — frozen
+
+Write `.magic/design-brief.md` at the root of the worktree, with exactly these sections:
+
+```text
+# Design brief — {TICKET_ID}
+
+## Source of truth
+
+| Rank | Type | Reference | Status |
+| --- | --- | --- | --- |
+| 1 | HTML mockup | `path/to/mockup.html` | ✅ read |
+| 3 | Figma | https://figma.com/… | ⚠️ unresolved (auth) |
+
+## Extracted tokens
+
+colors, spacing, typography, radii, shadows
+
+## Component structure
+
+markup tree + reusable classes
+
+## Mandatory rule
+
+Reuse the mockup's markup and classes. Do not invent an alternative layout.
+
+## Allowed deviations
+
+adapting to the repo's existing design system
+
+## Unresolved references
+
+- `reference` — reason (auth, 404, binary format, blob URL, path not found)
+```
+
+The only allowed statuses are `✅ read` and `⚠️ unresolved (<reason>)`.
+Keep the section headings verbatim and in English — downstream sub-agents and the critic look for them,
+and they must not shift with `languages.discussion`.
+Fill each section with content extracted from the resolved references, in the repo's discussion language.
+Leave a section with an explicit `none` rather than deleting it.
+
+### 4.3 One brief per worktree
+
+In a multi-repo task, write the brief into **every** worktree, exactly like `CLAUDE.local.md` in Step 4.6
+("in each worktree").
+A sub-agent only sees the worktree it was handed, so a brief that lives in one worktree is invisible to the others.
+
+### 4.4 Cite an absolute path in sub-agent prompts
+
+Sub-agent prompts must reference the brief by **absolute** path, for example
+`/Users/me/code/repo-PROJ-123/.magic/design-brief.md`.
+A relative path is unreliable because a sub-agent does not inherit the current working directory.
+The brief is git-excluded, so it never shows up in `git ls-files --others --exclude-standard`:
+when a prompt hands a sub-agent a list of modifiable or readable files, add the brief path explicitly.
+
+## 5. Explicit degradation
+
+### 5.1 A reference exists but cannot be resolved
+
+1. Display `MSG_DESIGN_REF_UNRESOLVED` from `references/messages.md`, filling `{reference}` and `{reason}`.
+2. Record the reference under `## Unresolved references` in the brief, with the same reason.
+3. Continue with the remaining references, in the rank order of §2.2.
+
+Allowed reasons: `auth` (403 / private URL), `404`, `binary format` (image that cannot be read), `blob URL`,
+`path not found` (repo-relative path that resolves nowhere, after the `Glob` check of §3).
+
+Never implement blind and never degrade silently: an unresolved reference is always surfaced to the user
+**and** always written into the brief.
+When every reference is unresolved, still write the brief with an empty `Source of truth` table and the full
+unresolved list — the critic needs that record to explain why nothing could be checked.
+An empty table also tells the critic to keep the `Design fidelity` axis at `N/A` (see Step 5.5.2's guards): there is
+nothing to be faithful to. This is the common case for a bug ticket carrying a stack-trace screenshot, which fires
+Tier 2 on the attachment without being a UI task at all — it must not cost a point.
+
+### 5.2 A UI signal but zero references
+
+Use `AskUserQuestion` with `MSG_DESIGN_NO_REF` (placeholder `{ticket_id}`) as the question text, and exactly the
+three options that message lists — same convention as `MSG_WORKTREE_EXISTS`, whose labels live only in
+`references/messages.md`:
+
+- Option 1 → the user supplies a path or a URL; resolve it via §3, then write the brief.
+- Option 2 → write no brief; the `Design fidelity` critic axis stays `N/A`.
+- Option 3 → stop the skill.
+
+Never start a UI task silently when no design reference was found.
+
+## Usage
+
+Step 5.0 of `SKILL.md` runs the Tier 1/2/3 detection inline, and reads this file **only** when a signal fires.
+Once read, execute §2, then §3, then §4 in order, applying §5 whenever a reference resists resolution.
+The brief must exist **before** the implementation plan is written in Step 5.2: the plan has to reference the mockup
+explicitly, and the plan-review agent of Step 5.2.3 checks exactly that.
+Every downstream prompt then receives the absolute path to the brief — Step 5.1 exploration, Step 5.2.3 plan review,
+Step 5.4A/5.4B implementation, Step 5.4.5 simplify, the Step 5.5.2 critic, and the auto-fix agent.

--- a/skills/magic-start/references/design-context.md
+++ b/skills/magic-start/references/design-context.md
@@ -198,8 +198,13 @@ three options that message lists — same convention as `MSG_WORKTREE_EXISTS`, w
 `references/messages.md`:
 
 - Option 1 → the user supplies a path or a URL; resolve it via §3, then write the brief.
-- Option 2 → write no brief; the `Design fidelity` critic axis stays `N/A`.
+- Option 2 → write no brief, and `rm -f .magic/design-brief.md` in each worktree so a brief left by an earlier
+  ticket in a reused worktree cannot stay active; the `Design fidelity` critic axis stays `N/A`.
 - Option 3 → stop the skill.
+
+The deletion in option 2 is the same guard as the no-signal path of Step 5.0, for the same reason: every downstream
+prompt keys off "when `.magic/design-brief.md` exists", so *not writing* a brief is not the same as there being none.
+Only option 1 and §4 ever create one; every other outcome must leave no brief behind.
 
 Never start a UI task silently when no design reference was found.
 

--- a/skills/magic-start/references/design-context.md
+++ b/skills/magic-start/references/design-context.md
@@ -117,7 +117,9 @@ The brief is a working artefact: it must never be committed.
 
 ### 4.2 Format — frozen
 
-Write `.magic/design-brief.md` at the root of the worktree, with exactly these sections:
+Write `.magic/design-brief.md` at the root of the worktree, with exactly these sections.
+Overwrite it wholesale rather than appending: a worktree reused via Step 4.0 may still hold a brief from an earlier
+ticket, and a merged brief would mix two mockups.
 
 ```text
 # Design brief — {TICKET_ID}

--- a/skills/magic-start/references/glossary.md
+++ b/skills/magic-start/references/glossary.md
@@ -16,3 +16,5 @@
 | Rebase | Rebaser | Reapply commits on top of another base |
 | Scope | Périmètre | Set of repos affected by a task |
 | Dispatcher | Répartiteur | Strategy selector (solo vs multi-agent) |
+| Mockup | Maquette | Visual reference the implementation must reproduce |
+| Design fidelity | Fidélité au design | Degree to which the code matches the design reference |

--- a/skills/magic-start/references/messages.md
+++ b/skills/magic-start/references/messages.md
@@ -416,6 +416,80 @@ Sauvegarder dans la config pour les prochains worktrees ? (o/n)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
+## MSG_DESIGN_REFS_FOUND
+
+### en
+
+```text
+🔍 Design references detected, strongest source of truth first:
+{ref_list}
+
+Written to .magic/design-brief.md — the implementation reuses it instead of inventing a layout.
+```
+
+### fr
+
+```text
+🔍 Références de design détectées, source de vérité la plus forte en premier :
+{ref_list}
+
+Écrites dans .magic/design-brief.md — l'implémentation la réutilise au lieu d'inventer un layout.
+```
+
+> One line per reference: `{rank}. {type} — {reference} — ✅ read` / `⚠️ unresolved ({reason})`,
+> in French `✅ lu` / `⚠️ non résolu ({reason})`. Display only — the brief keeps the English statuses
+> (`design-context.md` §4.2).
+
+## MSG_DESIGN_REF_UNRESOLVED
+
+### en
+
+```text
+⚠️ Design reference unreadable: {reference} ({reason}) — a definitive limit, not a transient error.
+Recorded as unresolved in .magic/design-brief.md; the implementation will flag the gap, not guess.
+```
+
+### fr
+
+```text
+⚠️ Référence de design illisible : {reference} ({reason}) — limite définitive, inutile de réessayer.
+Notée comme non résolue dans .magic/design-brief.md ; l'implémentation signalera le manque sans deviner.
+```
+
+## MSG_DESIGN_NO_REF
+
+### en
+
+```text
+🔍 {ticket_id} looks like a UI task, but no design reference was found.
+Nothing usable in the description, the comments, the attachments, the remote links or the repo.
+
+Without a mockup I will invent the layout, and design fidelity becomes unverifiable.
+
+Options:
+1. Provide a reference
+2. Continue without a mockup
+3. Stop
+
+Choose (1/2/3):
+```
+
+### fr
+
+```text
+🔍 {ticket_id} ressemble à une tâche UI, mais aucune référence de design n'a été trouvée.
+Rien d'exploitable dans la description, les commentaires, les pièces jointes, les liens ni le repo.
+
+Sans maquette, j'inventerai le layout et la fidélité au design sera invérifiable.
+
+Options :
+1. Fournir une référence
+2. Continuer sans maquette
+3. Arrêter
+
+Choix (1/2/3) :
+```
+
 ## MSG_STRATEGY_SOLO
 
 ### en

--- a/skills/magic-start/references/plan-template-fullstack-en.md
+++ b/skills/magic-start/references/plan-template-fullstack-en.md
@@ -32,6 +32,12 @@
 - Backend pattern: `path/to/reference.ts`
 - Frontend pattern: `path/to/reference.tsx`
 
+### Design context
+- Source of truth: [rank 1-5 — type] (rank 1 = repo HTML/CSS mockup, rank 5 = prose)
+- Mockup path(s): `path/to/mockup.html`
+- Mandatory rule: reuse the mockup's markup and classes, do not invent an alternative layout
+- Allowed deviations: [adapting to the repo's existing design system]
+
 ## Implementation Steps
 
 ### Backend Steps

--- a/skills/magic-start/references/plan-template-fullstack-fr.md
+++ b/skills/magic-start/references/plan-template-fullstack-fr.md
@@ -32,6 +32,12 @@
 - Pattern backend : `path/to/reference.ts`
 - Pattern frontend : `path/to/reference.tsx`
 
+### Contexte design
+- Source de vérité : [rang 1-5 — type] (rang 1 = maquette HTML/CSS du repo, rang 5 = prose)
+- Chemin(s) de la maquette : `path/to/mockup.html`
+- Règle impérative : réutiliser le markup et les classes de la maquette, ne pas inventer un layout alternatif
+- Déviations autorisées : [adaptation au design system existant du repo]
+
 ## Étapes d'implémentation
 
 ### Étapes Backend

--- a/skills/magic-start/references/plan-template-single-en.md
+++ b/skills/magic-start/references/plan-template-single-en.md
@@ -23,6 +23,12 @@
 - Similar implementation found in: `path/to/reference.ts`
 - Pattern to follow: [description]
 
+### Design context
+- Source of truth: [rank 1-5 — type] (rank 1 = repo HTML/CSS mockup, rank 5 = prose)
+- Mockup path(s): `path/to/mockup.html`
+- Mandatory rule: reuse the mockup's markup and classes, do not invent an alternative layout
+- Allowed deviations: [adapting to the repo's existing design system]
+
 ## Implementation Steps
 
 ### Step 1: [Short title]

--- a/skills/magic-start/references/plan-template-single-fr.md
+++ b/skills/magic-start/references/plan-template-single-fr.md
@@ -23,6 +23,12 @@
 - Implémentation similaire trouvée dans : `path/to/reference.ts`
 - Pattern à suivre : [description]
 
+### Contexte design
+- Source de vérité : [rang 1-5 — type] (rang 1 = maquette HTML/CSS du repo, rang 5 = prose)
+- Chemin(s) de la maquette : `path/to/mockup.html`
+- Règle impérative : réutiliser le markup et les classes de la maquette, ne pas inventer un layout alternatif
+- Déviations autorisées : [adaptation au design system existant du repo]
+
 ## Étapes d'implémentation
 
 ### Étape 1 : [Titre court]


### PR DESCRIPTION
## Description

`/magic:start` was blind to a ticket's design references. The trigger was a real Frontend ticket whose mockup was a link to an HTML file living in the codebase: the implementation sub-agent never opened it and invented its own layout. The words `design`, `mockup`, `maquette`, `figma` and `attachment` appeared **nowhere** across the 7 skills.

The fix closes the five broken links the issue identified, each at the altitude where it actually breaks. The load-bearing piece is an artifact: the design step writes `.magic/design-brief.md` into the worktree, git-excluded, and every downstream sub-agent prompt is handed its absolute path. Context that used to evaporate at the delegation boundary now survives it.

Behaviour is additive and conditional. A backend ticket reads no extra file, fetches no comment thread, writes no brief, and scores exactly as before.

## Related Issue

Fixes #156

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **New `skills/magic-start/references/design-context.md`** (211 lines) — conditionally loaded, following the `node-setup.md` pattern: where to look for references, a 5-rank ladder (repo HTML/CSS mockup > versioned design spec > Figma > screenshot > prose), resolution per type, brief format, and explicit degradation.
- **Widened ticket retrieval** — Step 2A passes an explicit `fields` array including `attachment` and calls `getJiraIssueRemoteIssueLinks` (Figma is often a remote link, never in the description). New Step 2B.5 scans GitHub comments.
- **New Step 5.0 "Design context"** — ~11 lines inline: a 3-tier UI signal detection, then read the reference file **only** if a signal fires. Tier 3 requires **two** keywords, so a ticket merely containing "page" does not trigger it.
- **Propagation into 7 sub-agent prompts** — exploration (5.1), plan template (5.2), plan review (5.2.3, with its own design axis), both implementation modes (5.4A/5.4B), simplify (5.4.5), the critic (5.5.2, brief **inlined** since the critic has no context about the plan) and the auto-fix agent.
- **6th critic axis "Design fidelity"** — `N/A` by default. The score table is deliberately **not** rewritten: its conditions are counts over non-N/A axes, so they stay exhaustive at 6 axes and no backend score shifts. Three ordered guards instead: `N/A` is forbidden when a brief has a source of truth, `PARTIALLY MET` caps the score at 7 (just below the loop's `>= 8` exit, so a half-ignored mockup cannot pass), and cap precedence is spelled out.
- **3 bilingual messages** — `MSG_DESIGN_REFS_FOUND`, `MSG_DESIGN_REF_UNRESOLVED`, `MSG_DESIGN_NO_REF` (the last backs an `AskUserQuestion`), plus 2 glossary pairs.
- **`### Design context` section in all 4 plan templates** (EN/FR, single and fullstack).
- **`install/install.sh`** — allowlists `getJiraIssueRemoteIssueLinks`. `WebFetch` is deliberately **not** pre-approved: an unscoped grant would widen every future session for a rare path, so the user is prompted on first fetch. The reasoning is recorded in a comment.
- **2 eval cases** — one positive, and one negative that locks in the over-triggering risk.

### Spike result worth knowing

The issue asked for a spike before implementing. It was run against a real Jira ticket and returned a **hard negative**: a Jira image attachment cannot be seen. `curl` on the `content` URL returns HTTP 403, no Atlassian credential is reachable from the shell (the OAuth session lives in the MCP server), and `mcp__atlassian__fetch` accepts only ARIs. Acceptance criterion 2 is therefore satisfied by its **"report the inaccessibility"** branch, and `design-context.md` §3.1 says so explicitly rather than implying a download path exists.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

Three of the four boxes are honestly unchecked. `skills/` in this repo is **not** synced to `~/.claude/skills/` — the installer copies it at install time only — so the new skill logic cannot be exercised end-to-end from this branch without running `install.sh` first. What *was* verified is every executable mechanism in isolation, plus `npm test` (561 passing), `npm run lint` (0 errors), `bash -n` and `shellcheck` on the installer, and `jq` on the eval set.

### Test Steps

1. **Backend ticket pays nothing.** Run `/magic:start` on an issue labelled `api` or `backend` with no UI keyword. Expect: `design-context.md` is never read, no `.magic/` directory appears, and the confidence rubric reports `Design fidelity: N/A` with an unchanged score.
2. **The comment filter is silent on backend content.** Run the Step 2B.5 pipeline against this very issue: `gh issue view 156 --repo Xrequillart/magic-slash --comments | grep -ioE '(figma\.com|\.fig\b|design/|mockups?/|[a-z0-9_./-]+\.(html|css|styles\.ts))[^[:space:]]*' | sort -u | head -20`. Expect: **no output at all** — that is the point, a backend thread costs zero context. Then pipe in a line containing a `figma.com` URL and expect only that URL back.
3. **The brief is genuinely uncommittable.** In a worktree, run the exclude snippet from `design-context.md` §4.1, create `.magic/design-brief.md`, then check `git status --porcelain` (expect nothing), `git check-ignore -v .magic/design-brief.md` (expect a match), and `git add -A && git diff --cached --name-only` (expect the brief absent). Bonus: strip the trailing newline from `.git/info/exclude` first and confirm the guard still produces two correct lines rather than `node_modules.magic/`.
4. **Full UI path, end to end.** Run `bash install/install.sh` from this checkout to sync the skills, then `/magic:start` on a frontend ticket carrying a link to an `.html` file in the repo. Expect: the mockup is read *before* the plan is written, the plan's `Design context` section names the file path, `.magic/design-brief.md` exists with a populated `Source of truth` table, and the implementation sub-agent prompt cites its absolute path.
5. **UI task with no reference asks instead of guessing.** Run `/magic:start` on a ticket labelled `frontend` with no mockup anywhere. Expect an `AskUserQuestion` offering *Provide a reference / Continue without a mockup / Stop*, not a silent start.

## Screenshots

Not applicable — this PR changes Markdown skill instructions and one bash allowlist. No UI surface.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

Notes on two of these. **Documentation**: the skill files *are* the documentation for this feature, and `docs/documentation.html` does not describe `/magic:start`'s internal steps, so there was nothing to update there. **CHANGELOG**: the file has no `[Unreleased]` section — entries are assembled at release time by the `magic-release` skill — so a feature PR conventionally does not hand-edit it. The `v0.59.3` header in `SKILL.md` was likewise left untouched.

## Additional Notes

**Two known limitations, stated rather than hidden.**

*Jira comment blind spot.* GitHub comments are filtered in the shell, so a reference living only in a GitHub comment still fires Tier 2 detection. There is no equivalent for Jira: an MCP response cannot be filtered before it enters the context window. Jira comments are therefore read only *after* a signal has fired, which means a design reference existing **solely** in a Jira comment, on a ticket with no `frontend`-style label and fewer than two Tier 3 keywords, is missed. This is a deliberate trade against the "a backend ticket consumes no extra context" criterion, and it is documented in `design-context.md` §2.1. The issue prescribed simply adding `comment` to Step 2A's `fields`; that was tried and rejected because a comment thread is already in context by the time the agent decides to ignore it.

*Issue item 8 is not fully satisfiable here.* It asked to "assert the mockup is actually opened". `skills/evals/eval_set.json` is a trigger/description set with no runner and no assertion DSL anywhere in the repo, so a behavioural assertion would mean building a harness — out of scope. The two cases added cover triggering and non-triggering, not behaviour. `results.json` was intentionally left alone; it is hand-written and already stale (claims 30 queries for what is now 40).

**Review process.** The plan was reviewed by a sub-agent before implementation, the changed files went through a simplification pass, and the result was graded twice by independent critic agents that had seen neither the plan nor the conversation. The first pass scored 6/10 and caught a genuine acceptance-criterion violation — comments were being fetched unconditionally — which is what produced the shell-filter design. The second scored 8/10 and caught the interaction fixed in the final commit: a bug ticket with an attached screenshot fires Tier 2, is unresolvable by construction, and would have burned auto-fix iterations on an axis nothing could satisfy. An empty `Source of truth` table now returns the axis to `N/A`.

**Note for the reviewer.** This branch is 2 commits behind `main` (two unrelated webapp commits landed during the work). There are no conflicts — `git merge-tree` reports none — so the 3-dot diff GitHub shows is exactly the 10 files above.
