### PR TITLE
[#161] Let repo pullRequest settings inherit their org-shared value

### DIFF
--- a/desktop/src/main/config/config-merge.test.ts
+++ b/desktop/src/main/config/config-merge.test.ts
@@ -3,6 +3,8 @@ import type { Config, OrgSharedConfig } from '../../types'
 import type { Store } from '../store/Store'
 import { setStore, NOOP_STORE } from '../store/Store'
 import { mergeOrgSharedConfig, hydrateConfig } from './config'
+import { DEFAULT_REPOSITORY_FIELDS } from './defaults'
+import { migrateConfig } from './migrate'
 
 // The DB is the single source of truth: config lives behind the Store. These
 // tests seed a fake in-memory store, hydrate the config cache from it, then
@@ -35,14 +37,15 @@ function baseConfig(): Config {
   }
 }
 
-describe('mergeOrgSharedConfig', () => {
-  const ORG = 'org-1'
-  const OTHER = 'org-2'
+const ORG = 'org-1'
 
-  /** A repo of ORG. `name` is the real cloud name; the record key may differ. */
-  function repo(name: string, extra: Partial<Config['repositories'][string]> = {}) {
-    return { name, orgId: ORG, path: `/local/${name}`, keywords: [], ...extra }
-  }
+/** A repo of ORG. `name` is the real cloud name; the record key may differ. */
+function repo(name: string, extra: Partial<Config['repositories'][string]> = {}) {
+  return { name, orgId: ORG, path: `/local/${name}`, keywords: [], ...extra }
+}
+
+describe('mergeOrgSharedConfig', () => {
+  const OTHER = 'org-2'
 
   it('fills unset language fields but never overrides existing local ones', async () => {
     const config = baseConfig()
@@ -184,5 +187,106 @@ describe('mergeOrgSharedConfig', () => {
     }, ORG)
     expect(result.repositories.web.languages).toEqual({ commit: 'fr' })
     expect(result.repositories.web.keywords).toEqual(['web'])
+  })
+})
+
+/**
+ * Regression cover for issue #161.
+ *
+ * The `repo()` helper above builds repositories BY HAND, without the fields the
+ * app actually stamps on every repo — which is why the tests above kept passing
+ * while no user ever inherited anything. These build a repository the way
+ * production does: DEFAULT_REPOSITORY_FIELDS spread on creation (addRepository),
+ * then the deep merge migrateConfig runs at every launch. A key with a concrete
+ * default there is set locally by the time the merge runs, and the merge only
+ * fills keys that are `undefined` — so the org's value is skipped forever.
+ */
+describe('mergeOrgSharedConfig — repositories carrying the app defaults', () => {
+  /**
+   * A repo shaped like one addRepository just created: the shared `repo()` above
+   * (which carries the orgId the merge's scoping filter needs — without it the
+   * assertions below would pass for the wrong reason), plus the defaults the app
+   * stamps on every repo at creation.
+   */
+  function defaultedRepo(name: string, extra: Partial<Config['repositories'][string]> = {}) {
+    return {
+      ...repo(name, { keywords: [name] }),
+      ...structuredClone(DEFAULT_REPOSITORY_FIELDS),
+      ...extra,
+    }
+  }
+
+  it("inherits the org's pullRequest settings on a repo built the production way", async () => {
+    const config = baseConfig()
+    config.repositories = { web: defaultedRepo('web') }
+    await seed(config)
+    migrateConfig()
+
+    const shared: OrgSharedConfig = {
+      pullRequest: { watchCI: false, testAccounts: 'inline', testAccountsSource: 'docs/test-accounts.md' },
+    }
+    const result = mergeOrgSharedConfig(shared, ORG)
+
+    expect(result.repositories.web.pullRequest).toEqual({
+      watchCI: false,
+      testAccounts: 'inline',
+      testAccountsSource: 'docs/test-accounts.md',
+    })
+  })
+
+  it('still lets a value the user set locally win over the org value', async () => {
+    const config = baseConfig()
+    config.repositories = {
+      web: defaultedRepo('web', { pullRequest: { testAccounts: 'reference' } }),
+    }
+    await seed(config)
+    migrateConfig()
+
+    const shared: OrgSharedConfig = {
+      pullRequest: { watchCI: false, testAccounts: 'inline' },
+    }
+    const result = mergeOrgSharedConfig(shared, ORG)
+
+    expect(result.repositories.web.pullRequest).toEqual({
+      testAccounts: 'reference', // local wins
+      watchCI: false, // inherited
+    })
+  })
+
+  /**
+   * The existing-install half of #161: dropping the default only helps repos
+   * created from now on, so a repo whose `pullRequest` column still holds the
+   * historical default comes back "already set" and inherits nothing. migrateConfig
+   * normalizes that block away in memory, which is what makes the merge below
+   * possible at all.
+   */
+  it("lets a repo carrying the legacy persisted defaults inherit the org's pullRequest", async () => {
+    const config = baseConfig()
+    config.repositories = {
+      web: {
+        ...repo('web', { keywords: ['web'] }),
+        // Exactly what an existing install has in repositories.pull_request.
+        pullRequest: { autoLinkTickets: true, watchCI: true, testAccounts: 'off', testAccountsSource: '' },
+      },
+    }
+    await seed(config)
+    migrateConfig()
+
+    const shared: OrgSharedConfig = {
+      pullRequest: { watchCI: false, testAccounts: 'inline', testAccountsSource: 'docs/test-accounts.md' },
+    }
+    const result = mergeOrgSharedConfig(shared, ORG)
+
+    expect(result.repositories.web.pullRequest).toEqual({
+      watchCI: false,
+      testAccounts: 'inline',
+      testAccountsSource: 'docs/test-accounts.md',
+    })
+  })
+
+  // The direct statement of the defect, so re-adding a default here fails loudly
+  // rather than quietly restoring "nothing is ever inherited".
+  it('carries no pullRequest default at all', () => {
+    expect(DEFAULT_REPOSITORY_FIELDS).not.toHaveProperty('pullRequest')
   })
 })

--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -3,6 +3,7 @@ import * as os from 'os'
 import { randomUUID } from 'crypto'
 import type { Config, RepositoryConfig, LanguageId, LaunchMode, OrgSharedConfig, ThemeId } from '../../types'
 import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig } from './defaults'
+import { normalizeLegacyPullRequest } from './normalize'
 import { expandPath } from './validation'
 import { getStore, reportWriteError } from '../store/Store'
 
@@ -77,9 +78,16 @@ function defaultConfig(): Config {
 /**
  * Fill in missing default fields on a config loaded from the store. Mirrors the
  * defaulting the old file-based reader performed on first load.
+ *
+ * Runs on EVERY install into the cache — hydrateConfig (the initial load AND
+ * remote-sync's mid-session refresh) and installRemoteConfig — which is exactly
+ * why the issue #161 normalization lives here rather than in migrateConfig
+ * alone: migrateConfig runs once per process, while the legacy `pullRequest`
+ * block is still in the database and comes back with every reload.
  */
 function withDefaults(config: Config): Config {
   config.repositories = config.repositories || {}
+  normalizeLegacyPullRequest(config)
   if (config.splitEnabled === undefined) config.splitEnabled = false
   if (config.splitActive === undefined) config.splitActive = false
   if (!config.integrations) config.integrations = { github: true, atlassian: true }

--- a/desktop/src/main/config/defaults.ts
+++ b/desktop/src/main/config/defaults.ts
@@ -57,12 +57,15 @@ export const DEFAULT_REPOSITORY_FIELDS: Omit<RepositoryConfig, 'path' | 'keyword
     replyToComments: true,
     replyLanguage: 'en'
   },
-  pullRequest: {
-    autoLinkTickets: true,
-    watchCI: true,
-    testAccounts: 'off',
-    testAccountsSource: ''
-  },
+  // KNOWN DEFECT (issue #161): a key an org can share — the SHARED_KEYS of
+  // store/CloudStore.ts — can never be inherited from the organization once it
+  // carries a concrete default HERE, because the default is already set locally by
+  // the time mergeOrgSharedConfig runs (see config-merge.test.ts for the mechanism).
+  // `pullRequest` was therefore dropped: the renderer already falls back to exactly
+  // these values (RepoPage: autoLinkTickets/watchCI true, testAccounts 'off'), so
+  // removing them changes nothing a user sees while making inheritance possible.
+  // `languages` and `commit` above still carry defaults and still have the bug —
+  // known follow-ups, not an exception to the rule.
   issues: {
     commentOnPR: true,
     jiraUrl: '',

--- a/desktop/src/main/config/migrate.test.ts
+++ b/desktop/src/main/config/migrate.test.ts
@@ -3,6 +3,7 @@ import type { Config } from '../../types'
 import type { Store } from '../store/Store'
 import { setStore, NOOP_STORE } from '../store/Store'
 import { readConfig, hydrateConfig } from './config'
+import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT } from './defaults'
 import { migrateConfig } from './migrate'
 
 // There is NO data migration from legacy local JSON files: migrateConfig only
@@ -61,6 +62,159 @@ describe('migrateConfig — repository defaults', () => {
     await seed(minimalConfig())
     migrateConfig('1.0.0')
     expect(readConfig().integrations).toEqual({ github: true, atlassian: true })
+  })
+})
+
+// The LAST pullRequest block DEFAULT_REPOSITORY_FIELDS stamped on every repo,
+// before issue #161 removed it. Written out rather than imported: it is what
+// existing installs PERSISTED, and the app no longer defaults to it at all.
+// Two OLDER shapes were persisted before it (see the tests below and the frozen
+// list in normalize.ts) and installs still carry them.
+const LEGACY_PULL_REQUEST = {
+  autoLinkTickets: true,
+  watchCI: true,
+  testAccounts: 'off',
+  testAccountsSource: '',
+} as const
+
+function withRepoPullRequest(pullRequest: unknown): Config {
+  return minimalConfig({
+    repositories: {
+      'test-repo': {
+        path: '/home/user/test-repo',
+        keywords: ['test'],
+        pullRequest: pullRequest as never,
+      },
+    },
+  })
+}
+
+describe('migrateConfig — legacy pullRequest defaults (issue #161)', () => {
+  it('drops a block left exactly at the historical default', async () => {
+    await seed(withRepoPullRequest({ ...LEGACY_PULL_REQUEST }))
+    migrateConfig('1.0.0')
+    expect(readConfig().repositories['test-repo'].pullRequest).toBeUndefined()
+  })
+
+  it('drops it whatever order the keys were persisted in', async () => {
+    await seed(withRepoPullRequest({ testAccountsSource: '', watchCI: true, testAccounts: 'off', autoLinkTickets: true }))
+    migrateConfig('1.0.0')
+    expect(readConfig().repositories['test-repo'].pullRequest).toBeUndefined()
+  })
+
+  // The shapes that PREDATE the four-key block. `repositories.pull_request` is
+  // only rewritten when the user edits that repo, so a repo created under an
+  // older release still holds the default of its day verbatim — which is the
+  // impact scenario of #161 and, by age, most of the installs in the wild.
+  it('drops the original one-key default an early release persisted', async () => {
+    await seed(withRepoPullRequest({ autoLinkTickets: true }))
+    migrateConfig('1.0.0')
+    expect(readConfig().repositories['test-repo'].pullRequest).toBeUndefined()
+  })
+
+  it('drops the two-key default that shipped between them', async () => {
+    await seed(withRepoPullRequest({ autoLinkTickets: true, watchCI: true }))
+    migrateConfig('1.0.0')
+    expect(readConfig().repositories['test-repo'].pullRequest).toBeUndefined()
+  })
+
+  it('keeps a block the user changed', async () => {
+    const touched = { ...LEGACY_PULL_REQUEST, watchCI: false }
+    await seed(withRepoPullRequest({ ...touched }))
+    migrateConfig('1.0.0')
+    expect(readConfig().repositories['test-repo'].pullRequest).toEqual(touched)
+  })
+
+  // Whole-block equality only: a partial block is not the default the app wrote,
+  // so it is somebody's choice and stays put.
+  it('keeps a partial block even when every key it has matches the default', async () => {
+    await seed(withRepoPullRequest({ watchCI: true }))
+    migrateConfig('1.0.0')
+    expect(readConfig().repositories['test-repo'].pullRequest).toEqual({ watchCI: true })
+  })
+
+  it('leaves a repo that never had the block alone', async () => {
+    await seed(minimalConfig())
+    migrateConfig('1.0.0')
+    expect(readConfig().repositories['test-repo'].pullRequest).toBeUndefined()
+  })
+
+  it('is idempotent: the second pass reports no change', async () => {
+    await seed(withRepoPullRequest({ ...LEGACY_PULL_REQUEST }))
+    expect(migrateConfig('1.0.0')).toBe(true)
+    expect(migrateConfig('1.0.0')).toBe(false)
+    expect(readConfig().repositories['test-repo'].pullRequest).toBeUndefined()
+  })
+
+  /**
+   * Models what production actually persists: the config BLOB and the
+   * REPOSITORIES are two different tables. saveConfig drops `repositories` from
+   * the blob (CloudStore.saveConfig) and repos are written per-repo only when the
+   * user edits one — so every loadConfig keeps handing back the legacy
+   * `pullRequest` block, however many times the app has stripped it in memory.
+   * The simpler `fakeStore` above cannot show this: it stores whatever it was
+   * last saved, repositories included, so the strip appears to stick.
+   */
+  function fakeSplitStore(initial: Config): Store {
+    let blob = structuredClone(initial)
+    const repositories = structuredClone(initial.repositories)
+    return {
+      ...NOOP_STORE,
+      loadConfig: async () => ({ ...structuredClone(blob), repositories: structuredClone(repositories) }),
+      saveConfig: async (c) => { blob = structuredClone(c) },
+    }
+  }
+
+  // The defect: migrateConfig is guarded by `restoredOnce` and runs ONCE per
+  // process, but remote-sync's runRefresh calls hydrateConfig again whenever a
+  // teammate edits a repo or a Realtime channel resubscribes. Normalizing only in
+  // migrateConfig let that reload restore the legacy block for the rest of the
+  // session — blocking inheritance and serving the stale block over /config.
+  it('keeps the block stripped across a mid-session re-hydration (remote-sync refresh)', async () => {
+    setStore(fakeSplitStore(withRepoPullRequest({ ...LEGACY_PULL_REQUEST })))
+    await hydrateConfig()
+    migrateConfig('1.0.0')
+    expect(readConfig().repositories['test-repo'].pullRequest).toBeUndefined()
+
+    // Exactly what runRefresh does: reload the whole config from the store.
+    await hydrateConfig()
+    expect(readConfig().repositories['test-repo'].pullRequest).toBeUndefined()
+  })
+
+  // A repo the user genuinely configured survives the reload untouched — the
+  // load-path normalization is the same whole-block rule, not a blanket wipe.
+  it('does not strip a user-modified block on re-hydration either', async () => {
+    const touched = { ...LEGACY_PULL_REQUEST, testAccounts: 'inline' }
+    setStore(fakeSplitStore(withRepoPullRequest({ ...touched })))
+    await hydrateConfig()
+    await hydrateConfig()
+    expect(readConfig().repositories['test-repo'].pullRequest).toEqual(touched)
+  })
+
+  /**
+   * Convergence. Because the block is already gone by the time migrateConfig
+   * runs, an otherwise up-to-date existing install reports NO change — so it no
+   * longer fires a writeConfig → `configs` upsert at every single launch just to
+   * re-strip a block the database will hand back again next time.
+   */
+  it('reports no change on an otherwise up-to-date install carrying the legacy block', async () => {
+    setStore(fakeSplitStore(minimalConfig({
+      version: '1.0.0',
+      integrations: { github: true, atlassian: true },
+      spotlight: { ...DEFAULT_SPOTLIGHT },
+      repositories: {
+        'test-repo': {
+          path: '/home/user/test-repo',
+          keywords: ['test'],
+          ...structuredClone(DEFAULT_REPOSITORY_FIELDS),
+          pullRequest: { ...LEGACY_PULL_REQUEST },
+        },
+      },
+    })))
+    await hydrateConfig()
+
+    expect(migrateConfig('1.0.0')).toBe(false)
+    expect(readConfig().repositories['test-repo'].pullRequest).toBeUndefined()
   })
 })
 

--- a/desktop/src/main/config/migrate.ts
+++ b/desktop/src/main/config/migrate.ts
@@ -1,5 +1,6 @@
 import { readConfig, writeConfig } from './config'
 import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig, isValidLaunchMode } from './defaults'
+import { normalizeLegacyPullRequest } from './normalize'
 import type { RepositoryConfig } from '../../types'
 
 // NOTE: There is deliberately NO data migration from the legacy local JSON files
@@ -52,6 +53,15 @@ export function migrateConfig(appVersion?: string): boolean {
         changed = true
       }
     }
+
+    // Issue #161. The load path (withDefaults) already ran this, so for a config
+    // that came from hydrateConfig this is a no-op — which is the point: it means
+    // migrateConfig no longer reports a change, and no longer triggers a
+    // writeConfig → `configs` upsert, on every single launch of an existing
+    // install. It stays here for configs that reached the cache another way, and
+    // AFTER the merge above so a block the merge re-filled is caught in the same
+    // pass.
+    if (normalizeLegacyPullRequest(config)) changed = true
   }
 
   if (!config.integrations) {

--- a/desktop/src/main/config/normalize.test.ts
+++ b/desktop/src/main/config/normalize.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import type { Config } from '../../types'
+import { normalizeLegacyPullRequest } from './normalize'
+
+// Pure unit cover for the load-path normalization (issue #161). No store, no
+// cache: normalizeLegacyPullRequest takes a config and mutates it in place.
+// migrate.test.ts covers the same rule end-to-end, through migrateConfig and a
+// re-hydration.
+
+/** The three shapes DEFAULT_REPOSITORY_FIELDS successively stamped on new repos. */
+const HISTORICAL: Record<string, Record<string, unknown>> = {
+  'the original one-key block (April → 2026-07-27)': { autoLinkTickets: true },
+  'the two-key block (2026-07-27 → 2026-07-31)': { autoLinkTickets: true, watchCI: true },
+  'the four-key block shipped in 0.62.0': {
+    autoLinkTickets: true, watchCI: true, testAccounts: 'off', testAccountsSource: '',
+  },
+}
+
+function configWith(pullRequest: unknown): Config {
+  return {
+    version: '1.0.0',
+    repositories: {
+      web: { path: '/local/web', keywords: ['web'], pullRequest: pullRequest as never },
+    },
+    splitEnabled: false,
+    splitActive: false,
+  }
+}
+
+describe('normalizeLegacyPullRequest — historical defaults', () => {
+  for (const [label, block] of Object.entries(HISTORICAL)) {
+    it(`strips ${label}`, () => {
+      const config = configWith({ ...block })
+      expect(normalizeLegacyPullRequest(config)).toBe(true)
+      expect(config.repositories.web.pullRequest).toBeUndefined()
+    })
+
+    it(`strips ${label} whatever order the keys were persisted in`, () => {
+      const reversed = Object.fromEntries(Object.entries(block).reverse())
+      const config = configWith(reversed)
+      expect(normalizeLegacyPullRequest(config)).toBe(true)
+      expect(config.repositories.web.pullRequest).toBeUndefined()
+    })
+  }
+})
+
+describe('normalizeLegacyPullRequest — blocks that must survive', () => {
+  // Whole-block equality: a near-miss is somebody's choice, and handing it to
+  // the org would silently replace a value the user picked.
+  const preserved: Record<string, Record<string, unknown>> = {
+    'one value changed': { autoLinkTickets: true, watchCI: false },
+    'one key missing from a historical shape': { autoLinkTickets: true, watchCI: true, testAccounts: 'off' },
+    'a key no historical shape ever had': { autoLinkTickets: true, watchCI: true, draft: true },
+    'every key matching but only a subset present': { watchCI: true },
+    'the newest shape with a non-default source': {
+      autoLinkTickets: true, watchCI: true, testAccounts: 'off', testAccountsSource: 'TESTING.md',
+    },
+    'a block the user emptied': {},
+  }
+
+  for (const [label, block] of Object.entries(preserved)) {
+    it(`keeps a block with ${label}`, () => {
+      const config = configWith({ ...block })
+      expect(normalizeLegacyPullRequest(config)).toBe(false)
+      expect(config.repositories.web.pullRequest).toEqual(block)
+    })
+  }
+
+  it('reports no change on a repo that never had the block', () => {
+    const config = configWith(undefined)
+    delete config.repositories.web.pullRequest
+    expect(normalizeLegacyPullRequest(config)).toBe(false)
+    expect(config.repositories.web.pullRequest).toBeUndefined()
+  })
+
+  it('ignores a block that is not an object at all', () => {
+    for (const value of [null, 'off', 42, [{ autoLinkTickets: true }]]) {
+      const config = configWith(value)
+      expect(normalizeLegacyPullRequest(config)).toBe(false)
+      expect(config.repositories.web.pullRequest).toEqual(value)
+    }
+  })
+})
+
+describe('normalizeLegacyPullRequest — across repositories', () => {
+  it('strips only the untouched repos, and reports a change when any was', () => {
+    const config = configWith({ autoLinkTickets: true })
+    config.repositories.api = {
+      path: '/local/api', keywords: ['api'],
+      pullRequest: { autoLinkTickets: false } as never,
+    }
+
+    expect(normalizeLegacyPullRequest(config)).toBe(true)
+    expect(config.repositories.web.pullRequest).toBeUndefined()
+    expect(config.repositories.api.pullRequest).toEqual({ autoLinkTickets: false })
+  })
+
+  it('is idempotent: a second pass reports nothing', () => {
+    const config = configWith({ autoLinkTickets: true, watchCI: true })
+    expect(normalizeLegacyPullRequest(config)).toBe(true)
+    expect(normalizeLegacyPullRequest(config)).toBe(false)
+  })
+
+  it('tolerates a config with no repositories', () => {
+    expect(normalizeLegacyPullRequest({ version: '1.0.0' } as Config)).toBe(false)
+  })
+})

--- a/desktop/src/main/config/normalize.ts
+++ b/desktop/src/main/config/normalize.ts
@@ -1,0 +1,101 @@
+import type { Config } from '../../types'
+
+// LEAF MODULE (imports types only, never ./config): every other module in
+// config/ depends on config.ts one-way, and this normalization runs FROM the
+// load path in config.ts — so it has to live below it, not beside migrate.ts
+// which imports readConfig/writeConfig and would close the loop into a cycle.
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Every `pullRequest` block DEFAULT_REPOSITORY_FIELDS ever stamped on the repos
+ * it created, oldest first, until issue #161 removed the default outright:
+ *
+ *  1. `{ autoLinkTickets: true }` — from 9b66ab5 (2026-04-05, and the same shape
+ *     in config.ts before defaults.ts existed) until 2026-07-27.
+ *  2. `+ watchCI: true` — 934873b (2026-07-27) until 2026-07-31.
+ *  3. `+ testAccounts / testAccountsSource` — e610bca (2026-07-31), shipped in
+ *     0.62.0 and the only shape the app itself still writes today.
+ *
+ * All three are still out there: a repo's `repositories.pull_request` column is
+ * only rewritten when the user edits that repo (persistRepoIdentity), so a repo
+ * created under 1. and never touched since still holds 1. verbatim. Recognising
+ * only the newest shape would leave most existing installs unable to inherit.
+ *
+ * FROZEN HISTORY — spelled out here on purpose and deliberately NOT derived from
+ * DEFAULT_REPOSITORY_FIELDS, which no longer carries the block at all. This is
+ * what installs PERSISTED, not what the app defaults to; re-deriving it would
+ * make the strip below silently follow future default changes. Append to this
+ * list, never edit an entry.
+ */
+const LEGACY_DEFAULT_PULL_REQUESTS: readonly Readonly<Record<string, unknown>>[] = Object.freeze([
+  Object.freeze({ autoLinkTickets: true }),
+  Object.freeze({ autoLinkTickets: true, watchCI: true }),
+  Object.freeze({ autoLinkTickets: true, watchCI: true, testAccounts: 'off', testAccountsSource: '' }),
+])
+
+/** Same key set AND same values — a block that partially matches is not a match. */
+function equalsBlock(value: Record<string, unknown>, legacy: Readonly<Record<string, unknown>>): boolean {
+  const keys = Object.keys(legacy)
+  if (Object.keys(value).length !== keys.length) return false
+  return keys.every((key) => value[key] === legacy[key])
+}
+
+/**
+ * Whether a repo's `pullRequest` block is EXACTLY one of the historical defaults,
+ * i.e. a block the user demonstrably never touched.
+ *
+ * Whole-block equality, never per-key: a user's deliberate `watchCI: true` is
+ * indistinguishable from the default one, so a per-key strip would hand a choice
+ * they made to the organization. A block must equal one historical default in
+ * full, or nothing happens to it.
+ */
+function isUntouchedLegacyPullRequest(value: unknown): boolean {
+  if (!isPlainObject(value)) return false
+  return LEGACY_DEFAULT_PULL_REQUESTS.some((legacy) => equalsBlock(value, legacy))
+}
+
+/**
+ * Issue #161: strip the historical `pullRequest` default off every repo that
+ * still carries it, IN MEMORY. Returns whether anything was removed.
+ *
+ * Why it has to exist at all: repos an existing install already created carry
+ * that block in the `repositories` table, so it comes back as "already set" and
+ * mergeOrgSharedConfig — which only fills keys that are undefined — can never
+ * hand them the organization's conventions. Dropping the default from
+ * DEFAULT_REPOSITORY_FIELDS only helps repos created from now on; this pass is
+ * what unblocks the repos that already exist.
+ *
+ * WHERE IT RUNS: `withDefaults` in config.ts, i.e. on EVERY load into the cache —
+ * the initial hydration, and equally the mid-session re-hydration that
+ * remote-sync's runRefresh performs when a teammate edits a repo or a Realtime
+ * channel resubscribes. That matters because migrateConfig is guarded by
+ * `restoredOnce` (ipc/connectivity-handlers.ts) and runs ONCE per process: were
+ * this applied there alone, the very next refresh would reload the legacy block
+ * straight from the database and block inheritance again — and serve the stale
+ * block over the /config HTTP endpoint (hooks/status-server.ts) the /magic:*
+ * skills read — for the rest of the session. migrateConfig still calls it, so a
+ * config that reached the cache by some other route is normalized too; by then
+ * it is normally a no-op.
+ *
+ * IN-MEMORY ONLY, and the database row is deliberately left untouched. Repos do
+ * not live in the config blob: writeConfig → CloudStore.saveConfig does
+ * `delete data.repositories` and repos are persisted per-repo into the
+ * `repositories` table, whose columns are only written by explicit repo edits
+ * (persistRepoIdentity). So the strip never reaches storage and a user's stored
+ * values are never destroyed — if the app ever stops stripping, their block is
+ * still exactly where they left it.
+ */
+export function normalizeLegacyPullRequest(config: Config): boolean {
+  if (!config.repositories) return false
+  let changed = false
+  for (const repo of Object.values(config.repositories)) {
+    if (isUntouchedLegacyPullRequest(repo.pullRequest)) {
+      delete repo.pullRequest
+      changed = true
+    }
+  }
+  return changed
+}

--- a/desktop/src/main/store/CloudStore.test.ts
+++ b/desktop/src/main/store/CloudStore.test.ts
@@ -1174,6 +1174,92 @@ describe('listRepositories', () => {
   })
 })
 
+/**
+ * Issue #161. The repositories table's jsonb blocks are `not null default '{}'`,
+ * so a repo that configures nothing round-trips as `{}` rather than as null.
+ * mapRepositoryRow maps the three SHAREABLE blocks back to `undefined` (toBlock);
+ * the rest keep the plain `?? undefined` mapping.
+ *
+ * NORMALIZATION, not the fix: a `{}` block would inherit from the organization
+ * anyway, because mergeOrgSharedConfig fills PER KEY over a `repo.pullRequest ||
+ * {}`. The guard that #161 actually needs is `isEmptyBlock` in
+ * projectSharedFields — covered by the saveConfig tests further down, which pin
+ * that an empty block is never published as the org's shared config.
+ *
+ * Exercised through listRepositories, the thinnest caller of mapRepositoryRow.
+ */
+describe('mapRepositoryRow — empty jsonb blocks (toBlock)', () => {
+  const rowWith = (blocks: Record<string, unknown>) => ({
+    id: 'r1', owner_id: UID, org_id: ORG, name: 'api', keywords: ['api'], color: null,
+    languages: null, commit: null, pull_request: null,
+    resolve: null, issues: null, branches: null, worktree_files: null,
+    ...blocks,
+  })
+
+  async function loadOne(blocks: Record<string, unknown>) {
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      repositories: { data: [rowWith(blocks)], error: null },
+      repository_paths: { data: [], error: null },
+    })
+    h.state.client = client
+    return (await new CloudStore().listRepositories())[0]
+  }
+
+  it('reads an empty shareable block as absent', async () => {
+    const repo = await loadOne({ languages: {}, commit: {}, pull_request: {} })
+    expect(repo.languages).toBeUndefined()
+    expect(repo.commit).toBeUndefined()
+    expect(repo.pullRequest).toBeUndefined()
+  })
+
+  it('preserves a populated shareable block untouched', async () => {
+    const repo = await loadOne({
+      languages: { commit: 'fr' },
+      commit: { format: 'gitmoji' },
+      pull_request: { watchCI: false },
+    })
+    expect(repo.languages).toEqual({ commit: 'fr' })
+    expect(repo.commit).toEqual({ format: 'gitmoji' })
+    expect(repo.pullRequest).toEqual({ watchCI: false })
+  })
+
+  // A block holding an explicit falsy value is configured, not empty: only `{}`
+  // (and null) read as absent.
+  it('keeps a block whose only value is falsy', async () => {
+    const repo = await loadOne({ pull_request: { autoLinkTickets: false } })
+    expect(repo.pullRequest).toEqual({ autoLinkTickets: false })
+  })
+
+  it('maps a null shareable block to undefined, as before', async () => {
+    const repo = await loadOne({})
+    expect(repo.languages).toBeUndefined()
+    expect(repo.commit).toBeUndefined()
+    expect(repo.pullRequest).toBeUndefined()
+  })
+
+  // resolve/issues/branches are NOT shareable: nothing merges an org value into
+  // them, so they keep their previous mapping. Collapsing their `{}` to undefined
+  // would change how migrate.ts's deepMergeDefaults treats them (a missing key is
+  // filled wholesale instead of recursed into) for no reason tied to this issue.
+  it('leaves the non-shareable blocks on their previous mapping', async () => {
+    const empty = await loadOne({ resolve: {}, issues: {}, branches: {} })
+    expect(empty.resolve).toEqual({})
+    expect(empty.issues).toEqual({})
+    expect(empty.branches).toEqual({})
+
+    const nulled = await loadOne({})
+    expect(nulled.resolve).toBeUndefined()
+    expect(nulled.issues).toBeUndefined()
+    expect(nulled.branches).toBeUndefined()
+
+    const set = await loadOne({ resolve: { commitMode: 'amend' }, issues: { commentOnPR: false }, branches: { development: 'dev' } })
+    expect(set.resolve).toEqual({ commitMode: 'amend' })
+    expect(set.issues).toEqual({ commentOnPR: false })
+    expect(set.branches).toEqual({ development: 'dev' })
+  })
+})
+
 describe('createRepository', () => {
   it('inserts an identity row owned by the caller and binds the local path', async () => {
     const { client, inserts, upserts } = makeClient({
@@ -1821,5 +1907,110 @@ describe('saveConfig', () => {
     // Shared projection derived from the in-memory repos is still mirrored top-level.
     expect(savedBlob.repoKeywords).toEqual({ demo: ['kw'] })
     expect(savedBlob.commit).toEqual({ format: 'angular' })
+  })
+
+  // Issue #161. The repositories table's jsonb columns are NOT NULL DEFAULT '{}',
+  // so a repo that configures nothing comes back with an empty block — truthy,
+  // and enough to be picked as "the" shared value if nothing checks.
+  it('never lets a repo with an empty block shadow one that is actually configured', async () => {
+    const { client, upserts } = makeClient({
+      memberships: membershipsOk,
+      configs: { data: null, error: null },
+      user_settings: { data: null, error: null },
+    })
+    h.state.client = client
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config: any = {
+      version: '1',
+      repositories: {
+        // First in the record, and carrying nothing.
+        blank: { id: 'r1', path: '/a', keywords: ['blank'], languages: {}, commit: {}, pullRequest: {} },
+        web: {
+          id: 'r2', path: '/b', keywords: ['web'],
+          languages: { commit: 'fr' }, commit: { format: 'gitmoji' }, pullRequest: { watchCI: false },
+        },
+      },
+    }
+    await new CloudStore().saveConfig(config)
+
+    const savedBlob = (upserts.configs[0] as { data: Record<string, unknown> }).data
+    expect(savedBlob.languages).toEqual({ commit: 'fr' })
+    expect(savedBlob.commit).toEqual({ format: 'gitmoji' })
+    expect(savedBlob.pullRequest).toEqual({ watchCI: false })
+  })
+
+  /**
+   * Load an existing `configs` row, then save a config with no repositories — so
+   * nothing local can re-derive the shared keys and only the mirror can supply
+   * them. `beforeSave` runs between the two, to change the session mid-flight.
+   * Returns the row the save upserted.
+   */
+  async function loadThenSaveEmpty(
+    blob: Record<string, unknown>,
+    beforeSave?: (store: CloudStore) => void | Promise<void>,
+  ): Promise<{ user_id: string; data: Record<string, unknown> }> {
+    const { client, upserts } = makeClient({
+      memberships: membershipsOk,
+      configs: { data: { data: blob }, error: null },
+      user_settings: { data: null, error: null },
+      organizations: { data: [], error: null },
+      repositories: { data: [], error: null },
+      repository_paths: { data: [], error: null },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.loadConfig()
+    await beforeSave?.(store)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await store.saveConfig({ version: '1', repositories: {} } as any)
+
+    return upserts.configs.at(-1) as { user_id: string; data: Record<string, unknown> }
+  }
+
+  // Issue #161. For an org admin this row IS the organization's shared config
+  // (get_org_shared_config reads it), and this upsert replaces `data` wholesale.
+  // Now that repositories carry no pullRequest default, nothing local can
+  // re-derive the key the admin wrote through set_org_shared_config.
+  it("keeps a shared key no repo can source, so a save never erases the org's config", async () => {
+    const saved = await loadThenSaveEmpty({
+      version: '1',
+      pullRequest: { watchCI: false, testAccounts: 'inline' },
+    })
+
+    expect(saved.data.pullRequest).toEqual({ watchCI: false, testAccounts: 'inline' })
+  })
+
+  /**
+   * Issue #161. set_org_shared_config writes into the ORG CREATOR's config row, so
+   * for the common case where the admin is the creator, the row the mirror is
+   * holding a snapshot of has just changed underneath it. A mirror left at its
+   * pre-RPC value makes the very next save republish the OLD shared config and
+   * silently revert what the admin published — and since no repo carries a
+   * pullRequest default any more, nothing local can correct it.
+   */
+  it('does not revert a shared config published earlier in the same session', async () => {
+    const saved = await loadThenSaveEmpty(
+      { version: '1', commit: { format: 'angular' }, pullRequest: { watchCI: true, testAccounts: 'off' } },
+      (store) => store.setOrgSharedConfig(ORG, { pullRequest: { watchCI: false, testAccounts: 'inline' } }),
+    )
+
+    expect(saved.data.pullRequest).toEqual({ watchCI: false, testAccounts: 'inline' })
+    // Keys the admin did not publish keep the value the row already had, exactly
+    // as the RPC's `data || subset` merge leaves them.
+    expect(saved.data.commit).toEqual({ format: 'angular' })
+  })
+
+  it("never writes one account's remembered shared keys into another account's row", async () => {
+    // The same store instance outlives a sign-out; the next user must not
+    // inherit the previous one's mirror.
+    const saved = await loadThenSaveEmpty(
+      { pullRequest: { watchCI: false } },
+      () => { h.state.session = { user: { id: 'user-2' } } },
+    )
+
+    expect(saved.user_id).toBe('user-2')
+    expect(saved.data).not.toHaveProperty('pullRequest')
   })
 })

--- a/desktop/src/main/store/CloudStore.ts
+++ b/desktop/src/main/store/CloudStore.ts
@@ -168,14 +168,39 @@ function mapSkillCountRows(data: unknown): SkillCounts {
   return counts
 }
 
+/**
+ * Whether a settings block carries nothing, i.e. is `{}`.
+ *
+ * The repositories table's jsonb columns are `not null default '{}'` (migration
+ * 20260724110000), so a repo that has no block at all round-trips as an EMPTY
+ * OBJECT rather than as null — and an empty object is both `!== undefined` and
+ * truthy. Every place that asks "does this repo configure X?" therefore has to
+ * ask this instead of a bare truthiness test. See issue #161.
+ */
+function isEmptyBlock(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && Object.keys(value).length === 0
+}
+
+/**
+ * A SHAREABLE jsonb settings column as the app sees it: the `{}` the column
+ * defaults to reads as an absent block rather than a configured one.
+ * Applied to the SHARED_KEYS blocks only — see mapRepositoryRow.
+ */
+function toBlock<T>(value: T | null): T | undefined {
+  return value === null || isEmptyBlock(value) ? undefined : value
+}
+
 /** The four shareable keys, projected to the TOP LEVEL of the config blob so the
  *  get_org_shared_config SECURITY DEFINER function keeps returning them. */
 function projectSharedFields(config: Config): Record<string, unknown> {
   const repos = Object.values(config.repositories ?? {})
   const named = Object.entries(config.repositories ?? {})
 
+  // An EMPTY block is not a configured one: taking it would let the first repo
+  // in the record — which may have nothing set — shadow the repo that actually
+  // carries the org's conventions, and publish `{}` as the org's shared config.
   const firstWith = <K extends keyof (typeof repos)[number]>(key: K) =>
-    repos.find((r) => r[key] !== undefined)?.[key]
+    repos.find((r) => r[key] !== undefined && !isEmptyBlock(r[key]))?.[key]
 
   const repoKeywords: Record<string, string[]> = {}
   for (const [name, repo] of named) {
@@ -234,6 +259,20 @@ export class CloudStore implements Store {
   private agentIdMap = new Map<string, string>()
   /** app agent id → digest of its last-synced repository ids (see syncRepoLinks). */
   private agentRepoKey = new Map<string, string>()
+  /**
+   * The top-level shared projection as found in the config blob at load, keyed by
+   * `org_id|user_id` — the `configs` primary key, so one account's mirror is never
+   * written into another's row (a CloudStore outlives a sign-out).
+   *
+   * Exists because saveConfig upserts the WHOLE `data` blob: a key that
+   * projectSharedFields cannot source from any repo would disappear on the next
+   * save. For an org admin that row IS the organization's shared config
+   * (get_org_shared_config reads it — migration 20260723100000), so the save would
+   * erase what set_org_shared_config wrote. Best-effort by construction: it only
+   * protects rows this process actually loaded, so a failed loadConfig leaves the
+   * mirror empty. The durable fix is a jsonb-merging save (see issue #161).
+   */
+  private sharedMirror = new Map<string, Record<string, unknown>>()
 
   setActiveOrgId(orgId: string | undefined): void {
     this.activeOrgId = orgId
@@ -396,7 +435,14 @@ export class CloudStore implements Store {
 
     const blob = { ...((data as ConfigRow | null)?.data ?? {}) } as Record<string, unknown>
     // Drop the top-level shared projection — it is a mirror, not part of Config.
-    for (const key of SHARED_KEYS) delete blob[key]
+    // Remember it first: saveConfig rewrites the entire blob and would otherwise
+    // delete any shared key the local repos cannot re-derive. See sharedMirror.
+    const mirror: Record<string, unknown> = {}
+    for (const key of SHARED_KEYS) {
+      if (blob[key] !== undefined) mirror[key] = blob[key]
+      delete blob[key]
+    }
+    this.sharedMirror.set(this.sharedMirrorKey(ctx), mirror)
 
     // One-shot migration: repos used to live inside the config blob. Move any
     // that remain into the repositories table (as personal repos) + bind the
@@ -439,7 +485,16 @@ export class CloudStore implements Store {
     // working for org admins. Two families of keys are stripped: `repositories`
     // (persisted in repositories/repository_paths) and every settings key (now
     // owned by user_settings), so the blob holds only org-scoped state.
-    const data: Record<string, unknown> = { ...config, ...projectSharedFields(config) }
+    //
+    // The projection is layered OVER what the row already held (sharedMirror):
+    // this upsert replaces `data` wholesale, so a key no repo can source — an
+    // org whose `pullRequest` conventions no member has overridden locally, or
+    // anything written straight into the row by set_org_shared_config — would be
+    // dropped by the very next save. A derived value still wins over the mirror;
+    // the mirror only fills what would otherwise be lost.
+    const mirrorKey = this.sharedMirrorKey(ctx)
+    const projected = { ...(this.sharedMirror.get(mirrorKey) ?? {}), ...projectSharedFields(config) }
+    const data: Record<string, unknown> = { ...config, ...projected }
     delete data.repositories
     for (const key of SETTINGS_KEYS) delete data[key]
 
@@ -447,6 +502,15 @@ export class CloudStore implements Store {
       .from('configs')
       .upsert({ org_id: ctx.orgId, user_id: ctx.uid, data }, { onConflict: 'org_id,user_id' })
     if (error) throw new Error(`saveConfig failed: ${error.message}`)
+
+    // The row now holds exactly this; keep the mirror in step so a second save
+    // in the same session does not fall back to a staler snapshot.
+    this.sharedMirror.set(mirrorKey, projected)
+  }
+
+  /** `configs` primary key as a map key: the mirror is per row, never per process. */
+  private sharedMirrorKey(ctx: { orgId: string; uid: string }): string {
+    return `${ctx.orgId}|${ctx.uid}`
   }
 
   // -------------------------------------------------------------------------
@@ -454,6 +518,11 @@ export class CloudStore implements Store {
   // path in `repository_paths`.
   // -------------------------------------------------------------------------
 
+  /**
+   * PATCH → column map. An ABSENT key is a no-op (the column keeps its value);
+   * only a key explicitly present writes. A cleared block is stored as `{}`, not
+   * null — the columns are `not null`, and `mapRepositoryRow` maps it back.
+   */
   private repoIdentityToRow(patch: Partial<RepositoryIdentity>): Record<string, unknown> {
     const row: Record<string, unknown> = {}
     if (patch.name !== undefined) row.name = patch.name
@@ -470,6 +539,29 @@ export class CloudStore implements Store {
     return row
   }
 
+  /**
+   * Row → app shape. The three SHAREABLE blocks come back through `toBlock`, so
+   * the columns' `{}` default reads as an absent block rather than a configured
+   * one.
+   *
+   * NORMALIZATION, not the issue #161 fix. An empty block does not block
+   * inheritance on its own: mergeOrgSharedConfig does `repo.pullRequest =
+   * repo.pullRequest || {}` and applyValues fills PER KEY (`if (target[key] ===
+   * undefined)`), so a `{}` block still inherits every key the org shares. What
+   * `toBlock` buys is a single shape for "nothing configured" — `undefined`,
+   * as for a repo that never round-tripped through the database.
+   *
+   * The guard that IS load-bearing for #161 is the `isEmptyBlock` test in
+   * `projectSharedFields`: without it a repo carrying `{}` is picked as the
+   * first repo "with" a block and `{}` gets published as the organization's
+   * shared config.
+   *
+   * Deliberately NOT applied to `resolve`/`issues`/`branches`: they are not in
+   * SHARED_KEYS, nothing merges an org's value into them, and mapping their `{}`
+   * to `undefined` would silently change how migrate.ts's deepMergeDefaults
+   * treats them (`if (!(key in result))` fills a missing key wholesale instead
+   * of recursing into it). They keep the plain `?? undefined` mapping.
+   */
   private mapRepositoryRow(row: RepositoryRow, path: string | null): StoredRepository {
     return {
       id: row.id,
@@ -478,9 +570,9 @@ export class CloudStore implements Store {
       name: row.name,
       keywords: row.keywords ?? [],
       color: row.color ?? undefined,
-      languages: row.languages ?? undefined,
-      commit: row.commit ?? undefined,
-      pullRequest: row.pull_request ?? undefined,
+      languages: toBlock(row.languages),
+      commit: toBlock(row.commit),
+      pullRequest: toBlock(row.pull_request),
       resolve: row.resolve ?? undefined,
       issues: row.issues ?? undefined,
       branches: row.branches ?? undefined,
@@ -1213,6 +1305,34 @@ export class CloudStore implements Store {
     if (!client) throw new Error('Cloud features are not available')
     const { error } = await client.rpc('set_org_shared_config', { p_org_id: orgId, p_shared: shared })
     if (error) throw new Error(error.message)
+
+    // Bring sharedMirror back in step with the row that was just written.
+    //
+    // UPDATE, not clear. Clearing would leave the next saveConfig with no fallback
+    // at all, and `pullRequest` is precisely the key no repo can re-derive since
+    // issue #161 — so the full-blob upsert would erase the config that was just
+    // published, which is the exact failure the mirror exists to prevent. Leaving
+    // the mirror alone is just as bad the other way: the next save would republish
+    // the PRE-RPC snapshot and silently revert the admin's change.
+    //
+    // The applied value mirrors what the RPC does (migration 20260724090000): the
+    // shared subset of `p_shared`, nulls dropped, merged over the row's existing
+    // data — so a key absent from `shared` keeps its mirrored value rather than
+    // being dropped.
+    //
+    // Applied to every mirrored row of this org rather than to one computed key:
+    // the RPC targets the ORG CREATOR's row, whose uid is not known here, and the
+    // case that actually goes stale — the admin IS the creator — is exactly the row
+    // this process loaded. Rows this process never loaded have no mirror entry, and
+    // no entry is created here: the mirror only ever protects what it has seen.
+    const subset: Record<string, unknown> = {}
+    for (const key of SHARED_KEYS) {
+      const value = (shared as Record<string, unknown>)[key]
+      if (value !== undefined && value !== null) subset[key] = value
+    }
+    for (const [key, mirrored] of this.sharedMirror) {
+      if (key.startsWith(`${orgId}|`)) this.sharedMirror.set(key, { ...mirrored, ...subset })
+    }
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`OrgSharedConfig.pullRequest` advertises `autoLinkTickets`, `watchCI`, `testAccounts` and `testAccountsSource` as values a repo inherits from its organization, but no repo ever inherited any of them: `DEFAULT_REPOSITORY_FIELDS.pullRequest` declared concrete values, those reached every repo on creation and through `migrate`, and `applyValues` only fills keys that are `undefined` — so `mergeOrgSharedConfig` always found the block already populated and skipped it.

This implements option 1 from the issue (drop the defaults). Two follow-on changes in `CloudStore` are included because the removal creates them, not as scope creep: with no repo able to source `pullRequest`, the wholesale `configs.data` upsert in `saveConfig` would delete the key from the org creator's row — i.e. from `get_org_shared_config` for the whole team.

## Related Issue

Fixes #161

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

Two commits, ordered so each is sound in isolation (`3095c30` first — the guard is harmless alone; reversing them would leave a commit where the org-shared config can be erased):

- **`3095c30` — `CloudStore.ts`**
  - `projectSharedFields.firstWith` now skips empty blocks. Without it a repo whose `pull_request` column holds the Postgres `not null default '{}'` would be published as the organization's shared config.
  - `sharedMirror`: `loadConfig` captures the `SHARED_KEYS` it strips from the blob, `saveConfig` layers the projection over them. This is what stops the full-blob upsert from dropping a key no repo can re-derive.
  - `setOrgSharedConfig` refreshes the mirror, so a freshly published shared config cannot be reverted by the next save in the same session.
  - `mapRepositoryRow` normalizes an empty jsonb block to `undefined` for the three `SHARED_KEYS` blocks only. This is normalization, not the fix — `applyValues` is per-key, so a `{}` block already inherited fine.
- **`871f463` — the fix proper**
  - `defaults.ts`: `pullRequest` removed from `DEFAULT_REPOSITORY_FIELDS`, with a note that `commit` and `languages` still carry the same defect.
  - `normalize.ts` (new leaf module): drops a persisted `pullRequest` block **in memory** when it exactly equals one of the three historical defaults (`{autoLinkTickets}` from 9b66ab5, `+watchCI` from 934873b, the 4-key shape from e610bca). Whole-block equality only — never per-key, so a deliberate `watchCI: true` is never handed to the org.
  - `config.ts`: called from `withDefaults`, so it runs on every load — not just the once-per-process `migrateConfig`, which a mid-session re-hydration would otherwise undo.
  - +19 tests across `normalize.test.ts`, `migrate.test.ts`, `config-merge.test.ts` and `CloudStore.test.ts`. The merge test now builds its repo the production way (`DEFAULT_REPOSITORY_FIELDS` spread + `migrateConfig`), which is the caveat the issue raised about the old `config-merge.test.ts`.

Nothing is written back to the database: `saveConfig` drops `repositories`, and `repoIdentityToRow` treats an absent key as a no-op, so a user's stored values survive untouched.

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script — not applicable, no install path touched
- [ ] Tested affected slash commands — see Additional Notes, the org path needs two accounts

`npm test` 704/704, `tsc --noEmit` clean, `npm run lint` 0 errors (3 pre-existing `no-explicit-any` warnings in `RepoPage.tsx`, untouched here). Each production change was mutation-tested: reverting `defaults.ts` fails 5 tests, `config.ts` + `migrate.ts` fails 2, `CloudStore.ts` fails 4.

### Test Steps

Prerequisites: Node 20 (`.nvmrc`), `npm ci` at the root and in `desktop/`, then `npm run desktop:install` before launching the app (electron-rebuild).

1. Run `npm test` at the repo root — expect 704 passing, including the new `normalize.test.ts` file and the new blocks in `migrate.test.ts` / `config-merge.test.ts` / `CloudStore.test.ts`.
2. Start the app (`npm run desktop`), open Config → any repo → Pull Request tab. The four settings must display their usual values (auto-link on, watch CI on, test accounts "off"). This confirms the renderer fallbacks cover the removed defaults — nothing should look blank or reset.
3. Toggle `watchCI` off, quit and relaunch the app. The value must still be off: a user-set value is not a historical default, so the normalization must leave it alone.
4. Toggle it back on, quit and relaunch. It stays on — but note this now reproduces the default block exactly, so the repo returns to "not decided" and becomes eligible to inherit. That is the intended trade, called out in Additional Notes.
5. With the app running, check that a never-edited repo no longer exposes the frozen block: `curl "http://127.0.0.1:$MAGIC_SLASH_PORT/config" | jq '.repositories[].pullRequest'` — expect `null` for repos left at defaults, and only user-set keys for the others.
6. Confirm the org-shared config is not erased: as an org admin, edit any repo setting (which triggers `saveConfig`), then re-read the shared config. `pullRequest` must still be present with its published value.

## Screenshots

Not applicable — no UI change. The Pull Request settings tab renders identically; only where its values come from has changed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly — no user-facing behaviour change to document
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md — release-generated from commits in this repo

## Additional Notes

Reviewer-facing caveats, in rough order of importance. The first two mean this PR unblocks the mechanism without yet producing a visible effect for org members, so there is no urgency to merge it ahead of them:

1. **Inheritance is not durable.** `mergeOrgSharedConfig` is only reached from `acceptInvitation` / `applySharedConfig`, called solely by `InvitationOnboardingWizard`, and its result is never persisted for repos (`saveConfig` drops `repositories`). An org's `watchCI: false` therefore reaches a member only during the onboarding session. Worth its own issue.
2. **Wizard repos have `orgId: null`.** `addRepository` hardcodes it, while `mergeOrgSharedConfig` filters on `r.orgId === orgId` — so the repos the wizard just created are skipped, contradicting the wizard's own comment. Second, independent reason an invitee inherits nothing.
3. **`sharedMirror` is best-effort by construction.** It only protects rows this process actually loaded, and it makes a shared key sticky once loaded (no local state can drop it again). The durable fix is a jsonb-merging `save_config` RPC — the pattern already exists in `20260724090000_set_org_shared_config.sql`. Reviewers who would rather not ship a transitional mechanism into the org-config write path should say so; that is the main merge-blocking question here.
4. **Whole-block equality reclassifies a matching user choice as "defaulted"** (see test step 4). Consistent with the issue deferring the "defaulted vs user-set" model, but it is a real behaviour change with no persisted marker.
5. **`commit` and `languages` have the identical defect** and are deliberately untouched: `repairConfig` dereferences `DEFAULT_REPOSITORY_FIELDS.languages!` / `.commit!`, so dropping them is a runtime TypeError there, and the consumer fallback for `commit.includeTicketId` is `false` where the default is `true` — an observable behaviour change. `repoKeywords` is unaffected; its `isDefaulted` escape hatch is the working reference pattern.
6. **`migrate.ts:64`** (`if (normalizeLegacyPullRequest(config)) changed = true`) is redundant now that normalization happens on load — the suite is green without it. Kept as a belt-and-braces call; happy to drop it if reviewers prefer.
