### PR TITLE
[#15] Read Jira custom fields when a ticket has no usable spec

### DIFF
--- a/skills/magic-continue/SKILL.md
+++ b/skills/magic-continue/SKILL.md
@@ -17,6 +17,7 @@ Follow each step in order. Each step builds on the previous one.
 - `references/node-setup.md` — Node.js version manager detection. Read before installing dependencies (Step 6.2).
 - `references/glossary.md` — EN/FR terminology for git concepts. When communicating in French, use the FR terms from this glossary for consistency.
 - `references/api.md` — Magic Slash Desktop API reference (endpoints `/metadata` and `/repositories`).
+- `references/jira-custom-fields.md` — Jira custom-field discovery: the `*all` re-read, its volume guards, and the empty-ticket options. Read in Step 2A, only when the ticket description carries no usable spec.
 
 ## Step 0: Configuration
 
@@ -85,6 +86,8 @@ Analyze `$ARGUMENTS`:
 Use `mcp__atlassian__getJiraIssue` to retrieve ticket details. If you don't know the `cloudId`, use `mcp__atlassian__getAccessibleAtlassianResources` first.
 
 If the MCP call fails (timeout, auth error), retry once. If it fails again, ask the user to provide the ticket title and description manually so the workflow can continue.
+
+**Completeness check.** The ticket's real spec may sit in a custom field. Read `references/jira-custom-fields.md` and follow it whenever `fields.description` does not state what to build: it is absent or null; or under **80 characters** of useful text once markup is stripped and not a complete one-liner ("Bump the Stripe SDK to v14" is a spec); or longer, yet stating neither what to build nor any acceptance criterion (every heading present with an empty or placeholder body, pure boilerplate, a deferral to another field, a bare link with no prose). A description that does say what to build never triggers it, however short — in doubt, skip, so this does not become a second full-issue call on every ticket. That file owns the discovery call, the volume guards, what the discovered text feeds into, and the handling of a ticket still empty afterwards. If it is missing on disk, skip discovery and degrade to the warning alone: say in one line that the ticket looks underspecified, ask the user for the missing context, and never fill the gap from the title alone.
 
 → Continue to Step 2.5, then Step 2.6.
 

--- a/skills/magic-continue/references/jira-custom-fields.md
+++ b/skills/magic-continue/references/jira-custom-fields.md
@@ -1,0 +1,145 @@
+# Jira custom-field discovery
+
+Read this file only when Step 2A's completeness check has fired: a Jira ticket whose description is too
+short, or which states neither what to build nor any acceptance criterion. It explains how to re-read the
+issue for the custom fields that may hold the real spec, what to keep out of the response, and what to do
+when discovery finds nothing either.
+
+Both `/magic:start` and `/magic:continue` read this file, and the two copies are byte-identical. Where the
+callers genuinely differ — essentially what the discovered text feeds into downstream — the difference is
+stated inline below; do not fork the file.
+
+## 1. The trigger, in full
+
+The gate is one question, asked of `fields.description`: **does it state what to build?** If it does, return
+to `SKILL.md` and continue with what the first call returned. If it does not, run the discovery pass. Length
+never decides on its own — it only tells you where to look first.
+
+1. **Absent, or under 80 characters** of useful text once markup and whitespace are stripped. At that length
+   a description almost never holds a spec, so treat it as triggering — **unless** the little text there is
+   does state what to build, as a one-liner like "Bump the Stripe SDK to v14" does. A complete one-line spec
+   is a spec; do not spend a second full-issue call on it.
+2. **Longer, but still no spec** — no statement of what to build and no acceptance criteria. Typically the
+   project-wide template whose real content sits in a field named something like "Acceptance criteria".
+   Signals: every section heading present but its body empty or a placeholder (`_No response_`, `N/A`,
+   `TBD`, `-`); nothing but a checklist, a definition of done, or boilerplate identical in every ticket of
+   the project; text that defers elsewhere ("see below", "voir ci-dessous", "cf. le champ", "détails dans");
+   a bare link with no prose.
+
+Both conditions are about substance — judge them the way a reader would. A description that does say what to
+build does **not** trigger discovery, however short, however badly written, and however much boilerplate
+surrounds it. In doubt, skip: this must not become a second full-issue call on every Jira ticket.
+
+80 is a heuristic for where to stop reading closely, not a verdict: higher, and you scrutinise descriptions
+that were plainly fine; lower, and a title-only ticket slips through unexamined.
+
+`SKILL.md` carries an abridged form of these two conditions — only what is needed to decide whether to read
+this file. This section is the authoritative wording.
+
+## 2. The discovery call
+
+Re-read the **same** issue with `mcp__atlassian__getJiraIssue`, this time passing `fields: ["*all","-comment"]`,
+`expand: "names"` and `responseContentFormat: "markdown"`:
+
+- `*all` is the documented way to return every field, custom ones included — Step 2A's first call cannot
+  name a `customfield_10045` nobody knew existed.
+- `expand: "names"` returns the fieldId → display-name map in the *same* response, so labelling
+  `customfield_10045` as "Acceptance criteria" costs no second call.
+- `responseContentFormat: "markdown"` means no ADF tree to flatten, and makes §1's 80-character threshold
+  measurable on plain text.
+
+**`-comment` is an assumption, not a documented parameter.** It is Jira REST field-negation syntax, while the
+MCP tool documents only `*all` and `comment`, so the wrapper may honour it, ignore it or reject it — and the
+ignore case fails silently: the call succeeds and the entire comment thread rides in on `*all`, which is
+exactly the cost this gated pass exists to avoid. If the response carries a `comment` field anyway, drop it
+on the spot, before it reaches any summary, prompt or artefact, and never carry the thread into the ticket
+context (under `/magic:start`, design references living in comments remain
+`references/design-context.md` §2.1's job, gated on a UI signal; `/magic:continue` never reads a comment
+thread at all). If the call errors outright on the negation, retry once with plain `["*all"]` and apply the
+same drop-on-arrival rule.
+
+A failure of the discovery pass is never blocking: continue with what the first call returned, and say so.
+
+## 3. What to keep
+
+Keep only keys matching `customfield_\d+` whose value carries text, whatever shape Jira returns it in:
+
+- a plain string (short text, URL, number rendered as text);
+- an **ADF document** — `{"type":"doc","version":1,"content":[…]}`, the shape of every rich-text custom field,
+  which is exactly where a long "Acceptance criteria" lives. Flatten its `content` tree to plain text. Do not
+  assume `responseContentFormat: "markdown"` spared you this: that parameter governs the description and
+  comment bodies, and a custom field may still arrive as ADF. A doc object has no top-level `value`, so a
+  filter that only accepts strings and `value` objects drops the single most important field on the ticket
+  and sends a fully-specified ticket down the empty-ticket path;
+- an option object (`{"value":"…"}`) or an array of them — join their `value`s;
+- an array of strings — join them.
+
+Skip shapes that cannot carry a spec: user and group pickers (arrays of account objects — their
+stringification is account IDs and email addresses, never a specification), dates, and numbers on their own.
+
+When the name map does not resolve a field, fall back to its raw `customfield_XXXXX` id — an unlabelled field
+is still content.
+
+Volume guards: skip anything under **20 characters**, keep at most **8 fields**, truncate each to
+**1500 characters**.
+
+Choose those 8 by relevance before length. `expand: "names"` already paid for the display names, so use them:
+a field named for a specification — acceptance, criteria, spec, scope, besoin, exigence, définition, user
+story, description — is kept ahead of a longer one named for history, sprint notes or an audit trail. Ranking
+by length alone would drop a short, decisive "Acceptance criteria" behind three long changelog fields, which
+is precisely the field this pass exists to find. Length only breaks ties.
+
+They bound what *propagates downstream*, not what enters the context — a payload can only be filtered once
+received. §1's check is therefore the only real ingestion guard, which is why discovery is gated behind it
+instead of running on every ticket.
+
+A custom field is also a common home for customer data, an internal URL or an outright credential, and what
+is kept here is summarised into a URL-encoded `curl` query string: drop every password, token, API key,
+one-time code and personal datum from what you propagate — quote the spec, not the credentials.
+
+## 4. Outcome
+
+### 4.1 Custom fields with content found
+
+Display `MSG_JIRA_CUSTOM_FIELDS_FOUND` from `references/messages.md`, listing the display names of the fields
+kept (`{field_names}`), and treat that text as part of the ticket description from then on:
+
+- Under **`/magic:start`**, for everything downstream without exception: the Step 2.5.1 description, the
+  Step 3.2 scope score (which counts it **+2 once**, never +2 per field), the Step 5.0 UI-signal check (a
+  mockup link often lives in a custom field), exploration, plan and acceptance criteria alike.
+- Under **`/magic:continue`**, for the Step 2.5.1 description and the Step 8 resume summary. That skill
+  writes no plan and scores no scope, so there is nothing else for the text to feed.
+
+### 4.2 Still empty after discovery
+
+Display `MSG_JIRA_TICKET_EMPTY`, then use `AskUserQuestion` with exactly the three options that message lists
+(their labels live only in `references/messages.md`). Handle all three — none of them may fall through to
+undefined behaviour.
+
+- **Option 1 — describe what has to be done** → take the free-text answer as the ticket's specification and
+  continue as if the description had carried it.
+- **Option 2 — continue with the title alone** → permitted, because the user chose it, but never silently.
+  State in one line the assumption you are working from: the goal you read into the title, and the criteria
+  you will implement against. Then carry an "underspecified ticket" caveat forward for the rest of the run —
+  under `/magic:start` into the plan of Step 5.2, named next to the assumption so the plan review of Step
+  5.2.3 sees it, and into `{attention_points}` of the final summary (Step 5.5.3); under `/magic:continue`,
+  as one line immediately after the Step 8 resume summary, since that template is a fixed box with no
+  attention-points slot — do not bend the template, follow it. A caveat stated only at the moment of the
+  choice is forgotten by the time the work is read back, which is how a guessed criterion ends up looking
+  like a specified one.
+- **Option 3 — stop** → the skill stops here. Under `/magic:start`, Step 6 still runs: it closes the run
+  record opened when the skill started, with `outcome` `failed` since the workflow did not complete — an
+  unclosed record is counted as abandoned and the run disappears from the statistics. Under
+  `/magic:continue`, stop the way Step 5 Case 3 does; its Step 9 already covers a workflow that stopped
+  early.
+
+**Never invent acceptance criteria from the title alone** survives this branch in the only two forms
+compatible with option 2: never invent *silently* — the assumption is always stated and always carried
+forward — and never without the user having explicitly chosen that path. Option 2 is never the default, and
+never inferred from silence, a timeout or an unparseable answer; those go back to the question.
+
+## Usage
+
+Step 2A of `SKILL.md` evaluates the trigger inline and reads this file **only** when it fires. Once read,
+execute §2, then §3, then §4, then return to Step 2A's continuation (`/magic:start`: Step 2.5, then 2.6, then
+2.7; `/magic:continue`: Step 2.5, then 2.6) — except on option 3 of §4.2, which stops the skill.

--- a/skills/magic-continue/references/messages.md
+++ b/skills/magic-continue/references/messages.md
@@ -130,6 +130,58 @@ Plusieurs issues #{number} trouvées :
 Laquelle veux-tu utiliser ? (ou 'all')
 ```
 
+## MSG_JIRA_CUSTOM_FIELDS_FOUND
+
+### en
+
+```text
+📄 {ticket_id} has no usable spec in its description — content found in custom fields: {field_names}
+
+Treated as part of the ticket description for the rest of this session.
+```
+
+### fr
+
+```text
+📄 {ticket_id} n'a pas de spec dans sa description — contenu trouvé dans des champs personnalisés : {field_names}
+
+Traité comme faisant partie de la description du ticket pour la suite de la session.
+```
+
+> `{field_names}`: display names of the fields kept, comma-separated (the raw-id fallback of `references/jira-custom-fields.md` §3 applies).
+
+## MSG_JIRA_TICKET_EMPTY
+
+### en
+
+```text
+⚠️ {ticket_id} is nearly empty: no usable description, and no custom field carrying content either.
+
+Working from the title alone means guessing what this ticket is about.
+
+Options:
+1. Describe what has to be done (free text)
+2. Continue with the title alone, at your own risk
+3. Stop
+
+Choose (1/2/3):
+```
+
+### fr
+
+```text
+⚠️ {ticket_id} est quasi vide : pas de description exploitable, et aucun champ personnalisé ne porte de contenu.
+
+Partir du seul titre revient à deviner le sujet du ticket.
+
+Options :
+1. Décrire ce qu'il faut faire (texte libre)
+2. Continuer avec le seul titre, à tes risques
+3. Arrêter
+
+Choix (1/2/3) :
+```
+
 ## MSG_TRANSITION_FAILED
 
 ### en

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -20,6 +20,7 @@ Follow each step in order. Each step builds on the previous one.
 - `references/glossary.md` — EN/FR terminology for git concepts. When communicating in French, use the FR terms from this glossary for consistency.
 - `references/api.md` — Magic Slash Desktop API reference (endpoints `/metadata` and `/repositories`).
 - `references/test-accounts.md` — Test-account modes, discovery cascade, and the credential guardrails. Read in Step 5.5.1, only when `pullRequest.testAccounts` is not `off`.
+- `references/jira-custom-fields.md` — Jira custom-field discovery: the `*all` re-read, its volume guards, and the empty-ticket options. Read in Step 2A, only when the ticket description carries no usable spec.
 
 ## Step 0: Configuration
 
@@ -102,6 +103,8 @@ In parallel, also call `mcp__atlassian__getJiraIssueRemoteIssueLinks` for the sa
 
 If the MCP call fails (timeout, auth error), retry once. If it fails again, ask the user to provide the ticket title and description manually so the workflow can continue. A failure on the remote links call is never blocking: continue without them.
 
+**Completeness check.** The ticket's real spec may sit in a custom field. Read `references/jira-custom-fields.md` and follow it whenever `fields.description` does not state what to build: it is absent or null; or under **80 characters** of useful text once markup is stripped and not a complete one-liner ("Bump the Stripe SDK to v14" is a spec); or longer, yet stating neither what to build nor any acceptance criterion (every heading present with an empty or placeholder body, pure boilerplate, a deferral to another field, a bare link with no prose). A description that does say what to build never triggers it, however short — in doubt, skip, so this does not become a second full-issue call on every ticket. That file owns the discovery call, the volume guards, what the discovered text feeds into, and the handling of a ticket still empty afterwards. If it is missing on disk, skip discovery and degrade to the warning alone: say in one line that the ticket looks underspecified, ask the user for the missing context, and never fill the gap from the title alone.
+
 → Continue to Step 2.5, then Step 2.6, then Step 2.7.
 
 ## Step 2B: Retrieve the GitHub issue
@@ -152,6 +155,8 @@ This step updates the Magic Slash Desktop sidebar so the user sees their task co
 
 Generate a concise description (2-3 sentences max) in the configured language, based on the ticket title, description, and acceptance criteria.
 
+Custom-field text discovered in Step 2A feeds this summarisation but must never reach `/metadata` raw: the description is URL-encoded into a `curl` query string (Step 2.5.2).
+
 ### 2.5.2: Send metadata
 
 ```bash
@@ -201,6 +206,8 @@ If `$SLUG` is empty after processing (e.g., title with only special characters),
 
 **Jira**: labels, components, title, description.
 **GitHub**: labels, title, description.
+
+Custom-field text discovered in Step 2A folds into the `description` source and scores **+2 once**, not +2 per field. Eight discovered fields would otherwise outweigh a +10 label match and silently change which repo gets selected.
 
 ### 3.3: Calculate relevance score for each repo
 
@@ -385,7 +392,7 @@ Display `MSG_TASK_SUMMARY` (or `MSG_TASK_SUMMARY_FULLSTACK` for multi-repo).
 
 ### 5.0: Design context (conditional)
 
-Check the ticket (title, description, labels, components, attachment metadata, remote links, and the filtered comment matches from Step 2B.5) for a UI signal. Full comment threads are not available yet: they are fetched in `references/design-context.md` §2.1 once a signal has fired.
+Check the ticket (title, description, custom-field text discovered in Step 2A, labels, components, attachment metadata, remote links, and the filtered comment matches from Step 2B.5) for a UI signal — a mockup link often lives in a custom field. Full comment threads are not available yet: they are fetched in `references/design-context.md` §2.1 once a signal has fired.
 
 - **Tier 1** — a label or component in {`frontend`, `front`, `ui`, `ux`, `design`, `css`, `web`}: sufficient alone.
 - **Tier 2** — a resolvable reference: repo-relative path to `.html`/`.css`/a spec `.md`/a `*.styles.ts`, a `figma.com` URL, an image attachment, a `design/` or `mockups/` folder, a `.fig` file: sufficient alone.

--- a/skills/magic-start/references/design-context.md
+++ b/skills/magic-start/references/design-context.md
@@ -17,6 +17,7 @@ Reaching this file means a signal already fired — do not re-run the detection.
 | Source | How to read it |
 | --- | --- |
 | Jira description | `fields.description` from Step 2A |
+| Jira custom fields | the text kept by `references/jira-custom-fields.md` — only present when Step 2A's discovery pass ran |
 | Jira attachments | `fields.attachment[]` from Step 2A — use `filename`, `mimeType`, `content` |
 | Jira remote links | `getJiraIssueRemoteIssueLinks`, called in Step 2A — extract `object.url` and `object.title` |
 | Jira comments | fetch now: `mcp__atlassian__getJiraIssue` with `fields: ["comment"]` → `fields.comment.comments` |
@@ -31,6 +32,12 @@ A `gh` failure is non-blocking — if `gh` fails or is unavailable, continue wit
 comment still fires Tier 2. There is no equivalent for Jira: an MCP response cannot be filtered before it enters the
 context, so Jira comments are read only after a signal has fired. A design reference that exists *solely* in a Jira
 comment, on a ticket with no Tier 1 label and no Tier 3 keyword, is therefore missed. Say so rather than guessing.
+
+**Known limitation, custom fields.** Step 2A fires discovery on a description that is too short *or* that carries no
+spec, so the boilerplate-description-plus-custom-field ticket is covered. It stays gated, though: a ticket whose
+description does state what to build never triggers it, so a Figma link living only in an unrelated custom field is
+never seen — same failure mode as the Jira comment above. This is a rescue path for under-specified tickets, not
+general custom-field support: do not present it as such to the user.
 
 Scan each source **only** to extract design references.
 Never inline a whole comment thread into your context: keep the references, drop everything else.

--- a/skills/magic-start/references/jira-custom-fields.md
+++ b/skills/magic-start/references/jira-custom-fields.md
@@ -1,0 +1,145 @@
+# Jira custom-field discovery
+
+Read this file only when Step 2A's completeness check has fired: a Jira ticket whose description is too
+short, or which states neither what to build nor any acceptance criterion. It explains how to re-read the
+issue for the custom fields that may hold the real spec, what to keep out of the response, and what to do
+when discovery finds nothing either.
+
+Both `/magic:start` and `/magic:continue` read this file, and the two copies are byte-identical. Where the
+callers genuinely differ — essentially what the discovered text feeds into downstream — the difference is
+stated inline below; do not fork the file.
+
+## 1. The trigger, in full
+
+The gate is one question, asked of `fields.description`: **does it state what to build?** If it does, return
+to `SKILL.md` and continue with what the first call returned. If it does not, run the discovery pass. Length
+never decides on its own — it only tells you where to look first.
+
+1. **Absent, or under 80 characters** of useful text once markup and whitespace are stripped. At that length
+   a description almost never holds a spec, so treat it as triggering — **unless** the little text there is
+   does state what to build, as a one-liner like "Bump the Stripe SDK to v14" does. A complete one-line spec
+   is a spec; do not spend a second full-issue call on it.
+2. **Longer, but still no spec** — no statement of what to build and no acceptance criteria. Typically the
+   project-wide template whose real content sits in a field named something like "Acceptance criteria".
+   Signals: every section heading present but its body empty or a placeholder (`_No response_`, `N/A`,
+   `TBD`, `-`); nothing but a checklist, a definition of done, or boilerplate identical in every ticket of
+   the project; text that defers elsewhere ("see below", "voir ci-dessous", "cf. le champ", "détails dans");
+   a bare link with no prose.
+
+Both conditions are about substance — judge them the way a reader would. A description that does say what to
+build does **not** trigger discovery, however short, however badly written, and however much boilerplate
+surrounds it. In doubt, skip: this must not become a second full-issue call on every Jira ticket.
+
+80 is a heuristic for where to stop reading closely, not a verdict: higher, and you scrutinise descriptions
+that were plainly fine; lower, and a title-only ticket slips through unexamined.
+
+`SKILL.md` carries an abridged form of these two conditions — only what is needed to decide whether to read
+this file. This section is the authoritative wording.
+
+## 2. The discovery call
+
+Re-read the **same** issue with `mcp__atlassian__getJiraIssue`, this time passing `fields: ["*all","-comment"]`,
+`expand: "names"` and `responseContentFormat: "markdown"`:
+
+- `*all` is the documented way to return every field, custom ones included — Step 2A's first call cannot
+  name a `customfield_10045` nobody knew existed.
+- `expand: "names"` returns the fieldId → display-name map in the *same* response, so labelling
+  `customfield_10045` as "Acceptance criteria" costs no second call.
+- `responseContentFormat: "markdown"` means no ADF tree to flatten, and makes §1's 80-character threshold
+  measurable on plain text.
+
+**`-comment` is an assumption, not a documented parameter.** It is Jira REST field-negation syntax, while the
+MCP tool documents only `*all` and `comment`, so the wrapper may honour it, ignore it or reject it — and the
+ignore case fails silently: the call succeeds and the entire comment thread rides in on `*all`, which is
+exactly the cost this gated pass exists to avoid. If the response carries a `comment` field anyway, drop it
+on the spot, before it reaches any summary, prompt or artefact, and never carry the thread into the ticket
+context (under `/magic:start`, design references living in comments remain
+`references/design-context.md` §2.1's job, gated on a UI signal; `/magic:continue` never reads a comment
+thread at all). If the call errors outright on the negation, retry once with plain `["*all"]` and apply the
+same drop-on-arrival rule.
+
+A failure of the discovery pass is never blocking: continue with what the first call returned, and say so.
+
+## 3. What to keep
+
+Keep only keys matching `customfield_\d+` whose value carries text, whatever shape Jira returns it in:
+
+- a plain string (short text, URL, number rendered as text);
+- an **ADF document** — `{"type":"doc","version":1,"content":[…]}`, the shape of every rich-text custom field,
+  which is exactly where a long "Acceptance criteria" lives. Flatten its `content` tree to plain text. Do not
+  assume `responseContentFormat: "markdown"` spared you this: that parameter governs the description and
+  comment bodies, and a custom field may still arrive as ADF. A doc object has no top-level `value`, so a
+  filter that only accepts strings and `value` objects drops the single most important field on the ticket
+  and sends a fully-specified ticket down the empty-ticket path;
+- an option object (`{"value":"…"}`) or an array of them — join their `value`s;
+- an array of strings — join them.
+
+Skip shapes that cannot carry a spec: user and group pickers (arrays of account objects — their
+stringification is account IDs and email addresses, never a specification), dates, and numbers on their own.
+
+When the name map does not resolve a field, fall back to its raw `customfield_XXXXX` id — an unlabelled field
+is still content.
+
+Volume guards: skip anything under **20 characters**, keep at most **8 fields**, truncate each to
+**1500 characters**.
+
+Choose those 8 by relevance before length. `expand: "names"` already paid for the display names, so use them:
+a field named for a specification — acceptance, criteria, spec, scope, besoin, exigence, définition, user
+story, description — is kept ahead of a longer one named for history, sprint notes or an audit trail. Ranking
+by length alone would drop a short, decisive "Acceptance criteria" behind three long changelog fields, which
+is precisely the field this pass exists to find. Length only breaks ties.
+
+They bound what *propagates downstream*, not what enters the context — a payload can only be filtered once
+received. §1's check is therefore the only real ingestion guard, which is why discovery is gated behind it
+instead of running on every ticket.
+
+A custom field is also a common home for customer data, an internal URL or an outright credential, and what
+is kept here is summarised into a URL-encoded `curl` query string: drop every password, token, API key,
+one-time code and personal datum from what you propagate — quote the spec, not the credentials.
+
+## 4. Outcome
+
+### 4.1 Custom fields with content found
+
+Display `MSG_JIRA_CUSTOM_FIELDS_FOUND` from `references/messages.md`, listing the display names of the fields
+kept (`{field_names}`), and treat that text as part of the ticket description from then on:
+
+- Under **`/magic:start`**, for everything downstream without exception: the Step 2.5.1 description, the
+  Step 3.2 scope score (which counts it **+2 once**, never +2 per field), the Step 5.0 UI-signal check (a
+  mockup link often lives in a custom field), exploration, plan and acceptance criteria alike.
+- Under **`/magic:continue`**, for the Step 2.5.1 description and the Step 8 resume summary. That skill
+  writes no plan and scores no scope, so there is nothing else for the text to feed.
+
+### 4.2 Still empty after discovery
+
+Display `MSG_JIRA_TICKET_EMPTY`, then use `AskUserQuestion` with exactly the three options that message lists
+(their labels live only in `references/messages.md`). Handle all three — none of them may fall through to
+undefined behaviour.
+
+- **Option 1 — describe what has to be done** → take the free-text answer as the ticket's specification and
+  continue as if the description had carried it.
+- **Option 2 — continue with the title alone** → permitted, because the user chose it, but never silently.
+  State in one line the assumption you are working from: the goal you read into the title, and the criteria
+  you will implement against. Then carry an "underspecified ticket" caveat forward for the rest of the run —
+  under `/magic:start` into the plan of Step 5.2, named next to the assumption so the plan review of Step
+  5.2.3 sees it, and into `{attention_points}` of the final summary (Step 5.5.3); under `/magic:continue`,
+  as one line immediately after the Step 8 resume summary, since that template is a fixed box with no
+  attention-points slot — do not bend the template, follow it. A caveat stated only at the moment of the
+  choice is forgotten by the time the work is read back, which is how a guessed criterion ends up looking
+  like a specified one.
+- **Option 3 — stop** → the skill stops here. Under `/magic:start`, Step 6 still runs: it closes the run
+  record opened when the skill started, with `outcome` `failed` since the workflow did not complete — an
+  unclosed record is counted as abandoned and the run disappears from the statistics. Under
+  `/magic:continue`, stop the way Step 5 Case 3 does; its Step 9 already covers a workflow that stopped
+  early.
+
+**Never invent acceptance criteria from the title alone** survives this branch in the only two forms
+compatible with option 2: never invent *silently* — the assumption is always stated and always carried
+forward — and never without the user having explicitly chosen that path. Option 2 is never the default, and
+never inferred from silence, a timeout or an unparseable answer; those go back to the question.
+
+## Usage
+
+Step 2A of `SKILL.md` evaluates the trigger inline and reads this file **only** when it fires. Once read,
+execute §2, then §3, then §4, then return to Step 2A's continuation (`/magic:start`: Step 2.5, then 2.6, then
+2.7; `/magic:continue`: Step 2.5, then 2.6) — except on option 3 of §4.2, which stops the skill.

--- a/skills/magic-start/references/messages.md
+++ b/skills/magic-start/references/messages.md
@@ -140,6 +140,58 @@ Plusieurs issues #{number} trouvées :
 Laquelle veux-tu utiliser ? (ou 'all')
 ```
 
+## MSG_JIRA_CUSTOM_FIELDS_FOUND
+
+### en
+
+```text
+📄 {ticket_id} has no usable spec in its description — content found in custom fields: {field_names}
+
+Treated as part of the ticket description: plan, scope and acceptance criteria are built on it too.
+```
+
+### fr
+
+```text
+📄 {ticket_id} n'a pas de spec dans sa description — contenu trouvé dans des champs personnalisés : {field_names}
+
+Traité comme faisant partie de la description : le plan, le périmètre et les critères d'acceptation s'appuient dessus aussi.
+```
+
+> `{field_names}`: display names of the fields kept, comma-separated (the raw-id fallback of `references/jira-custom-fields.md` §3 applies).
+
+## MSG_JIRA_TICKET_EMPTY
+
+### en
+
+```text
+⚠️ {ticket_id} is nearly empty: no usable description, and no custom field carrying content either.
+
+Working from the title alone means inventing the acceptance criteria, then implementing the wrong thing.
+
+Options:
+1. Describe what has to be done (free text)
+2. Continue with the title alone, at your own risk
+3. Stop
+
+Choose (1/2/3):
+```
+
+### fr
+
+```text
+⚠️ {ticket_id} est quasi vide : pas de description exploitable, et aucun champ personnalisé ne porte de contenu.
+
+Partir du seul titre revient à inventer les critères d'acceptation, puis à implémenter autre chose.
+
+Options :
+1. Décrire ce qu'il faut faire (texte libre)
+2. Continuer avec le seul titre, à tes risques
+3. Arrêter
+
+Choix (1/2/3) :
+```
+
 ## MSG_SCOPE_MULTIPLE
 
 ### en


### PR DESCRIPTION
## Description

Both `/magic:start` and `/magic:continue` were blind to Jira custom fields: `/start` passed an explicit `fields` array that omitted them (`skills/magic-start/SKILL.md:96`), `/continue` passed none at all and relied on MCP defaults. On a ticket whose real specification lives in a custom field, the agent had nothing but the title to work from.

Worth recording: the cause stated in the issue — "jira API wasn't supporting custom fields" — was wrong. The API supports them; our field list excluded them.

Both skills now detect a ticket carrying no usable spec, re-read the issue for the custom fields that may hold it, and — when there is nothing to find — warn and ask instead of guessing.

## Related Issue

Fixes #15

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **New `references/jira-custom-fields.md`**, duplicated byte-identically into `magic-start` and `magic-continue` (the convention `test-accounts.md` and `node-setup.md` already follow). It owns the whole mechanism and is read only when the trigger fires, so a ticket with a normal description never loads it.
- **Two-condition trigger** in both skills' Step 2A: description absent, null or under 80 characters of useful text; **or** present but stating neither what to build nor any acceptance criterion — the project-wide template whose sections are empty or `_No response_`, pure boilerplate, a deferral to another field, a bare link. A description that does say what to build never triggers it, and the text is explicit that in doubt the agent skips.
- **Discovery call**: `fields: ["*all","-comment"]`, `expand: "names"` (the fieldId → display-name map arrives in the same response, so labelling `customfield_10045` costs no extra call) and `responseContentFormat: "markdown"` (no ADF tree to flatten).
- **Selection and guards**: keep `customfield_\d+` keys carrying text, skip under 20 characters, keep at most 8 fields — ranked by name relevance before length, so a short "Acceptance criteria" is not pushed out by three long changelog fields — truncate each to 1500 characters, and drop credentials and personal data before propagating anything.
- **Two new bilingual messages**: `MSG_JIRA_CUSTOM_FIELDS_FOUND` and `MSG_JIRA_TICKET_EMPTY`, added to both skills' `references/messages.md`. The empty-ticket path has all three of its options defined, including what "continue with the title alone" must state and carry forward.
- **Downstream wiring in `/start`**: the discovered text folds into the Step 2.5.1 summary input (never the raw `/metadata` query string), scores **+2 once** in Step 3.2 (eight fields would otherwise outweigh a +10 label match and silently change repo selection), and is scanned for a UI signal in Step 5.0 — a mockup link often lives in a custom field.
- **`references/design-context.md`**: custom fields added to the §2.1 source table, plus the residual limitation written down where the next reader will hit it.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

Two boxes are deliberately left unchecked: end-to-end verification needs a Jira project that actually has a populated custom field, which I do not have on hand. `npm test` (663 tests) and `npm run lint` (0 errors) both pass, but they cannot exercise skill prose — `vitest` only globs `desktop/**` and `webapp/lib/**`. The steps below are what a reviewer with Jira access should run.

### Test Steps

1. From the worktree, run `npm test` and `npm run lint`: expect 663 tests passing and 0 errors (3 pre-existing `no-explicit-any` warnings in `desktop/src/renderer/pages/Config/RepoPage.tsx`, untouched here).
2. Run `diff skills/magic-start/references/jira-custom-fields.md skills/magic-continue/references/jira-custom-fields.md`: expect no output. The repo requires shared reference files to be byte-identical.
3. On a Jira project with a custom field such as "Acceptance criteria", create a ticket with a title only — or with a template description whose sections are all `_No response_` — and the real spec in that custom field. Run `/magic:start PROJ-XXX` **using the skills from this branch** (installed skills live in `~/.claude/skills/`, so the repo copy has no effect until reinstalled). Expect the `MSG_JIRA_CUSTOM_FIELDS_FOUND` line naming the field, and a plan built on the field's content rather than on the title.
4. The important anti-regression check: run `/magic:start` on a ticket with a normal, self-sufficient description. Expect **no** second Jira call — if discovery fires there, the gate is too permissive and every ticket pays for it.
5. Create a ticket with neither a description nor any populated custom field and run `/magic:start` on it. Expect the `MSG_JIRA_TICKET_EMPTY` warning with three options; choosing "continue with the title alone" must print the assumption it is working from and carry an underspecified-ticket caveat into the plan and the final summary's attention points.
6. Repeat step 3 with `/magic:continue` on the same ticket to confirm the two skills agree about when discovery runs.

## Screenshots

Not applicable — no UI surface is touched.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

Three unchecked boxes, on purpose:

- **Documentation**: no user-facing docs changed because no config option was added. I checked `docs/skills.html` — `skills.startDesc` / `continueDesc` stop well above field-level detail, so audit items SK-04/SK-05 are already satisfied. The new `jira-custom-fields.md` is itself the documentation of the mechanism.
- **Tests**: `vitest` covers only `desktop/**` and `webapp/lib/**`; skill behaviour is prose executed by an agent, so there is no harness that can assert it. A regex test asserting that the prose mentions `*all` would guard nothing — unlike `terminal-handlers.test.ts`, which guards a real markdown ↔ TypeScript-union invariant.
- **CHANGELOG**: generated from conventional commits by the release skill, which also owns the version headers. Left untouched on purpose.

## Additional Notes

**Scope, deliberately narrow.** No config option was added. The alternative was a per-repo key listing custom-field IDs, which would have had to traverse the whole chain — JSON schema, TS types, defaults, writers, IPC, desktop UI, webapp, Supabase, docs — because the desktop app is the source of truth and a hand-edited `config.json` would be invisible. For a "Nice to have", auto-discovery with zero configuration is the better trade.

**One unverified assumption, flagged in the reference file itself.** `-comment` is Jira REST field-negation syntax; the `mcp__atlassian__getJiraIssue` schema documents only `*all` and `comment`, and this is the first use of `-`-negation anywhere in the repo. If the wrapper silently ignores it, `*all` drags the entire comment thread into context — exactly the cost Step 2A and `design-context.md` §2.1 are built to avoid, and it fails quietly rather than erroring. The file names the assumption, covers all three wrapper behaviours (honour / ignore / reject), and specifies a drop-on-arrival rule plus a retry on plain `["*all"]`. Still worth confirming against a live call.

**A limitation that is a design choice, not an oversight.** Discovery is gated behind the trigger, so a ticket with a serviceable description that *also* has a critical custom field is still never read. The issue's title says "Handle Jira custom fields" while its proposal says "either a warning… or being able to read from custom fields" — this implements the gated form. It is recorded as a limitation in `design-context.md`, with an instruction not to present it to the user as general custom-field support. @claire-mila, worth confirming this covers your case before we close the issue.

**`/continue` is in scope even though the issue names `/start`.** The two skills share the same Step 2A Jira retrieval; leaving one reading the title alone would have created exactly the cross-skill contradiction the shared reference files exist to prevent.

**Reviewer's attention is best spent** on the trigger's second condition — "no statement of what to build and no acceptance criteria" is a judgement call expressed in prose, re-evaluated on every run. It is written to lean toward skipping, but it is not deterministic, and it is the part most likely to need tuning against real tickets.
