### PR TITLE
fix: state skill run duration and skill exclusions in the recording breakdown

### DIFF
--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -232,7 +232,8 @@ export const en = {
   'settings.features.usageLogs.collected': 'Collected',
   'settings.features.usageLogs.excluded': 'Never collected',
   'settings.features.usageLogs.collected.activity': 'Agent activity: tickets, commits, PRs, reviews',
-  'settings.features.usageLogs.collected.skills': 'The skills you run (/magic:start, /magic:pr, …)',
+  'settings.features.usageLogs.collected.skills':
+    'The skills you run (/magic:start, /magic:pr, …), how long each run takes and how it ended',
   'settings.features.usageLogs.collected.session':
     'End-of-session summary: estimated cost, lines added/removed, duration, model',
   'settings.features.usageLogs.collected.context': 'Ticket id and title, and the repositories you work in',
@@ -240,6 +241,8 @@ export const en = {
   'settings.features.usageLogs.excluded.code': 'Your code, your diffs, your file contents',
   'settings.features.usageLogs.excluded.terminal': 'Terminal output and command history',
   'settings.features.usageLogs.excluded.secrets': 'Your tokens, keys and credentials',
+  'settings.features.usageLogs.excluded.args': 'What you type after a skill’s name',
+  'settings.features.usageLogs.excluded.otherSkills': 'Any skill whose name does not start with “magic-”',
   'settings.features.usageLogs.footnote':
     'Every member of your organization can see these figures per person on the Team page.',
   'settings.features.usageLogs.footnote.agents':

--- a/desktop/src/i18n/fr.ts
+++ b/desktop/src/i18n/fr.ts
@@ -227,7 +227,8 @@ export const fr: Record<keyof typeof en, string> = {
   'settings.features.usageLogs.collected': 'Collecté',
   'settings.features.usageLogs.excluded': 'Jamais collecté',
   'settings.features.usageLogs.collected.activity': 'L’activité des agents : tickets, commits, PR, revues',
-  'settings.features.usageLogs.collected.skills': 'Les skills que vous lancez (/magic:start, /magic:pr, …)',
+  'settings.features.usageLogs.collected.skills':
+    'Les skills que vous lancez (/magic:start, /magic:pr, …), la durée de chaque exécution et comment elle s’est terminée',
   'settings.features.usageLogs.collected.session':
     'Le résumé de fin de session : coût estimé, lignes ajoutées/supprimées, durée, modèle',
   'settings.features.usageLogs.collected.context':
@@ -236,6 +237,8 @@ export const fr: Record<keyof typeof en, string> = {
   'settings.features.usageLogs.excluded.code': 'Votre code, vos diffs, le contenu de vos fichiers',
   'settings.features.usageLogs.excluded.terminal': 'La sortie du terminal et l’historique des commandes',
   'settings.features.usageLogs.excluded.secrets': 'Vos jetons, vos clés et vos identifiants',
+  'settings.features.usageLogs.excluded.args': 'Ce que vous tapez après le nom d’un skill',
+  'settings.features.usageLogs.excluded.otherSkills': 'Les skills dont le nom ne commence pas par « magic- »',
   'settings.features.usageLogs.footnote':
     'Chaque membre de votre organisation voit ces chiffres par personne sur la page Équipe.',
   'settings.features.usageLogs.footnote.agents':

--- a/desktop/src/renderer/pages/Config/index.tsx
+++ b/desktop/src/renderer/pages/Config/index.tsx
@@ -171,11 +171,23 @@ const USAGE_LOGS_COLLECTED: MessageKey[] = [
   'settings.features.usageLogs.collected.context',
 ]
 
+// The last two are the counterweight to the skills line opposite: now that a run
+// carries its duration and its outcome, the obvious next question is whether the
+// words next to /magic:pr travel with it (they do not — types.ts, SkillInvocationInput)
+// and which skills reach the table at all.
+//
+// That second one is worded as a NAME test, not as ownership, because that is all
+// isMagicSkill does (main/usage/skill-invocations.ts): it folds the plugin prefix,
+// then requires the basename to start with `magic-`. Promising "nothing that is not
+// ours" would over-claim — a third-party skill called `acme:magic-deploy` clears that
+// filter. The panel states the rule the code actually enforces.
 const USAGE_LOGS_EXCLUDED: MessageKey[] = [
   'settings.features.usageLogs.excluded.prompts',
   'settings.features.usageLogs.excluded.code',
   'settings.features.usageLogs.excluded.terminal',
   'settings.features.usageLogs.excluded.secrets',
+  'settings.features.usageLogs.excluded.args',
+  'settings.features.usageLogs.excluded.otherSkills',
 ]
 
 /**

--- a/webapp/components/AppSettings.tsx
+++ b/webapp/components/AppSettings.tsx
@@ -95,11 +95,22 @@ const COLLECTED: MessageKey[] = [
   'settings.usageLogs.collected.context',
 ]
 
+// The last two answer what the skills line opposite invites: a run now carries its
+// duration and its outcome, so whether the words typed after /magic:pr travel with
+// it (they do not) and which skills reach the table at all are the two questions
+// that follow. Both are enforced desktop-side, in main/usage/skill-invocations.ts.
+//
+// The second is deliberately a NAME test rather than an ownership one: isMagicSkill
+// folds the plugin prefix and then requires a `magic-` basename, so a third-party
+// `acme:magic-deploy` clears it. Wording it as "nothing that is not ours" would
+// promise more than the filter delivers.
 const NEVER_COLLECTED: MessageKey[] = [
   'settings.usageLogs.excluded.prompts',
   'settings.usageLogs.excluded.code',
   'settings.usageLogs.excluded.terminal',
   'settings.usageLogs.excluded.secrets',
+  'settings.usageLogs.excluded.args',
+  'settings.usageLogs.excluded.otherSkills',
 ]
 
 function UsageLogsBreakdown({ t }: { t: Translate }) {

--- a/webapp/lib/i18n/en.ts
+++ b/webapp/lib/i18n/en.ts
@@ -302,7 +302,8 @@ export const en = {
   'settings.usageLogs.collected': 'Collected',
   'settings.usageLogs.excluded': 'Never collected',
   'settings.usageLogs.collected.activity': 'Agent activity: tickets, commits, PRs, reviews',
-  'settings.usageLogs.collected.skills': 'The skills you run (/magic:start, /magic:pr, …)',
+  'settings.usageLogs.collected.skills':
+    'The skills you run (/magic:start, /magic:pr, …), how long each run takes and how it ended',
   'settings.usageLogs.collected.session':
     'End-of-session summary: estimated cost, lines added/removed, duration, model',
   'settings.usageLogs.collected.context':
@@ -311,6 +312,8 @@ export const en = {
   'settings.usageLogs.excluded.code': 'Your code, your diffs, your file contents',
   'settings.usageLogs.excluded.terminal': 'Terminal output and command history',
   'settings.usageLogs.excluded.secrets': 'Your tokens, keys and credentials',
+  'settings.usageLogs.excluded.args': 'What you type after a skill’s name',
+  'settings.usageLogs.excluded.otherSkills': 'Any skill whose name does not start with “magic-”',
   'settings.usageLogs.footnote':
     'Every member of your organization can see these figures per person on the Team page.',
   'settings.usageLogs.footnoteAgents':

--- a/webapp/lib/i18n/fr.ts
+++ b/webapp/lib/i18n/fr.ts
@@ -312,7 +312,7 @@ export const fr: Record<keyof typeof en, string> = {
   'settings.usageLogs.collected.activity':
     'L’activité des agents : tickets, commits, PR, revues',
   'settings.usageLogs.collected.skills':
-    'Les skills que vous lancez (/magic:start, /magic:pr, …)',
+    'Les skills que vous lancez (/magic:start, /magic:pr, …), la durée de chaque exécution et comment elle s’est terminée',
   'settings.usageLogs.collected.session':
     'Le résumé de fin de session : coût estimé, lignes ajoutées/supprimées, durée, modèle',
   'settings.usageLogs.collected.context':
@@ -322,6 +322,8 @@ export const fr: Record<keyof typeof en, string> = {
   'settings.usageLogs.excluded.terminal':
     'La sortie du terminal et l’historique des commandes',
   'settings.usageLogs.excluded.secrets': 'Vos jetons, vos clés et vos identifiants',
+  'settings.usageLogs.excluded.args': 'Ce que vous tapez après le nom d’un skill',
+  'settings.usageLogs.excluded.otherSkills': 'Les skills dont le nom ne commence pas par « magic- »',
   'settings.usageLogs.footnote':
     'Chaque membre de votre organisation voit ces chiffres par personne sur la page Équipe.',
   'settings.usageLogs.footnoteAgents':


### PR DESCRIPTION
## Description

The "Collected / Never collected" breakdown under Settings → Features → Activity recording was written on 2026-07-28 (`37860da`) and never updated when skill-run tracking changed on 2026-07-31 (`c6926ca`). A run now opens on the PreToolUse hook and closes on the skill's own final step, so it carries a **duration** and an **outcome** — neither of which the panel admitted to collecting. A panel that under-states what is recorded is worse than no panel, since it is the thing users read to decide whether to leave the toggle on.

This corrects the collected side and adds the two exclusions that the new wording immediately raises.

## Related Issue

No ticket — follow-up on `c6926ca`, spotted while auditing the settings copy against the current tracking code.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [x] Other (please describe): corrects in-app privacy copy — what the app tells the user it collects

## Changes Made

- `collected.skills` now states that each run's **duration and outcome** are recorded, not just the skill name (desktop + webapp, EN + FR).
- New `excluded.args` — what the user types after a skill's name is never collected, which is deliberate (`SkillInvocationInput`, `desktop/src/types.ts`).
- New `excluded.otherSkills` — skills that are not Magic Slash ones are filtered out before the write (`isMagicSkill`, `desktop/src/main/usage/skill-invocations.ts`), so a user's own or their employer's internal skills never land in a table their org can read.
- Both key lists updated in the two components that render the breakdown, with a comment recording why the two exclusions sit opposite the skills line.

Kept as one commit on purpose: the desktop and webapp copies of this block are maintained diffable line by line, so splitting them would leave an intermediate commit where the two surfaces contradict each other.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

Verified on this exact tree: `npm test` → 664 passed (includes the fr/en key-parity suites, which is what guards the two new keys), `tsc --noEmit` clean in both `desktop/` and `webapp/`, `npm run lint` → 0 errors (the 3 `any` warnings in `RepoPage.tsx` are pre-existing and untouched).

### Test Steps

1. Run `npm run desktop`, open **Settings → Features → Activity recording** with the toggle on — the ✓ column's skills line now reads "The skills you run (/magic:start, /magic:pr, …), how long each run takes and how it ended".
2. In the same panel, the ✗ column lists **six** items, the last two being "What you type after a skill's name" and "Any skill that is not a Magic Slash one".
3. Switch the interface language to French (**Settings → Language**) — both columns render the FR wording, with no raw key showing through as a missing-translation fallback.
4. Start the webapp (`cd webapp && npm run dev`), open the account settings page, and confirm the same 4 / 6 items appear there in both languages (language switcher on the login page).
5. Turn **"Share my activity with my team"** off — the whole breakdown and the "every member can see these figures" line disappear, while the agents footnote stays. Unchanged behaviour, worth confirming nothing regressed.

## Screenshots

Not included — text-only change inside an existing panel; steps 1-4 above cover the rendering in both languages and both surfaces.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

The three unchecked ones, explicitly: `docs/` carries no copy of this breakdown so there was nothing to update there; the existing i18n parity suites already cover the new keys, so no new test was warranted; `CHANGELOG.md` is written at release time by `/magic:release`.

## Additional Notes

One known gap this PR deliberately leaves open, so it is not mistaken for finished work: the footnote still says only that **agents** sync regardless of the toggle. Two other writes also escape it —

- `settings_events`, the settings-audit trigger (`supabase/migrations/20260801110000_settings_events.sql`), which records which setting changed and its before/after value and is readable org-wide for shared repository settings;
- `app_installations`, refreshed on every launch with the device id, device name, app version, platform and arch.

Both keep being written when "Share my activity with my team" is off, because neither goes through `usageLogsEnabled`. Extending the footnote to cover all three is a two-key follow-up in the same four files.
