### PR TITLE
[#158] Gate on ticket dependencies before starting

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -639,6 +639,8 @@ else
       'mcp__atlassian__getAccessibleAtlassianResources'
       'mcp__atlassian__getJiraIssue'
       'mcp__atlassian__getJiraIssueRemoteIssueLinks'
+      'mcp__atlassian__getIssueLinkTypes'
+      'mcp__atlassian__searchJiraIssuesUsingJql'
       'mcp__atlassian__getTransitionsForJiraIssue'
       'mcp__atlassian__transitionJiraIssue'
       'mcp__atlassian__addCommentToJiraIssue'

--- a/skills/evals/eval_set.json
+++ b/skills/evals/eval_set.json
@@ -285,5 +285,26 @@
     "expected_skill": "magic:pr",
     "notes": "Completion intent on a frontend change that mentions test accounts — the credentials vocabulary must not deflect routing away from magic:pr. Covers routing only: this eval set matches a skill against an utterance, so it cannot check that the PR body actually surfaced the right test account (pullRequest.testAccounts behaviour is not observable here)",
     "difficulty": "medium"
+  },
+  {
+    "id": 42,
+    "query": "start #158, it depends on #156",
+    "expected_skill": "magic:start",
+    "notes": "Start intent carrying an explicit dependency — blocker vocabulary must not deflect routing away from magic:start. Covers routing only: this eval set matches a skill against an utterance, so it cannot check the Step 2.4 verdict, the branch offer, or that nothing was created before the user answered",
+    "difficulty": "easy"
+  },
+  {
+    "id": 43,
+    "query": "je commence PROJ-142, il est bloqué par PROJ-138 je crois",
+    "expected_skill": "magic:start",
+    "notes": "French start intent with an FR blocker phrase — 'bloqué par' must still route to magic:start. Routing only: whether the gate resolved PROJ-138's status or offered its PR head branch is not observable from an utterance",
+    "difficulty": "medium"
+  },
+  {
+    "id": 44,
+    "query": "is #156 merged yet? #158 is waiting on it",
+    "expected_skill": null,
+    "notes": "Pure status question about a dependency, with no intent to start anything — blocker vocabulary plus issue numbers must not fire magic:start. Routing only: nothing here asserts what the dependency gate would have concluded",
+    "difficulty": "hard"
   }
 ]

--- a/skills/magic-continue/references/jira-custom-fields.md
+++ b/skills/magic-continue/references/jira-custom-fields.md
@@ -141,5 +141,8 @@ never inferred from silence, a timeout or an unparseable answer; those go back t
 ## Usage
 
 Step 2A of `SKILL.md` evaluates the trigger inline and reads this file **only** when it fires. Once read,
-execute §2, then §3, then §4, then return to Step 2A's continuation (`/magic:start`: Step 2.5, then 2.6, then
-2.7; `/magic:continue`: Step 2.5, then 2.6) — except on option 3 of §4.2, which stops the skill.
+execute §2, then §3, then §4, then return to Step 2A's continuation (`/magic:start`: Step 2.4, then 2.5, then
+2.6, then 2.7; `/magic:continue`: Step 2.5, then 2.6) — except on option 3 of §4.2, which stops the skill.
+The `/magic:start` continuation goes through the dependency gate like any other: a thin ticket is exactly the
+kind that carries a dependency link, so skipping 2.4 here would transition it and create its worktree with no
+verdict.

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -289,7 +289,11 @@ Use `AskUserQuestion` with `MSG_BLOCKER_IN_FLIGHT`, offering the blocker's PR he
 
 - **Same branch** — the 🟢 stands. Continue.
 - **Different, and the PR merged into `$DEV_BRANCH` too** — the 🟢 stands. Continue.
-- **Different, and it did not** — the blocker's code is *not* on the branch this worktree starts from, so the 🟢 was earned against the wrong base. Downgrade to 🟡 and ask the question above, offering the blocker's `headRefName`. Say in one line which two branches diverged, so the user sees this came from their Step 0.4 answer and not from the PR.
+- **Different, and it did not** — the blocker's code is *not* on the branch this worktree starts from, so the 🟢 was earned against the wrong base. Downgrade to 🟡 and ask the question above. Say in one line which two branches diverged, so the user sees this came from their Step 0.4 answer and not from the PR.
+
+**On this downgrade, offer `mergeCommit.oid`, not `headRefName`.** The blocker's PR is merged, and GitHub deletes the head branch on merge by default — so `headRefName` names a branch that usually no longer exists, and offering it would produce a 🟡 with nothing checkoutable behind it. The merge commit always exists. `references/dependencies.md` §3.4 requests both fields for exactly this reason: `headRefName` is the base to offer on an **open** PR, `mergeCommit.oid` on a **merged** one. A detached base ref is fine here — the worktree gets its own new branch either way, since Step 4.1 passes `-b "$BRANCH_NAME"`.
+
+**And the `$DEV_BRANCH` fallback below does not apply on this path.** That fallback exists for a base branch that cannot be resolved, where continuing on the dev branch is harmless. Here it is the opposite: this re-check just established that `$DEV_BRANCH` lacks the blocker's code, so silently falling back to it would undo the very finding that triggered the downgrade — a false 🟢 restored one step after being caught, and invisible because the fallback is silent. If the merge commit cannot be resolved either (`git fetch origin <oid>` then `git rev-parse --verify` both fail), do not create anything. Display `MSG_BLOCKER_CHECK_UNAVAILABLE` for the reason — that key reports, it does not ask — then ask with `MSG_BLOCKER_HARD`'s three options, exactly as the 🔴 path does: start on `$DEV_BRANCH` anyway, start the blocker instead, or stop. Better to stop than to start on a base known to be wrong.
 
 This is the only verdict that can move after Step 2.4, and it can only move in the safe direction — 🟢 → 🟡, never the reverse. A 🔴 was already settled with the user before anything was created, and a 🟡 is re-asked here anyway.
 
@@ -311,21 +315,26 @@ git pull --rebase origin $DEV_BRANCH
 
 This pair always targets `$DEV_BRANCH`, never `$BASE_BRANCH`: pulling a remote feature branch into the local dev branch would rewrite the dev branch with the blocker's commits, in the user's main checkout, for every later ticket. Refresh the dev branch here, and get the blocker's branch as a ref instead — it may not exist locally at all, so fetch it before using it as a base:
 
+The base may be a **branch name** (an open blocker PR's `headRefName`) or a **commit SHA** (a merged one's `mergeCommit.oid`, per the downgrade above). They fetch differently, so branch on the shape:
+
 ```bash
 BASE_REF="$DEV_BRANCH"
 if [ "$BASE_BRANCH" != "$DEV_BRANCH" ]; then
-  git fetch origin "$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH" 2>/dev/null || true
-  if git rev-parse --verify --quiet "origin/$BASE_BRANCH" > /dev/null; then
-    BASE_REF="origin/$BASE_BRANCH"
+  if printf '%s' "$BASE_BRANCH" | grep -qE '^[0-9a-f]{7,40}$'; then
+    git fetch origin "$BASE_BRANCH" 2>/dev/null || true
+    git rev-parse --verify --quiet "${BASE_BRANCH}^{commit}" > /dev/null && BASE_REF="$BASE_BRANCH"
   else
-    BASE_BRANCH="$DEV_BRANCH"
+    git fetch origin "$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH" 2>/dev/null || true
+    git rev-parse --verify --quiet "origin/$BASE_BRANCH" > /dev/null && BASE_REF="origin/$BASE_BRANCH"
   fi
 fi
 ```
 
-`$BASE_REF`, not `$BASE_BRANCH`, is what the worktree is created from. The distinction matters: the blocker's branch is fetched into `refs/remotes/origin/`, so a **local** branch of that name usually does not exist, and `git worktree add … "$BASE_BRANCH"` would fail with `invalid reference` on exactly the 🟡 path this feature exists to serve. `$DEV_BRANCH` is safe bare because the checkout above created it locally; a remote-only base is not. Keeping `$BASE_BRANCH` as the plain name is still useful — it is what the messages and the `baseBranch` metadata report.
+`$BASE_REF`, not `$BASE_BRANCH`, is what the worktree is created from. The distinction matters: a blocker's branch is fetched into `refs/remotes/origin/`, so a **local** branch of that name usually does not exist, and `git worktree add … "$BASE_BRANCH"` would fail with `invalid reference` on exactly the 🟡 path this feature exists to serve. `$DEV_BRANCH` is safe bare because the checkout above created it locally; a remote-only base is not. Keeping `$BASE_BRANCH` as the plain value is still useful — it is what the messages and the `baseBranch` metadata report.
 
-If the fetch leaves the ref unresolvable, fall back to `$DEV_BRANCH` for that repo and say so in one line — never let a missing base branch abort the start.
+The hex test is a safety net, not the decision: you already know which kind of base the gate handed over — `headRefName` for an open PR, `mergeCommit.oid` for a merged one — so use that knowledge and treat the test as a guard against the rare branch whose name is bare hex.
+
+`$BASE_REF` is left at `$DEV_BRANCH` when the fetch leaves the base unresolvable — say so in one line, and never let a missing base branch abort the start. **One exception, and it is not optional**: on the 🟢 → 🟡 downgrade above, this re-check has already established that `$DEV_BRANCH` lacks the blocker's code, so falling back to it would silently undo that finding. There, an unresolvable base stops and asks with `MSG_BLOCKER_CHECK_UNAVAILABLE` instead of defaulting. The rule is only safe where the fallback is harmless.
 
 If `git pull --rebase` fails with conflicts, use `AskUserQuestion` with `MSG_REBASE_CONFLICT` options.
 

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -285,6 +285,14 @@ If it exists, use `AskUserQuestion` with `MSG_WORKTREE_EXISTS` options:
 
 Use `AskUserQuestion` with `MSG_BLOCKER_IN_FLIGHT`, offering the blocker's PR head branch and `$DEV_BRANCH` (the default). Keep the answer **per repo, keyed by config key**, the way Step 0.5 keeps the test-account pair: the blocker's PR head branch exists in exactly **one** repo, so a single `$BASE_BRANCH` scalar would send that ref to repos where it does not exist and fail `git worktree add` in all of them. Every other repo keeps `$DEV_BRANCH`.
 
+**Re-check any 🟢 that rested on a merged PR, before creating anything.** `references/dependencies.md` §3.5 clears a blocker whose PR merged into the branch the worktree will start from — but at Step 2.4 it could only compare against the *configured* development branch, since `$DEV_BRANCH` is resolved here in Step 0.4 and the user may have answered with a different branch. Compare the gate's `merge_target_checked_against` (its `## Usage` contract) with the `$DEV_BRANCH` now in hand:
+
+- **Same branch** — the 🟢 stands. Continue.
+- **Different, and the PR merged into `$DEV_BRANCH` too** — the 🟢 stands. Continue.
+- **Different, and it did not** — the blocker's code is *not* on the branch this worktree starts from, so the 🟢 was earned against the wrong base. Downgrade to 🟡 and ask the question above, offering the blocker's `headRefName`. Say in one line which two branches diverged, so the user sees this came from their Step 0.4 answer and not from the PR.
+
+This is the only verdict that can move after Step 2.4, and it can only move in the safe direction — 🟢 → 🟡, never the reverse. A 🔴 was already settled with the user before anything was created, and a 🟡 is re-asked here anyway.
+
 For each selected repo, resolve that repo's own value once, up front — so every use below reads a variable that is always set:
 
 ```bash

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -304,11 +304,18 @@ git pull --rebase origin $DEV_BRANCH
 This pair always targets `$DEV_BRANCH`, never `$BASE_BRANCH`: pulling a remote feature branch into the local dev branch would rewrite the dev branch with the blocker's commits, in the user's main checkout, for every later ticket. Refresh the dev branch here, and get the blocker's branch as a ref instead — it may not exist locally at all, so fetch it before using it as a base:
 
 ```bash
+BASE_REF="$DEV_BRANCH"
 if [ "$BASE_BRANCH" != "$DEV_BRANCH" ]; then
   git fetch origin "$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH" 2>/dev/null || true
-  git rev-parse --verify --quiet "origin/$BASE_BRANCH" > /dev/null || BASE_BRANCH="$DEV_BRANCH"
+  if git rev-parse --verify --quiet "origin/$BASE_BRANCH" > /dev/null; then
+    BASE_REF="origin/$BASE_BRANCH"
+  else
+    BASE_BRANCH="$DEV_BRANCH"
+  fi
 fi
 ```
+
+`$BASE_REF`, not `$BASE_BRANCH`, is what the worktree is created from. The distinction matters: the blocker's branch is fetched into `refs/remotes/origin/`, so a **local** branch of that name usually does not exist, and `git worktree add … "$BASE_BRANCH"` would fail with `invalid reference` on exactly the 🟡 path this feature exists to serve. `$DEV_BRANCH` is safe bare because the checkout above created it locally; a remote-only base is not. Keeping `$BASE_BRANCH` as the plain name is still useful — it is what the messages and the `baseBranch` metadata report.
 
 If the fetch leaves the ref unresolvable, fall back to `$DEV_BRANCH` for that repo and say so in one line — never let a missing base branch abort the start.
 
@@ -319,7 +326,7 @@ If `git pull --rebase` fails with conflicts, use `AskUserQuestion` with `MSG_REB
 ```bash
 BRANCH_NAME="feature/$TICKET_ID"
 [ -n "$SLUG" ] && BRANCH_NAME="feature/$TICKET_ID-$SLUG"
-git worktree add -b "$BRANCH_NAME" ../${REPO_NAME}-$TICKET_ID "$BASE_BRANCH"
+git worktree add -b "$BRANCH_NAME" ../${REPO_NAME}-$TICKET_ID "$BASE_REF"
 ```
 
 If this fails because the branch already exists, use `AskUserQuestion` with `MSG_BRANCH_ALREADY_EXISTS` options:

--- a/skills/magic-start/SKILL.md
+++ b/skills/magic-start/SKILL.md
@@ -21,6 +21,7 @@ Follow each step in order. Each step builds on the previous one.
 - `references/api.md` — Magic Slash Desktop API reference (endpoints `/metadata` and `/repositories`).
 - `references/test-accounts.md` — Test-account modes, discovery cascade, and the credential guardrails. Read in Step 5.5.1, only when `pullRequest.testAccounts` is not `off`.
 - `references/jira-custom-fields.md` — Jira custom-field discovery: the `*all` re-read, its volume guards, and the empty-ticket options. Read in Step 2A, only when the ticket description carries no usable spec.
+- `references/dependencies.md` — Dependency detection, blocker resolution, the decision matrix and the per-verdict behaviour. Read in Step 2.4, only when the ticket declares at least one blocker.
 
 ## Step 0: Configuration
 
@@ -94,10 +95,11 @@ Use `mcp__atlassian__getJiraIssue` to retrieve ticket details. If you don't know
 Pass an explicit `fields` array so design references are never dropped:
 
 ```json
-["summary","description","issuetype","status","labels","components","attachment"]
+["summary","description","issuetype","status","labels","components","attachment","issuelinks"]
 ```
 
 `attachment` is metadata only (`filename`, `mimeType`, `content`) and is what Step 5.0 needs to spot an image attachment. Comments are **not** requested here: they are retrieved later, and only if Step 5.0 detects a UI signal (see `references/design-context.md` §2.1), so a backend ticket never pays for its comment thread.
+`issuelinks` rides along with the retrieval already performed, which is what makes Jira "is blocked by" links visible to Step 2.4 — they are absent from the MCP default field set — and what makes the dependency gate free when no blocker is declared.
 
 In parallel, also call `mcp__atlassian__getJiraIssueRemoteIssueLinks` for the same issue: a Figma file is very often attached as a remote link rather than pasted in the description. Extract `object.url` and `object.title` from each entry and keep them for Step 5.0.
 
@@ -105,7 +107,7 @@ If the MCP call fails (timeout, auth error), retry once. If it fails again, ask 
 
 **Completeness check.** The ticket's real spec may sit in a custom field. Read `references/jira-custom-fields.md` and follow it whenever `fields.description` does not state what to build: it is absent or null; or under **80 characters** of useful text once markup is stripped and not a complete one-liner ("Bump the Stripe SDK to v14" is a spec); or longer, yet stating neither what to build nor any acceptance criterion (every heading present with an empty or placeholder body, pure boilerplate, a deferral to another field, a bare link with no prose). A description that does say what to build never triggers it, however short — in doubt, skip, so this does not become a second full-issue call on every ticket. That file owns the discovery call, the volume guards, what the discovered text feeds into, and the handling of a ticket still empty afterwards. If it is missing on disk, skip discovery and degrade to the warning alone: say in one line that the ticket looks underspecified, ask the user for the missing context, and never fill the gap from the title alone.
 
-→ Continue to Step 2.5, then Step 2.6, then Step 2.7.
+→ Continue to Step 2.4, then Step 2.5, then Step 2.6, then Step 2.7.
 
 ## Step 2B: Retrieve the GitHub issue
 
@@ -127,6 +129,8 @@ Parse `owner/repo` from either `git@github.com:owner/repo.git` or `https://githu
 
 Use `mcp__github__get_issue` for each repo — launch all calls in parallel for speed. Collect all found issues. If an MCP call fails, retry once; if still failing, skip that repo and continue with the others.
 
+Keep the `issue_dependencies_summary` object this call already returns (`blocked_by`, `total_blocked_by`, `blocking`, `total_blocking`): it carries counts only, no IDs, but that is enough for Step 2.4 to short-circuit at zero cost when `blocked_by == 0`. Only a non-zero count justifies resolving the actual blocker IDs.
+
 ### 2B.4: Resolution
 
 - **No issue found**: Display `MSG_NO_ISSUE_FOUND`.
@@ -145,7 +149,38 @@ gh issue view {number} --repo {owner}/{repo} --comments 2>/dev/null \
 
 On a ticket with no design reference this prints nothing, so it costs nothing — and empty output is the nominal backend case, not a failure. (`grep` exits 1 when it matches nothing, but the pipeline's status is `head`'s, so the command still succeeds.) If `gh` is unavailable or fails, continue with the issue body alone. The full thread is never retrieved here: `references/design-context.md` §2.1 reads it later, once a signal has actually fired.
 
-→ Continue to Step 2.5, then Step 2.6, then Step 2.7.
+→ Continue to Step 2.4, then Step 2.5, then Step 2.6, then Step 2.7.
+
+## Step 2.4: Dependency gate
+
+A ticket that depends on unlanded work is not ready to start. This step resolves that dependency against reality — and a **merged PR carrying the blocker's ID means the dependency has landed, whatever the tracker says**.
+
+**Position.** The gate sits here because everything before it is read-only and everything after it mutates something — so it runs on the ticket already retrieved in Step 2A/2B, before any of it.
+
+**Early exit — the zero-blocker case.** First decide, from data already in hand, whether the ticket declares a dependency at all. It does when either tracker signal fires:
+
+- Jira: `fields.issuelinks` (requested in Step 2A) holds a link whose type is inward "is blocked by" / "depends on".
+- GitHub: `issue_dependencies_summary.blocked_by > 0` (returned by Step 2B.3).
+
+…or when the description — including any custom-field text discovered in Step 2A — carries a dependency keyword that is **not** preceded by a negation (`not`, `no longer`, `pas`, `plus`). The keyword list is the one in `references/dependencies.md` §2.3, in full and verbatim — EN `blocked by`, `depends on`, `dependent on`, `needs`, `requires`, `waiting on`, `waiting for`, `after`; FR `bloqué par`, `bloque par`, `dépend de`, `depend de`, `nécessite`, `en attente de`, `après`. That is a string scan, not an API call, so it stays free.
+
+This pre-filter must never be narrower than §2.3, only looser: it skips the adjacency window and the full negation skip-list, both of which §2.3 applies afterwards and which can still conclude that nothing is declared — a `none` verdict, handled exactly like this early exit. Dropping a keyword here instead early-exits a ticket that §2.3 would have matched, and the reference file is never read to catch it. `after PROJ-4` is the case that makes this concrete: it is a detection case the ticket names explicitly, and it fires on `after` alone.
+
+If nothing is declared, the gate ends here: do not read `references/dependencies.md`, make **no** extra API call, say nothing, and continue.
+
+**Otherwise, read `references/dependencies.md`** and follow it. That file owns detection, the blocker resolution calls, the `owner/repo` derivation, the decision matrix, the worst-verdict aggregation, every message key, and the values this gate returns to its callers (its `## Usage` section). Do not restate its rules here.
+
+**If `references/dependencies.md` is missing on disk**: skip the gate, say in one line that the dependency check could not run because its reference file is absent, and continue to Step 2.5 — never fabricate a verdict from the blocker's tracker status alone. The same applies to any degradation the file itself defines (`gh` absent or unauthenticated, `$ATLASSIAN_ENABLED` false with a Jira-shaped blocker): report `MSG_BLOCKER_CHECK_UNAVAILABLE` and continue.
+
+**The 🔴 question is asked here**, before anything is created. Use `AskUserQuestion` with `MSG_BLOCKER_HARD` (no PR found) or `MSG_BLOCKER_ABANDONED_PR` (closed unmerged PR — a distinct outcome, never folded into the first) and exactly three options:
+
+1. **Start this ticket anyway** → continue to Step 2.5 as usual, carrying the blocker into `{attention_points}` of the final summary.
+2. **Start the blocker instead** → re-enter this skill at Step 1 with the blocker's ID as `$ARGUMENTS`. The guard is a **note carried in the conversation** — state that the gate has already run this session, and the second pass skips Step 2.4 on seeing it. The gate is depth 1 by design: direct blockers only, never the blockers of blockers, so without that note the blocker's own blockers would ask the same question one level down.
+3. **Stop here** → the skill stops. Step 6 still runs, with `outcome` `failed` since the workflow did not complete — an unclosed run record is counted as abandoned and the run disappears from the statistics.
+
+Nothing is created before the answer: no `/metadata` POST, no Jira transition, no GitHub label, no worktree, no branch. "Stop here" is never inferred from silence, a timeout or an unparseable answer; those go back to the question.
+
+**The 🟡 branch question is asked in Step 4.1**, not here — only the verdict is computed at this step.
 
 ## Step 2.5: Update Magic Slash Desktop metadata
 
@@ -246,11 +281,16 @@ If it exists, use `AskUserQuestion` with `MSG_WORKTREE_EXISTS` options:
 
 ### 4.1: Create the worktree
 
-For each selected repo:
+**Resolve the base branch, per repo.** If Step 2.4 returned a 🟡 verdict with a candidate base branch, ask the question **now** — this is the earliest point where it can be asked, because `$DEV_BRANCH` is only resolved in Step 0.4 ("execute after repo is identified in step 3") and the repo set is only known after Step 3. Asking at Step 2.4 would name a default that does not exist yet, and Step 0.4 would then ask about the dev branch anyway. The verdict is computed at 2.4; only the question moves here.
+
+Use `AskUserQuestion` with `MSG_BLOCKER_IN_FLIGHT`, offering the blocker's PR head branch and `$DEV_BRANCH` (the default). Keep the answer **per repo, keyed by config key**, the way Step 0.5 keeps the test-account pair: the blocker's PR head branch exists in exactly **one** repo, so a single `$BASE_BRANCH` scalar would send that ref to repos where it does not exist and fail `git worktree add` in all of them. Every other repo keeps `$DEV_BRANCH`.
+
+For each selected repo, resolve that repo's own value once, up front — so every use below reads a variable that is always set:
 
 ```bash
 cd {REPO_PATH}
 REPO_NAME=$(basename "$PWD")
+BASE_BRANCH="${BASE_BRANCH:-$DEV_BRANCH}"
 git fetch origin
 ```
 
@@ -261,6 +301,17 @@ git checkout $DEV_BRANCH
 git pull --rebase origin $DEV_BRANCH
 ```
 
+This pair always targets `$DEV_BRANCH`, never `$BASE_BRANCH`: pulling a remote feature branch into the local dev branch would rewrite the dev branch with the blocker's commits, in the user's main checkout, for every later ticket. Refresh the dev branch here, and get the blocker's branch as a ref instead — it may not exist locally at all, so fetch it before using it as a base:
+
+```bash
+if [ "$BASE_BRANCH" != "$DEV_BRANCH" ]; then
+  git fetch origin "$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH" 2>/dev/null || true
+  git rev-parse --verify --quiet "origin/$BASE_BRANCH" > /dev/null || BASE_BRANCH="$DEV_BRANCH"
+fi
+```
+
+If the fetch leaves the ref unresolvable, fall back to `$DEV_BRANCH` for that repo and say so in one line — never let a missing base branch abort the start.
+
 If `git pull --rebase` fails with conflicts, use `AskUserQuestion` with `MSG_REBASE_CONFLICT` options.
 
 **Create the worktree:**
@@ -268,7 +319,7 @@ If `git pull --rebase` fails with conflicts, use `AskUserQuestion` with `MSG_REB
 ```bash
 BRANCH_NAME="feature/$TICKET_ID"
 [ -n "$SLUG" ] && BRANCH_NAME="feature/$TICKET_ID-$SLUG"
-git worktree add -b "$BRANCH_NAME" ../${REPO_NAME}-$TICKET_ID $DEV_BRANCH
+git worktree add -b "$BRANCH_NAME" ../${REPO_NAME}-$TICKET_ID "$BASE_BRANCH"
 ```
 
 If this fails because the branch already exists, use `AskUserQuestion` with `MSG_BRANCH_ALREADY_EXISTS` options:
@@ -297,8 +348,10 @@ cd ../${REPO_NAME}-$TICKET_ID
 
 Read from `git branch --show-current` rather than echoing `$BRANCH_NAME` back: that reports what git actually checked out, so it stays correct on the "branch already exists" path where the user chose to reuse it.
 
+`baseBranch` rides along to **overwrite** the value Step 2.5.2 already sent. That earlier call reports `$DEV_BRANCH` because it runs before the 🟡 question is answered; on the 🟡 path the real base is the blocker's branch, and only this call knows it. Sending it unconditionally keeps the two paths identical: on a nominal start the value is `$DEV_BRANCH` either way.
+
 ```bash
-[ -n "$MAGIC_SLASH_PORT" ] && [ -n "$MAGIC_SLASH_TERMINAL_ID" ] && curl -s "http://127.0.0.1:$MAGIC_SLASH_PORT/metadata?id=$MAGIC_SLASH_TERMINAL_ID&branchName=$(echo -n "$(git branch --show-current)" | jq -sRr @uri)" > /dev/null 2>&1 || true
+[ -n "$MAGIC_SLASH_PORT" ] && [ -n "$MAGIC_SLASH_TERMINAL_ID" ] && curl -s "http://127.0.0.1:$MAGIC_SLASH_PORT/metadata?id=$MAGIC_SLASH_TERMINAL_ID&branchName=$(echo -n "$(git branch --show-current)" | jq -sRr @uri)&baseBranch=$(echo -n "$BASE_BRANCH" | jq -sRr @uri)" > /dev/null 2>&1 || true
 ```
 
 In a multi-repo start this runs once per worktree and the agent keeps the last one, since `branch_name` is a single column. For Jira that is the same name in every repo; for GitHub, where the name is prefixed per repo, the last repo processed wins.
@@ -389,6 +442,8 @@ Create a `CLAUDE.local.md` in each worktree using `MSG_MULTI_REPO_CONTEXT` from 
 ## Step 5: Planning and implementation
 
 Display `MSG_TASK_SUMMARY` (or `MSG_TASK_SUMMARY_FULLSTACK` for multi-repo).
+
+`{blocker_line}` carries the one line Step 2.4 produced; `references/messages.md` documents the placeholder and how it renders when no dependency was declared.
 
 ### 5.0: Design context (conditional)
 
@@ -707,7 +762,7 @@ Display `MSG_FINAL_SUMMARY` (or `MSG_FINAL_SUMMARY_FULLSTACK` for multi-repo). P
 - `{confidence_score}` — final score from the evaluation loop (5.5.2)
 - `{test_steps}` — manual testing steps generated in 5.5.1
 - `{positive_points}` — strengths identified during confidence evaluation (5.5.2)
-- `{attention_points}` — remaining concerns after auto-fix iterations (5.5.2)
+- `{attention_points}` — remaining concerns after auto-fix iterations (5.5.2). When Step 2.4 ended on a blocker the user chose to start anyway, or on an unresolvable one, prepend that blocker (id, title, PR state) here: the critic never saw it, so nothing else would carry it into the summary.
 
 **Data available from prior steps / context:**
 - `{TICKET-ID}` — ticket identifier (available since step 1)

--- a/skills/magic-start/references/dependencies.md
+++ b/skills/magic-start/references/dependencies.md
@@ -126,16 +126,56 @@ in §3.1, in parallel:
 
 ```bash
 gh pr list --repo {owner}/{repo} --search "{BLOCKER_ID}" --state all \
-  --json number,title,state,mergedAt,headRefName,url 2>/dev/null
+  --json number,title,state,mergedAt,headRefName,baseRefName,url 2>/dev/null
 ```
 
-Keep the most advanced match per blocker: `merged` beats `open`, `open` beats `closed`. `state` is
-`MERGED` / `OPEN` / `CLOSED`; a draft reports as `OPEN` and is treated as open. `headRefName` comes back on that
-same response, so the branch the 🟡 offer needs requires no second call, and `title` is requested for the same
-reason — it fills `{pr_title}` in `MSG_BLOCKER_IN_FLIGHT` without a `gh pr view` round-trip.
+`headRefName` comes back on that same response, so the branch the 🟡 offer needs requires no second call, and
+`title` is requested for the same reason — it fills `{pr_title}` in `MSG_BLOCKER_IN_FLIGHT` without a
+`gh pr view` round-trip. `baseRefName` is what §3.5 needs.
 
-Empty output across all repos means **no PR found** — a different verdict from a closed unmerged PR, and §4
-keeps them apart.
+**Every result must then be validated — `--search` is full-text, and it is not a filter.** It matches the
+blocker ID anywhere in the title, body or comments, so a PR that merely *mentions* the blocker comes back
+alongside the one that implements it, and `PROJ-1` also matches `PROJ-15` and `PROJ-158`. Ranking an unvalidated
+result would let an unrelated merged PR clear a dependency that has not landed — a false 🟢, the worst outcome
+this gate can produce, since it starts the ticket silently.
+
+Keep a result only when the blocker ID appears in its `title` or `headRefName` as a **whole token**: the
+character before it must not be alphanumeric, and the character after must be neither a digit nor a hyphen
+followed by a digit. `PROJ-1` therefore matches `PROJ-1`, `[PROJ-1]` and `feature/PROJ-1-refactor`, but not
+`PROJ-15`, `PROJ-158` or `PROJ-1-2`. For a GitHub `#N` blocker, require `#N` on the same boundary rule — `#15`
+must not satisfy `#1`. Discard everything else silently: a PR that only mentions the blocker in its body is not
+evidence the blocker landed.
+
+Then keep the most advanced surviving match per blocker: `merged` beats `open`, `open` beats `closed`. `state` is
+`MERGED` / `OPEN` / `CLOSED`; a draft reports as `OPEN` and is treated as open.
+
+No surviving match across all repos means **no PR found** — a different verdict from a closed unmerged PR, and
+§4 keeps them apart. A search that returned rows which all failed validation is *also* "no PR found", not a
+weaker form of evidence.
+
+### 3.5 A merged PR only counts if it merged into the base the worktree will use
+
+`MERGED` alone is not "the code has landed". A PR merged into a release branch, a stacked feature branch or
+another team's integration branch is merged, yet its commits are absent from `$DEV_BRANCH` — which is exactly
+where the new worktree starts. Accepting it would produce a 🟢, start the ticket, and leave the user building on
+code that is not in their tree: silent, and harder to diagnose than a 🔴.
+
+So compare `baseRefName` against the development branch configured for the repo that hosts the PR
+(`.repositories.<config key>.branches.development`), not against the scoped repo's — a cross-repo match (§3.1)
+is resolved against its own repo's config:
+
+| `baseRefName` | Treated as |
+| --- | --- |
+| the hosting repo's development branch | **merged** — the code is on the branch the worktree starts from |
+| anything else | **open**, with the target branch named in the line shown to the user |
+
+Downgrading to `open` rather than to "no PR" is deliberate: the work demonstrably exists and has a head branch,
+so the 🟡 path can still offer `headRefName` as the worktree base. That is the useful outcome here — it is how
+the user builds on a dependency that landed somewhere they do not branch from.
+
+When the hosting repo has no `branches.development` configured, fall back to its remote default branch
+(`gh repo view --repo {owner}/{repo} --json defaultBranchRef -q .defaultBranchRef.name`) and say in one line
+which branch the comparison used, so a 🟡 caused by configuration rather than by the PR is legible.
 
 ## 4. The decision matrix
 
@@ -150,6 +190,12 @@ Blocker status (§3.2, from `status.statusCategory.key`) crossed with the state 
 **Master rule: a merged PR, or a blocker whose status category is `done`, is green — regardless of what the
 tracker says.** The code is on the development branch, and that is the only thing that actually matters to the
 ticket being started. A backlog ticket with a merged PR is a stale ticket, not a blocked start.
+
+"Merged" in that rule means merged **as §3.4 and §3.5 define it**: a PR whose ID validated as a whole token, and
+whose `baseRefName` is the development branch of the repo hosting it. The rule's own justification is what
+forces both conditions — it is green *because* the code is on the branch the worktree starts from, so a PR that
+merged elsewhere, or one that merely mentions the blocker, does not satisfy it and never reaches the `merged`
+column.
 
 Two distinctions the matrix exists to preserve:
 

--- a/skills/magic-start/references/dependencies.md
+++ b/skills/magic-start/references/dependencies.md
@@ -1,0 +1,237 @@
+# Dependency gate
+
+Read this file only when Step 2.4 of `SKILL.md` has found that the ticket declares at least one blocker. It
+owns the detection vocabulary, the resolution calls, the decision matrix and the behaviour per verdict. Only
+`/magic:start` reads it; `/magic:continue` deliberately has no gate, since the work it resumes has already
+started.
+
+## 1. Scope
+
+Nothing here runs on a ticket that declares no blocker — that is what keeps an always-on gate free on the
+common case.
+
+Depth 1 only: the blockers of blockers are never resolved, because a chain is the tracker's problem and one hop
+is what a person can act on at the moment they start a ticket.
+
+## 2. Detection — the three sources
+
+A blocker is declared if **any** of the three matches. They are complementary, not ranked: a Jira link and a
+description sentence often describe the same dependency, so deduplicate by blocker ID before resolving.
+
+### 2.1 Jira issue links
+
+`fields.issuelinks` is an array of link objects, each carrying a `type` and either an `inwardIssue` or an
+`outwardIssue`. Only the inward direction of a "blocked by" / "depends on" type is a blocker.
+
+**For "A is blocked by B", `inwardIssue` is B — the blocker.** An entry carrying `outwardIssue` on the same
+type means this ticket blocks something else, which is not a reason to stop.
+
+Link type names are configurable per Jira site ("Blocks" / "Bloque" / "Dependency" / "Precedes" all exist in
+the wild), so resolve them instead of hardcoding: call `mcp__atlassian__getIssueLinkTypes` and keep the types
+whose `inward` label means "is blocked by" or "depends on". Call it **only when `issuelinks` is non-empty**.
+
+If `getIssueLinkTypes` fails, fall back to matching the link's own `type.inward` string against
+`is blocked by`, `est bloqué par`, `depends on`, `dépend de` — and say the type resolution degraded, per §6.
+
+### 2.2 Native GitHub issue dependencies
+
+`mcp__github__get_issue` already returns `issue_dependencies_summary`, but with **counts only, no IDs**:
+
+```json
+{ "blocked_by": 2, "total_blocked_by": 2, "blocking": 0, "total_blocking": 0 }
+```
+
+`blocked_by == 0` short-circuits at zero cost. A non-zero count justifies one call for the actual IDs:
+
+```bash
+gh api "repos/{owner}/{repo}/issues/{number}/dependencies/blocked_by" \
+  --jq '.[] | {number, title, state, state_reason}' 2>/dev/null
+```
+
+The MCP tool exposes no equivalent, which is why this one path goes through `gh`.
+
+### 2.3 Free text in the description
+
+The primary requested path, and the only one that works on both trackers regardless of link configuration.
+Scan the description (including custom-field text discovered in Step 2A) for a dependency keyword with a
+ticket reference **adjacent** to it.
+
+| Language | Keywords |
+| --- | --- |
+| EN | `blocked by`, `depends on`, `dependent on`, `needs`, `requires`, `waiting on`, `waiting for`, `after` |
+| FR | `bloqué par`, `bloque par`, `dépend de`, `depend de`, `nécessite`, `en attente de`, `après` |
+
+A ticket reference is `[A-Z][A-Z0-9]+-\d+` (Jira) or `#\d+` (GitHub). **Adjacency is required**: the reference
+must follow the keyword within roughly 30 characters, allowing only filler like `the`, `on`, `:`, `ticket`,
+`issue`, `PR`, `le`, `la`, `du`. Without adjacency, "this needs a rewrite of the parser, see PROJ-9 for
+context" would be read as a hard block on PROJ-9, and the gate would stop a ticket nothing is blocking.
+
+**Negated forms are skipped, never matched.** Check the words immediately preceding the keyword:
+
+| Skip when preceded by | Example that must trigger nothing |
+| --- | --- |
+| `not`, `no longer`, `isn't`, `is not`, `nothing` | `not blocked by anything`, `no longer blocked by PROJ-1` |
+| `pas`, `plus`, `n'est pas`, `rien` | `pas bloqué par PROJ-1`, `plus bloqué par le refacto` |
+
+Both checks are kept: adjacency alone misses `no longer blocked by PROJ-1`, which does carry an ID.
+
+## 3. Resolving the blockers
+
+### 3.1 Deriving `owner/repo`
+
+Reuse the slugs `SKILL.md` Step 2B.2 already resolved when they exist. On a Jira start they do not: Step 2B.2
+lives in the GitHub branch only, so derive them here with the same parsing Step 2B.2 describes.
+
+Either way, cover **every** configured repo, not just the one this ticket will be scoped to — the blocker's PR
+may live elsewhere, and Step 3 has not run yet. A path with no origin remote, or a remote that is not GitHub,
+is skipped silently: it simply cannot host the blocker's PR.
+
+### 3.2 Jira blocker status — one JQL call
+
+Resolve **all** Jira blockers in a single call, never one `getJiraIssue` per blocker:
+
+```json
+{
+  "jql": "key in (PROJ-2, PROJ-3)",
+  "fields": ["summary", "status"]
+}
+```
+
+Use `mcp__atlassian__searchJiraIssuesUsingJql`. Decide the verdict from `status.statusCategory.key` —
+`new`, `indeterminate` or `done` — and **never** from `status.name`. Names are per-project and per-language
+("Backlog", "À faire", "Ready for dev", "Recette"); the category key is the only stable value, and the matrix
+in §4 is written against it.
+
+`status.name` has exactly one use: it is the source of the `{blocker_status}` placeholder, shown to the user so
+the line reads `status Backlog` rather than `status new`. The same response carries both, so this costs nothing.
+Display only — it must never reach the matrix. On the GitHub path (§3.3) `{blocker_status}` is the issue `state`,
+plus `state_reason` when it is `not_planned`.
+
+A key absent from the JQL response (deleted ticket, no permission, wrong project) is not a blocker: report it
+as unresolvable per §6 rather than assuming `new`, which would manufacture a 🔴.
+
+### 3.3 GitHub blocker status
+
+Blockers discovered in §2.2 already carry `number`, `title`, `state` and `state_reason`, so this applies only to
+`#N` references found in free text (§2.3). For those, launch the calls in parallel, one per blocker:
+`gh issue view 123 --repo {owner}/{repo} --json number,title,state,stateReason`. Map the result
+onto the same three categories so §4 stays single-table: `open` → `indeterminate`, `closed` with reason
+`completed` → `done`, `closed` with reason `not_planned` → `done` for gate purposes (nobody is waiting on it
+any more) while mentioning the reason in the line shown to the user.
+
+### 3.4 PR lookup — cross-repo fan-out
+
+A blocker's PR is not necessarily in the repo the blocker's ticket suggests, so search **every** repo resolved
+in §3.1, in parallel:
+
+```bash
+gh pr list --repo {owner}/{repo} --search "{BLOCKER_ID}" --state all \
+  --json number,title,state,mergedAt,headRefName,url 2>/dev/null
+```
+
+Keep the most advanced match per blocker: `merged` beats `open`, `open` beats `closed`. `state` is
+`MERGED` / `OPEN` / `CLOSED`; a draft reports as `OPEN` and is treated as open. `headRefName` comes back on that
+same response, so the branch the 🟡 offer needs requires no second call, and `title` is requested for the same
+reason — it fills `{pr_title}` in `MSG_BLOCKER_IN_FLIGHT` without a `gh pr view` round-trip.
+
+Empty output across all repos means **no PR found** — a different verdict from a closed unmerged PR, and §4
+keeps them apart.
+
+## 4. The decision matrix
+
+Blocker status (§3.2, from `status.statusCategory.key`) crossed with the state of any PR carrying its ID:
+
+| status ↓ / PR → | merged | open/draft | closed unmerged | none |
+| --- | --- | --- | --- | --- |
+| done | 🟢 clear | 🟢 clear | 🟢 clear | 🟢 clear |
+| indeterminate (in progress) | 🟢 code landed | 🟡 in flight | 🔴 abandoned? | 🟡 in flight, no code |
+| new (backlog / to do) | 🟢 clear ⚠️ stale ticket | 🟡 in flight | 🔴 abandoned | 🔴 hard blocked |
+
+**Master rule: a merged PR, or a blocker whose status category is `done`, is green — regardless of what the
+tracker says.** The code is on the development branch, and that is the only thing that actually matters to the
+ticket being started. A backlog ticket with a merged PR is a stale ticket, not a blocked start.
+
+Two distinctions the matrix exists to preserve:
+
+- 🔴 **closed unmerged** is reported **distinctly** from 🔴 **no PR found**. "Someone abandoned this work" and
+  "nobody has started" call for different decisions from the user, and collapsing them into one message throws
+  away the more actionable of the two.
+- 🟢 **merged PR on a `new` ticket** adds one line about the staleness (`MSG_BLOCKER_STALE_TICKET`). The start
+  proceeds; the tracker is simply behind.
+
+**Aggregation: the overall verdict is the worst verdict across all blockers** — 🔴 beats 🟡 beats 🟢. One
+unlanded dependency is enough to hold the ticket, and a green sibling does not offset it. When several
+blockers are 🟡, offer the head branch of the one whose PR is most advanced; when several are 🔴, list them all
+in the single question.
+
+## 5. Behaviour per verdict
+
+Every user-facing string lives in `references/messages.md`, by key. Never inline the wording here or in
+`SKILL.md`: the messages are bilingual and the language is only known once Step 0.2 has read the repo config.
+
+### 5.1 🟢 Clear
+
+Emit one line for `{blocker_line}` of `MSG_TASK_SUMMARY` — `MSG_BLOCKER_CLEAR`, or
+`MSG_BLOCKER_STALE_TICKET` on the merged-PR-but-backlog-ticket cell. Ask nothing, and continue to Step 2.5
+normally.
+
+### 5.2 🟡 In flight
+
+Display `MSG_BLOCKER_IN_FLIGHT` and offer to base the new worktree on the blocker's PR head branch, with
+`$DEV_BRANCH` as the other option. The message carries the one-line warning that a force-push or a rebase on
+that PR propagates into the user's worktree — that is the real cost of the convenience, and it is stated
+before the choice, not after.
+
+`SKILL.md` Step 4.1 owns the question; this file only returns the candidate branch and the repo it belongs to
+(see `## Usage`). `{blocker_line}` stays **empty** on this path: the message is a multi-line block with a choice
+in it, so it cannot be folded into the summary box. The blocker still reaches the user, through `blockers` →
+`{attention_points}`. The same holds for §5.3 when the user starts the ticket anyway.
+
+### 5.3 🔴 Hard blocked
+
+Display `MSG_BLOCKER_HARD` (no PR found) or `MSG_BLOCKER_ABANDONED_PR` (closed unmerged), then ask with
+`AskUserQuestion`. `SKILL.md` Step 2.4 owns the question, its three options and their mechanics — including
+that nothing is created before the answer.
+
+## 6. Degradation — never fabricate a verdict
+
+Every failure path says what it could not check and continues; none of them invents an answer.
+
+| Failure | Detection | Behaviour |
+| --- | --- | --- |
+| `gh` not installed | `command -v gh` | `MSG_BLOCKER_CHECK_UNAVAILABLE`, no PR verdict |
+| `gh` not authenticated | `gh auth status` non-zero | `MSG_BLOCKER_CHECK_UNAVAILABLE`, no PR verdict |
+| `$ATLASSIAN_ENABLED` false, Jira blocker | Step 0.3 value | `MSG_BLOCKER_CHECK_UNAVAILABLE`, no status |
+| JQL call fails, or a key is missing from the response | §3.2 | that blocker is unresolvable, not `new` |
+| `getIssueLinkTypes` fails | §2.1 | fall back to literal `type.inward` matching, say so |
+
+The `$ATLASSIAN_ENABLED == false` row matters more than it looks. Free-text detection (§2.3) happily finds
+`blocked by PROJ-138` in a GitHub issue on a site with no Atlassian integration — and with no way to read that
+ticket's status, defaulting it to `new` would produce a confident 🔴 on a dependency that may well have
+shipped months ago. Degrade like a missing `gh` instead: report that the blocker could not be resolved and let
+the user decide.
+
+```bash
+command -v gh > /dev/null 2>&1 && gh auth status > /dev/null 2>&1 && echo "OK" || echo "UNAVAILABLE"
+```
+
+`MSG_BLOCKER_CHECK_UNAVAILABLE` is never blocking on its own: the start continues, and the unchecked
+dependency is carried into `{attention_points}` of Step 5.5.3 so it is not forgotten by the end of the run.
+
+## Usage
+
+`SKILL.md` Step 2.4 reads this file **only** when its declaration check has fired. Once read, execute §2, then
+§3, then §4, then §5, and return these values — this table is the whole contract; Step 2.4 restates none of it:
+
+| Returned | Shape | Consumer |
+| --- | --- | --- |
+| `verdict` | `none` / `clear` / `in_flight` / `hard_blocked` / `unavailable`, worst (§4) | Step 2.4 |
+| `blocker_line` | `MSG_BLOCKER_CLEAR` / `_STALE_TICKET` / `_CHECK_UNAVAILABLE`, else empty | Step 5 |
+| `base_branch_candidate` | map **keyed by repo config key** → branch; empty unless 🟡 | Step 4.1 |
+| `blockers` | id, title and PR state per blocker | `{attention_points}` of Step 5.5.3 |
+
+`none` is the verdict when §2 finds nothing after all — Step 2.4's cheap pre-filter is deliberately broader than
+§2.3 — and it behaves exactly like Step 2.4's early exit: say nothing, continue.
+
+Then return to Step 2.4's continuation, except on the "stop here" option of §5.3, which stops the skill after
+Step 6.

--- a/skills/magic-start/references/dependencies.md
+++ b/skills/magic-start/references/dependencies.md
@@ -160,9 +160,8 @@ another team's integration branch is merged, yet its commits are absent from `$D
 where the new worktree starts. Accepting it would produce a 🟢, start the ticket, and leave the user building on
 code that is not in their tree: silent, and harder to diagnose than a 🔴.
 
-So compare `baseRefName` against the development branch configured for the repo that hosts the PR
-(`.repositories.<config key>.branches.development`), not against the scoped repo's — a cross-repo match (§3.1)
-is resolved against its own repo's config:
+So compare `baseRefName` against the development branch of the repo that **hosts the PR**, not against the
+scoped repo's — a cross-repo match (§3.1) is resolved against its own repo's config:
 
 | `baseRefName` | Treated as |
 | --- | --- |
@@ -173,9 +172,40 @@ Downgrading to `open` rather than to "no PR" is deliberate: the work demonstrabl
 so the 🟡 path can still offer `headRefName` as the worktree base. That is the useful outcome here — it is how
 the user builds on a dependency that landed somewhere they do not branch from.
 
-When the hosting repo has no `branches.development` configured, fall back to its remote default branch
-(`gh repo view --repo {owner}/{repo} --json defaultBranchRef -q .defaultBranchRef.name`) and say in one line
-which branch the comparison used, so a 🟡 caused by configuration rather than by the PR is legible.
+#### Which branch to compare against, and why it is not simply the configured one
+
+"The hosting repo's development branch" resolves differently depending on whether that repo is the one this
+ticket will actually be worked in, and getting this wrong is how a false 🟢 sneaks back in:
+
+| Hosting repo | Compare `baseRefName` against | Final here? |
+| --- | --- | --- |
+| the repo this ticket is scoped to | `.repositories.<config key>.branches.development` | **No** — provisional |
+| any other configured repo | its own `branches.development`, else its remote default branch | Yes |
+
+The asymmetry is the point: only the scoped repo gets a worktree, so only it has a "branch the worktree will
+start from". A third-party repo is never branched from, so its own configured value — or its remote default when
+unconfigured — is the right and final answer for it.
+
+For the scoped repo the configured value is **provisional, not authoritative**. `$DEV_BRANCH` is resolved in
+Step 0.4, which runs *after* Step 3 and therefore after this gate, and Step 0.4 uses the configured value only
+as the **default of an `AskUserQuestion`** — the user may answer with any other branch. So `$DEV_BRANCH` can
+differ from `branches.development` even when one is configured, and the worktree starts from `$DEV_BRANCH`, not
+from the config. Comparing against the config alone would mark a PR merged into `main` as landed while the user
+starts from `develop`.
+
+Two consequences, both mandatory:
+
+- **Name the branch the comparison used**, every time, in the line shown to the user. A 🟡 caused by
+  configuration rather than by the PR has to be legible, and a 🟢 has to be auditable.
+- **Record that branch alongside the verdict** so Step 4.1 can re-check it. Step 4.1 is where `$DEV_BRANCH` is
+  finally known and where `git worktree add` actually runs: if `$DEV_BRANCH` differs from the branch this section
+  compared against, the "merged" conclusion no longer holds for the scoped repo and the verdict must be
+  downgraded there. `## Usage` carries the field.
+
+When the scoped repo has no `branches.development` configured either, there is nothing provisional to compare
+against at all: do not fall back to the remote default and call it merged — that is precisely the mismatch above,
+with no configured value to even be wrong about. Treat the PR as **open** for now, name the situation in one
+line, and let Step 4.1 settle it once Step 0.4 has produced a real `$DEV_BRANCH`.
 
 ## 4. The decision matrix
 
@@ -274,7 +304,13 @@ dependency is carried into `{attention_points}` of Step 5.5.3 so it is not forgo
 | `verdict` | `none` / `clear` / `in_flight` / `hard_blocked` / `unavailable`, worst (§4) | Step 2.4 |
 | `blocker_line` | `MSG_BLOCKER_CLEAR` / `_STALE_TICKET` / `_CHECK_UNAVAILABLE`, else empty | Step 5 |
 | `base_branch_candidate` | map **keyed by repo config key** → branch; empty unless 🟡 | Step 4.1 |
+| `merge_target_checked_against` | branch §3.5 compared `baseRefName` to; empty if no merged PR | Step 4.1 |
 | `blockers` | id, title and PR state per blocker | `{attention_points}` of Step 5.5.3 |
+
+`merge_target_checked_against` exists so a 🟢 earned on a provisional comparison can be revoked. §3.5 compares
+against the scoped repo's *configured* development branch, but the worktree starts from `$DEV_BRANCH`, which
+Step 0.4 only resolves later and may set to something else entirely. Step 4.1 owns that re-check; without this
+field it would have nothing to compare and the mismatch would pass silently.
 
 `none` is the verdict when §2 finds nothing after all — Step 2.4's cheap pre-filter is deliberately broader than
 §2.3 — and it behaves exactly like Step 2.4's early exit: say nothing, continue.

--- a/skills/magic-start/references/dependencies.md
+++ b/skills/magic-start/references/dependencies.md
@@ -126,12 +126,18 @@ in §3.1, in parallel:
 
 ```bash
 gh pr list --repo {owner}/{repo} --search "{BLOCKER_ID}" --state all \
-  --json number,title,state,mergedAt,headRefName,baseRefName,url 2>/dev/null
+  --json number,title,state,mergedAt,headRefName,baseRefName,mergeCommit,url 2>/dev/null
 ```
 
 `headRefName` comes back on that same response, so the branch the 🟡 offer needs requires no second call, and
 `title` is requested for the same reason — it fills `{pr_title}` in `MSG_BLOCKER_IN_FLIGHT` without a
 `gh pr view` round-trip. `baseRefName` is what §3.5 needs.
+
+`mergeCommit.oid` is requested because **`headRefName` is not a durable ref on a merged PR**: GitHub deletes the
+head branch on merge by default, so the branch named there frequently no longer exists. The merge commit always
+does. On an `open` PR the head branch is live and `headRefName` is the right thing to offer as a base; on a
+`merged` one it usually is not, and `mergeCommit.oid` is the only ref still checkoutable. §3.5 relies on that
+distinction, so both fields travel together — a 🟡 that can name no usable ref is a 🟡 that cannot be acted on.
 
 **Every result must then be validated — `--search` is full-text, and it is not a filter.** It matches the
 blocker ID anywhere in the title, body or comments, so a PR that merely *mentions* the blocker comes back

--- a/skills/magic-start/references/jira-custom-fields.md
+++ b/skills/magic-start/references/jira-custom-fields.md
@@ -141,5 +141,8 @@ never inferred from silence, a timeout or an unparseable answer; those go back t
 ## Usage
 
 Step 2A of `SKILL.md` evaluates the trigger inline and reads this file **only** when it fires. Once read,
-execute §2, then §3, then §4, then return to Step 2A's continuation (`/magic:start`: Step 2.5, then 2.6, then
-2.7; `/magic:continue`: Step 2.5, then 2.6) — except on option 3 of §4.2, which stops the skill.
+execute §2, then §3, then §4, then return to Step 2A's continuation (`/magic:start`: Step 2.4, then 2.5, then
+2.6, then 2.7; `/magic:continue`: Step 2.5, then 2.6) — except on option 3 of §4.2, which stops the skill.
+The `/magic:start` continuation goes through the dependency gate like any other: a thin ticket is exactly the
+kind that carries a dependency link, so skipping 2.4 here would transition it and create its worktree with no
+verdict.

--- a/skills/magic-start/references/messages.md
+++ b/skills/magic-start/references/messages.md
@@ -192,6 +192,153 @@ Options :
 Choix (1/2/3) :
 ```
 
+## MSG_BLOCKER_CLEAR
+
+### en
+
+```text
+🟢 Dependency checked: {blocker_id} — {evidence}. Nothing holds {ticket_id}.
+```
+
+### fr
+
+```text
+🟢 Dépendance vérifiée : {blocker_id} — {evidence}. Rien ne retient {ticket_id}.
+```
+
+> `{evidence}`: what made the verdict green, in a few words — `PR #91 merged`, `ticket done`
+> (`PR #91 mergée`, `ticket terminé`). Never a status name alone: the verdict comes from
+> `status.statusCategory.key`, per `references/dependencies.md` §3.2.
+
+## MSG_BLOCKER_STALE_TICKET
+
+### en
+
+```text
+🟢 Dependency checked: {blocker_id} has landed (PR #{pr_number} merged), but its ticket is still {blocker_status} — the tracker is behind, the code is not.
+```
+
+### fr
+
+```text
+🟢 Dépendance vérifiée : {blocker_id} est livré (PR #{pr_number} mergée), mais son ticket est encore {blocker_status} — c'est le tracker qui est en retard, pas le code.
+```
+
+## MSG_BLOCKER_IN_FLIGHT
+
+### en
+
+```text
+⏳ {ticket_id} depends on {blocker_id} (in flight)
+
+  PR #{pr_number}  "{pr_title}"  {pr_state}
+  branch  {blocker_branch}
+
+  Base the new worktree on:
+  > {blocker_branch}
+    {dev_branch}  (default)
+
+A force-push or a rebase on that PR propagates straight into your worktree.
+```
+
+### fr
+
+```text
+⏳ {ticket_id} dépend de {blocker_id} (en cours)
+
+  PR #{pr_number}  "{pr_title}"  {pr_state}
+  branche  {blocker_branch}
+
+  Baser le nouveau worktree sur :
+  > {blocker_branch}
+    {dev_branch}  (défaut)
+
+Un force-push ou un rebase sur cette PR se propage directement dans ton worktree.
+```
+
+> `{dev_branch}`: the repo's dev branch, resolved in Step 0.4 — which is why Step 4.1 asks this, not Step 2.4.
+
+## MSG_BLOCKER_HARD
+
+### en
+
+```text
+⚠ {ticket_id} is blocked by {blocker_id}
+
+  {blocker_id}  "{blocker_title}"
+  status    {blocker_status}
+  PR        none found
+
+  > Start {ticket_id} anyway
+    Start {blocker_id} instead
+    Stop here
+```
+
+### fr
+
+```text
+⚠ {ticket_id} est bloqué par {blocker_id}
+
+  {blocker_id}  "{blocker_title}"
+  statut    {blocker_status}
+  PR        aucune trouvée
+
+  > Démarrer {ticket_id} quand même
+    Démarrer {blocker_id} à la place
+    Arrêter ici
+```
+
+## MSG_BLOCKER_ABANDONED_PR
+
+### en
+
+```text
+⚠ {ticket_id} depends on {blocker_id}, whose work looks abandoned
+
+  {blocker_id}  "{blocker_title}"
+  status    {blocker_status}
+  PR        #{pr_number} closed, never merged — {pr_url}
+
+  A closed unmerged PR is not the same as no PR: someone started this and stopped.
+
+  > Start {ticket_id} anyway
+    Start {blocker_id} instead
+    Stop here
+```
+
+### fr
+
+```text
+⚠ {ticket_id} dépend de {blocker_id}, dont le travail semble abandonné
+
+  {blocker_id}  "{blocker_title}"
+  statut    {blocker_status}
+  PR        #{pr_number} fermée, jamais mergée — {pr_url}
+
+  Une PR fermée sans merge n'est pas une absence de PR : quelqu'un a commencé, puis arrêté.
+
+  > Démarrer {ticket_id} quand même
+    Démarrer {blocker_id} à la place
+    Arrêter ici
+```
+
+## MSG_BLOCKER_CHECK_UNAVAILABLE
+
+### en
+
+```text
+⚪ {ticket_id} declares a dependency on {blocker_id}, but it could not be checked: {reason}. No verdict is assumed — carried forward as an attention point.
+```
+
+### fr
+
+```text
+⚪ {ticket_id} déclare une dépendance sur {blocker_id}, mais elle n'a pas pu être vérifiée : {reason}. Aucun verdict n'est supposé — repris en point d'attention.
+```
+
+> `{reason}`: `gh` missing, `gh` not authenticated, Atlassian integration disabled, or the blocker
+> could not be resolved (`references/dependencies.md` §6). Never leave it vague.
+
 ## MSG_SCOPE_MULTIPLE
 
 ### en
@@ -413,6 +560,7 @@ Sauvegarder dans la config pour les prochains worktrees ? (o/n)
 🎫 Ticket    : {ticket_id} - {title}
 📋 Type      : {type_or_labels}
 📁 Worktree  : {worktree_path}
+{blocker_line}
 
 🔍 Exploring codebase...
 
@@ -428,11 +576,20 @@ Sauvegarder dans la config pour les prochains worktrees ? (o/n)
 🎫 Ticket    : {ticket_id} - {title}
 📋 Type      : {type_or_labels}
 📁 Worktree  : {worktree_path}
+{blocker_line}
 
 🔍 Exploration du codebase...
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
+
+> `{blocker_line}`: the single line produced by the Step 2.4 dependency gate — `MSG_BLOCKER_CLEAR`,
+> `MSG_BLOCKER_STALE_TICKET` or `MSG_BLOCKER_CHECK_UNAVAILABLE`. Those three are the only one-line keys;
+> `MSG_BLOCKER_IN_FLIGHT`, `MSG_BLOCKER_HARD` and `MSG_BLOCKER_ABANDONED_PR` are multi-line question blocks
+> shown at their own moment and **never** folded in here — on those paths `{blocker_line}` is empty and the
+> blocker reaches the user through `{attention_points}` instead. When no dependency was declared it is likewise
+> **empty and the line is omitted entirely**, so the box renders exactly as it did before the gate existed. The
+> same placeholder and rule apply to `MSG_TASK_SUMMARY_FULLSTACK` below.
 
 ## MSG_TASK_SUMMARY_FULLSTACK
 
@@ -446,6 +603,7 @@ Sauvegarder dans la config pour les prochains worktrees ? (o/n)
 📋 Type      : {type_or_labels}
 🔀 Full-Stack Task:
 {worktree_list}
+{blocker_line}
 
 🔍 Exploring codebase...
 
@@ -462,6 +620,7 @@ Sauvegarder dans la config pour les prochains worktrees ? (o/n)
 📋 Type      : {type_or_labels}
 🔀 Tâche Full-Stack :
 {worktree_list}
+{blocker_line}
 
 🔍 Exploration du codebase...
 

--- a/skills/magic-start/references/messages.md
+++ b/skills/magic-start/references/messages.md
@@ -336,8 +336,14 @@ Un force-push ou un rebase sur cette PR se propage directement dans ton worktree
 ⚪ {ticket_id} déclare une dépendance sur {blocker_id}, mais elle n'a pas pu être vérifiée : {reason}. Aucun verdict n'est supposé — repris en point d'attention.
 ```
 
-> `{reason}`: `gh` missing, `gh` not authenticated, Atlassian integration disabled, or the blocker
-> could not be resolved (`references/dependencies.md` §6). Never leave it vague.
+> `{reason}`: `gh` missing, `gh` not authenticated, Atlassian integration disabled, the blocker
+> could not be resolved (`references/dependencies.md` §6), or — on Step 4.1's 🟢 → 🟡 downgrade — the
+> blocker's base ref could not be fetched. Never leave it vague.
+>
+> This message **reports**, it does not ask: it states that no verdict was assumed and the workflow
+> continues. On the one path that must not continue (Step 4.1's downgrade, where falling back to
+> `$DEV_BRANCH` would undo the finding), display this line for the reason and then ask separately with
+> `MSG_BLOCKER_HARD`'s three options. Do not reword this text into a question.
 
 ## MSG_SCOPE_MULTIPLE
 


### PR DESCRIPTION
## Description

`/magic:start` used to start any ticket unconditionally — it never asked whether the ticket was *ready*. The words `blocked`, `blocker` and `issuelinks` appeared nowhere across the 7 skills, so a Jira "is blocked by" link was structurally invisible: `getJiraIssue` was called without an explicit `issuelinks` field. The result was a whole class of wasted work — you start a ticket, a plan gets built against a codebase that lacks the dependency, and you discover halfway through that the thing you build on does not exist yet.

This adds an always-on **dependency gate** as a new **Step 2.4**, placed immediately after ticket retrieval and strictly before the first side effect. The rule it enforces: **when a ticket declares a dependency, resolve it against reality before doing anything — and a merged PR carrying the blocker's ID means the dependency has landed, whatever the tracker says.**

Placement is the constraint that drove the design. The existing sequence is `2A/2B` retrieval → `2.5` Desktop metadata POST → `2.6` Jira transition to "In Progress" → `4` worktree + branch creation. A check landing any later would have already moved the ticket to In Progress and created an orphan worktree before discovering the work cannot proceed. Everything before the gate is read-only; the first mutation is the `/metadata` curl that follows it.

The feature is **free in the common case**: `issuelinks` rides along with a call that already happens, GitHub reuses the `issue_dependencies_summary` counts that `get_issue` already returns, and free-text detection is a string scan. A ticket with no declared dependency makes no additional API call, prints nothing, and renders its summary box byte-identically to before.

## Related Issue

Fixes #158

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **New `skills/magic-start/references/dependencies.md`** (237 lines) — owns the whole specification: the three detection sources, blocker resolution, the decision matrix, the degradation paths and a `## Usage` return contract. Keeps `SKILL.md` from growing, per the existing `node-setup.md` / `jira-custom-fields.md` pattern.
- **`skills/magic-start/SKILL.md`** — `issuelinks` added to the Step 2A `fields` array (merged with `attachment` from #156, not overwriting it); a note in Step 2B.3 that `issue_dependencies_summary.blocked_by == 0` short-circuits at zero cost; both retrieval hand-off lines rerouted through the gate; the new thin Step 2.4; Step 4.1 wired for the base-branch override.
- **Detection** — Jira `issuelinks` with link type names resolved via `getIssueLinkTypes` rather than hardcoded (they are per-site configurable), and only when `issuelinks` is non-empty; native GitHub issue dependencies; and free text in EN/FR (`blocked by PROJ-123`, `bloqué par`, `dépend de`, `after PROJ-4`, `needs #12`) requiring a ticket reference **adjacent** to the keyword and skipping negated forms such as `not blocked by anything`.
- **Resolution** — one JQL call for all Jira blockers (`key in (…)`), reading `status.statusCategory.key` (`new` / `indeterminate` / `done`) and never `status.name`, which is per-project and localized; `status.name` is used for display only. PR lookup fans out across **all** configured repos in parallel, since a blocker's PR may live in a different repo from the scoped one.
- **Verdicts** — 🟢 one line in the task summary and continue; 🟡 offer the blocker's PR head branch as the worktree base, with a one-line warning that a force-push or rebase on that PR propagates; 🔴 ask (start anyway / start the blocker instead / stop) with nothing created before the answer. A closed-unmerged PR is reported as **abandoned**, distinctly from "no PR found" — the treacherous case, where "there is a PR" reads as covered when the work was actually dropped. The overall verdict is the worst across all blockers.
- **`skills/magic-start/references/messages.md`** — 6 new `MSG_BLOCKER_*` keys (EN + FR), plus a `{blocker_line}` placeholder in `MSG_TASK_SUMMARY` and `MSG_TASK_SUMMARY_FULLSTACK`. Those summary boxes are fixed layouts with no free-text slot, so without the placeholder the 🟢 confirmation line had nowhere to go. The line is omitted entirely when no dependency was declared.
- **`skills/magic-start/references/jira-custom-fields.md`** (and its byte-identical `magic-continue` twin, kept in lockstep as that file's own rule requires) — its `## Usage` hand-off jumped straight to Step 2.5, which would have bypassed the new gate. A thin ticket is exactly the kind that carries a dependency link, so it is now routed through 2.4.
- **`install/install.sh`** — `getIssueLinkTypes` and `searchJiraIssuesUsingJql` added to the `ATLASSIAN_ENABLED` allowlist. That list holds exact tool names, not wildcards, so without them a gated Jira start would stop on an approval prompt inside the one step meant to run before anything else.
- **`skills/evals/eval_set.json`** — 3 routing entries (ids 42-44).

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

`npm test` passes at 664/664 across 50 files — notably `desktop/src/main/ipc/terminal-handlers.test.ts`, which walks every `skills/magic-*/SKILL.md`, extracts each `status=` from the curl query strings and asserts the produced action set equals exactly its 9-element list. Step 2.4 deliberately emits **no new `status=` value**, so that contract still holds; `baseBranch` is a separate query parameter.

`shellcheck install/install.sh` is clean, `eval_set.json` is valid JSON with contiguous ids, `dependencies.md` has no line over 120 chars, no dangling `MSG_*` key and no broken `§` cross-reference.

The two unchecked boxes are honest: the gate is specification prose executed by an agent, and it has not yet been exercised end-to-end against a live blocked ticket. `### Test Steps` below is how to do that. `shellcheck` covers the installer edit statically, but the installer itself was not run.

### Test Steps

1. From this branch, run `npm test && npx eslint desktop/src/ && shellcheck install/install.sh` — expect 664 passing tests, no ESLint errors (3 pre-existing `no-explicit-any` warnings in `desktop/src/renderer/pages/Config/RepoPage.tsx`, untouched here), and a clean shellcheck.
2. Point your local skills at this branch (`cp -r skills/* ~/.claude/skills/`), then run `/magic:start` on any ticket with **no** dependency. Expect behaviour identical to today: no extra API call, nothing printed about blockers, and no blocker line in the task-summary box.
3. Open a GitHub issue whose description contains `blocked by #156` and run `/magic:start` on it. Expect Step 2.4 to fire, find #156's PR as merged, and start with a single confirmation line — **no question asked**, because a merged PR means the code has landed.
4. Edit that description to `not blocked by anything` and re-run. Expect the gate to trigger nothing at all — the negation skip-list must swallow it.
5. Create an issue that declares `blocked by #<some open issue with an open PR>` and run `/magic:start`. Expect to be offered that PR's head branch as the worktree base alongside `main`; pick it and confirm `git worktree add` used it (`git log --oneline -1` in the new worktree should show the blocker's tip, and the Desktop sidebar should report it as the base branch).
6. Run `gh auth logout`, then run `/magic:start` on a ticket with a blocker. Expect `MSG_BLOCKER_CHECK_UNAVAILABLE`, an explicit statement that the check could not run, and the workflow continuing — never a fabricated verdict. Re-authenticate afterwards with `gh auth login`.

## Screenshots

Not applicable — no UI surface. The user-visible output is terminal text, whose exact layouts live in the new `MSG_BLOCKER_*` keys in `skills/magic-start/references/messages.md`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

**Two unchecked boxes, both deliberate.** `CHANGELOG.md` has no `[Unreleased]` section — version blocks are added at bump time, and `release.yml` parses those `## [x.y.z]` headings — so a feature PR that appended one would either sit in the wrong release or break the extraction. Docs were skipped because this adds no config key: the closest precedent, #163 (`read jira custom fields`), touched no docs either, while #160 (test accounts) touched README and `documentation.html` precisely because it added one. `v0.63.1` is untouched throughout; the version string is hand-maintained in 20+ places with no bump script, so bumping belongs to its own release change.

**Two design decisions worth a reviewer's attention.**

The verdict is computed at Step 2.4, but the 🟡 branch **question** is asked in Step 4.1. `$DEV_BRANCH` is only resolved in Step 0.4, which runs *after* Step 3 — so asking at 2.4 would have offered a default that does not exist yet, and would then be followed by Step 0.4 asking about it anyway. The issue only requires the choice be honored in Step 4, which it is.

The candidate base branch is keyed **per repo config key**, not held as a single scalar. A blocker's PR head branch exists in exactly one repo, so on a multi-repo start a shared scalar would make `git worktree add` fail in every other worktree. Step 0.5 sets the same precedent for per-repo values.

**Two departures from the issue text.** A GitHub blocker closed as `not_planned` is mapped to `done` for gate purposes — nobody is waiting on it — while the reason is surfaced in the line shown to the user. The issue's matrix is written for Jira's three `statusCategory` keys and has no cell for "won't do"; treating it as `new` would produce a permanent false 🔴. And the issue predicted a merge conflict with #156 on the `fields` list: #156 has since landed on `main`, so `attachment` was already there and `issuelinks` was merged into it rather than overwriting.

**Known coverage gap, stated rather than papered over.** `skills/evals/eval_set.json` matches an utterance against a skill — it tests *routing only*. Five of the issue's acceptance criteria are therefore not observable in it: merged PR → starts silently, no PR → asks, open PR → offers the branch, no blocker → no extra behaviour, and `statusCategory` verified against non-English status names. The three added entries say so explicitly in their `notes`, following the convention set by entry 41. Real coverage would need a skill-execution harness that does not exist in this repo, which is outside this issue's scope. `### Test Steps` above is the manual substitute.

One residual nit surfaced by self-review: Step 4.1 reads the resolved base as `${BASE_BRANCH:-$DEV_BRANCH}` from the shell, while the value is actually held by the agent across blocks — the same convention the file already uses for `$SLUG` and `$BRANCH_NAME`. It is consistent with the surrounding code, but here a mismatch would fail silently and land right on the "picking it is honored in Step 4" criterion. Flagging it for a reviewer's opinion rather than diverging from the file's established style unilaterally.
