### PR TITLE
[#168] Add an onboarding modal on launch when repository paths are not set

### DIFF
--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -1033,6 +1033,7 @@ export const en = {
   'repoSetup.addRepo': 'Add a repository',
   'repoSetup.resolved': 'Ready',
   'repoSetup.error': 'Could not use this folder',
+  'repoSetup.unverified': 'Folder saved, but its state could not be checked — try again',
 
   // ── Config validation / invalid repositories ─────────────────────────────
   'toast.invalidConfig.one': 'Invalid configuration: {count} error found in config.json',

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -1007,11 +1007,7 @@ export const en = {
   'app.closeAgent.title': 'Close this agent?',
   'app.closeAgent.body': 'Are you sure you want to close this agent?',
   'app.closeAgent.confirm': 'Yes, close agent',
-  'app.configRequired.title': 'Configuration required',
-  'app.configRequired.body':
-    'No repository is configured. To use Magic Slash, you must first add at least one repository in the configuration.',
   'app.later': 'Later',
-  'app.configure': 'Configure',
   'app.errorBoundary.title': 'Something went wrong',
   'app.errorBoundary.body': 'An unexpected error occurred.',
   'app.errorBoundary.retry': 'Try again',
@@ -1022,6 +1018,21 @@ export const en = {
   'gate.connectionLost.title': 'Connection lost',
   'gate.connectionLost.body':
     'Magic Slash can’t reach its backend. Check your internet connection — the app stays locked until the connection is restored.',
+
+  // ── Repository setup onboarding ──────────────────────────────────────────
+  'repoSetup.title.empty': 'Add your first repository',
+  'repoSetup.title.fix': 'Finish setting up your repositories',
+  'repoSetup.body.empty':
+    'Magic Slash needs at least one repository to launch agents on. Pick a local folder to get started.',
+  'repoSetup.body.fix':
+    'These repositories have no usable local folder yet. Pick one for each so agents can run on them.',
+  'repoSetup.reason.noLocalPath': 'No folder on this machine',
+  'repoSetup.reason.missing': 'Folder no longer exists',
+  'repoSetup.reason.notGit': 'Not a git repository',
+  'repoSetup.chooseFolder': 'Choose folder',
+  'repoSetup.addRepo': 'Add a repository',
+  'repoSetup.resolved': 'Ready',
+  'repoSetup.error': 'Could not use this folder',
 
   // ── Config validation / invalid repositories ─────────────────────────────
   'toast.invalidConfig.one': 'Invalid configuration: {count} error found in config.json',

--- a/desktop/src/i18n/fr.ts
+++ b/desktop/src/i18n/fr.ts
@@ -1034,6 +1034,7 @@ export const fr: Record<keyof typeof en, string> = {
   'repoSetup.addRepo': 'Ajouter un dépôt',
   'repoSetup.resolved': 'Prêt',
   'repoSetup.error': 'Impossible d’utiliser ce dossier',
+  'repoSetup.unverified': 'Dossier enregistré, mais son état n’a pas pu être vérifié — réessayez',
 
   // ── Validation de la config / dépôts invalides ───────────────────────────
   'toast.invalidConfig.one': 'Configuration invalide : {count} erreur trouvée dans config.json',

--- a/desktop/src/i18n/fr.ts
+++ b/desktop/src/i18n/fr.ts
@@ -1008,11 +1008,7 @@ export const fr: Record<keyof typeof en, string> = {
   'app.closeAgent.title': 'Fermer cet agent ?',
   'app.closeAgent.body': 'Voulez-vous vraiment fermer cet agent ?',
   'app.closeAgent.confirm': 'Oui, fermer l’agent',
-  'app.configRequired.title': 'Configuration requise',
-  'app.configRequired.body':
-    'Aucun dépôt n’est configuré. Pour utiliser Magic Slash, ajoutez d’abord au moins un dépôt dans la configuration.',
   'app.later': 'Plus tard',
-  'app.configure': 'Configurer',
   'app.errorBoundary.title': 'Une erreur est survenue',
   'app.errorBoundary.body': 'Une erreur inattendue s’est produite.',
   'app.errorBoundary.retry': 'Réessayer',
@@ -1023,6 +1019,21 @@ export const fr: Record<keyof typeof en, string> = {
   'gate.connectionLost.title': 'Connexion perdue',
   'gate.connectionLost.body':
     'Magic Slash n’arrive pas à joindre son backend. Vérifiez votre connexion Internet — l’application reste verrouillée jusqu’au rétablissement.',
+
+  // ── Configuration initiale des dépôts ────────────────────────────────────
+  'repoSetup.title.empty': 'Ajoutez votre premier dépôt',
+  'repoSetup.title.fix': 'Terminez la configuration de vos dépôts',
+  'repoSetup.body.empty':
+    'Magic Slash a besoin d’au moins un dépôt pour lancer des agents. Choisissez un dossier local pour commencer.',
+  'repoSetup.body.fix':
+    'Ces dépôts n’ont pas encore de dossier local utilisable. Choisissez-en un pour chacun afin que les agents puissent y travailler.',
+  'repoSetup.reason.noLocalPath': 'Aucun dossier sur cette machine',
+  'repoSetup.reason.missing': 'Le dossier n’existe plus',
+  'repoSetup.reason.notGit': 'Ce n’est pas un dépôt git',
+  'repoSetup.chooseFolder': 'Choisir un dossier',
+  'repoSetup.addRepo': 'Ajouter un dépôt',
+  'repoSetup.resolved': 'Prêt',
+  'repoSetup.error': 'Impossible d’utiliser ce dossier',
 
   // ── Validation de la config / dépôts invalides ───────────────────────────
   'toast.invalidConfig.one': 'Configuration invalide : {count} erreur trouvée dans config.json',

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useCallback, useRef, useMemo, useState } from 'react'
 import { AlertTriangle, RotateCcw, FolderOpen } from 'lucide-react'
+import { REASON_META, buildRepoSetup, needsRepoSetup } from './utils/repoSetup'
 import type { InvalidRepo } from '../preload'
 import { useStore } from './store'
 import { useConfig } from './hooks/useConfig'
@@ -21,6 +22,7 @@ import { LiveIndicator } from './components/LiveIndicator'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { ProfileOnboardingWizard } from './components/ProfileOnboardingWizard'
 import { SetupWizard } from './components/SetupWizard'
+import { RepoSetupWizard } from './components/RepoSetupWizard'
 import { useWindowSplitMode } from './hooks/useWindowSplitMode'
 import FilePreviewPanel from './components/FilePreviewPanel'
 import { useT, type MessageKey } from './i18n'
@@ -56,17 +58,22 @@ function ErrorScreen({ error }: { error: string }) {
 
 export function App() {
   const t = useT()
-  const { closeAgentModal, closeCloseAgentModal, terminals, activeTerminalId, setActiveTerminal, rightPaneTerminalIds, toggleRightSidebar, toggleLeftSidebar, toggleSplitActive, isWideScreen, splitEnabled, config, setConfig, noReposWarningShown, setNoReposWarningShown, activeModal, openSettingsModal, closeModal } = useStore()
+  const { closeAgentModal, closeCloseAgentModal, terminals, activeTerminalId, setActiveTerminal, rightPaneTerminalIds, toggleRightSidebar, toggleLeftSidebar, toggleSplitActive, isWideScreen, splitEnabled, config, setConfig, repoSetupDismissed, setRepoSetupDismissed, activeModal, closeModal } = useStore()
   const { configLoading, configError, loadConfig } = useConfig()
   const { killTerminal, launchClaudeTerminal } = useTerminals()
   const { flatVisualOrder } = useGroupedTerminals()
   useWindowSplitMode()
   const confirmCloseButtonRef = useRef<HTMLButtonElement>(null)
-  const [showNoReposModal, setShowNoReposModal] = useState(false)
   const [showProfileWizard, setShowProfileWizard] = useState(false)
   const [profileChecked, setProfileChecked] = useState(false)
   const [setupNeeded, setSetupNeeded] = useState(false)
+  const [setupChecked, setSetupChecked] = useState(false)
+  const [invalidRepos, setInvalidRepos] = useState<InvalidRepo[]>([])
+  const [showRepoWizard, setShowRepoWizard] = useState(false)
   const didLandRef = useRef(false)
+  // Repositories already surfaced by a launch toast, kept out of the effect body
+  // so a re-run never re-toasts what the user has already been told about.
+  const toastedReposRef = useRef<Set<string>>(new Set())
 
   // Landing page: stay on the agents page and select the topmost agent of the
   // sidebar list, so the app never opens on an empty screen. Runs once, only
@@ -103,8 +110,14 @@ export function App() {
     if (configLoading) return
     window.electronAPI.setup
       .getStatus()
-      .then((status) => setSetupNeeded(status.needsSetup))
-      .catch(() => { /* the wizard stays closed; Settings still reports the state */ })
+      .then((status) => {
+        setSetupNeeded(status.needsSetup)
+        setSetupChecked(true)
+      })
+      .catch(() => {
+        /* the wizard stays closed; Settings still reports the state */
+        setSetupChecked(true)
+      })
   }, [configLoading])
 
   // Sequenced behind the profile wizard rather than raced against it: both trigger on
@@ -113,25 +126,36 @@ export function App() {
   // wizard to be closed) is what makes the order deterministic.
   const showSetupWizard = profileChecked && !showProfileWizard && setupNeeded
 
-  // Check if there are no repos configured
-  const hasNoRepos = useMemo(() => {
-    if (!config) return false
-    return Object.keys(config.repositories).length === 0
-  }, [config])
+  // Everything the launch repository-setup modal needs: no repository at all, or
+  // repositories the main process reported as unusable (no folder bound, folder
+  // gone, folder not a git repo). Both inputs are needed — the config says what
+  // the user has, only the main process can say whether the paths still work.
+  const repoSetup = useMemo(() => buildRepoSetup(config?.repositories, invalidRepos), [config, invalidRepos])
 
-  // Show warning modal on first app open if no repos configured
+  // Sequenced behind the profile and machine wizards for the same reason they are
+  // sequenced behind each other, and LATCHED rather than derived: fixing the last
+  // row makes the condition false, and a derived boolean would rip the modal away
+  // mid-action instead of letting the user see the row turn green. Only onClose
+  // closes it. `invalidRepos` is in the deps because an organization's repos land
+  // after the connectivity check, well after the first render.
+  //
+  // Both checks must have RESOLVED, not merely be "not showing a wizard right now":
+  // `profile.get()` is a file read and settles long before `setup.getStatus()` probes
+  // prerequisites and versions, so testing `showSetupWizard` alone would latch this
+  // modal open first and let the machine wizard mount on top of it — two backdrops,
+  // and one Escape reaching both keydown handlers.
   useEffect(() => {
-    if (!configLoading && hasNoRepos && !noReposWarningShown) {
-      setShowNoReposModal(true)
-      setNoReposWarningShown(true)
-    }
-  }, [configLoading, hasNoRepos, noReposWarningShown, setNoReposWarningShown])
+    if (configLoading || !profileChecked || !setupChecked || showProfileWizard || showSetupWizard) return
+    if (repoSetupDismissed || !needsRepoSetup(repoSetup)) return
+    setShowRepoWizard(true)
+  }, [configLoading, profileChecked, setupChecked, showProfileWizard, showSetupWizard, repoSetupDismissed, repoSetup])
 
-  // Handle going to configuration
-  const handleGoToConfig = useCallback(() => {
-    setShowNoReposModal(false)
-    openSettingsModal('repositories')
-  }, [openSettingsModal])
+  // "Later": gone for this session, back on the next launch while paths are still
+  // missing — the state is real and the user has to deal with it eventually.
+  const handleCloseRepoWizard = useCallback(() => {
+    setShowRepoWizard(false)
+    setRepoSetupDismissed(true)
+  }, [setRepoSetupDismissed])
 
   // Handle closing an agent
   const handleCloseAgent = useCallback(async () => {
@@ -263,11 +287,28 @@ export function App() {
     return () => { unsubscribe() }
   }, [loadConfig, t])
 
-  // Surface configured repositories whose folder is missing or is not a git repo,
-  // with a one-click "re-point folder" action. Runs on launch (initial fetch +
-  // the main-process 'repos:invalid' event) so invalid paths are caught early.
+  // The repositories the main process reports as unusable. Kept in state rather
+  // than consumed on the spot: both the launch modal and the toasts read it, and
+  // an organization's repositories only arrive with the event, once the
+  // connectivity check has passed — well after the initial fetch has resolved.
   useEffect(() => {
-    const shownRef = new Set<string>()
+    window.electronAPI.config.getInvalidRepos().then(setInvalidRepos).catch(() => {})
+    const unsubscribe = window.electronAPI.config.onInvalidRepos(setInvalidRepos)
+    return () => { unsubscribe() }
+  }, [])
+
+  // Surface configured repositories whose folder is missing or is not a git repo,
+  // with a one-click "re-point folder" action, for the ones the launch modal is
+  // NOT already showing — the same problem told twice, once behind a backdrop and
+  // once as a toast that outlives it, reads as two problems. Once the modal is
+  // out of the way, a repository that breaks later in the session toasts as usual.
+  useEffect(() => {
+    if (configLoading) return
+
+    const shownRef = toastedReposRef.current
+    if (!repoSetupDismissed) {
+      for (const row of repoSetup.rows) shownRef.add(row.name)
+    }
 
     const repointFolder = async (name: string) => {
       const folder = await window.electronAPI.dialog.openFolder()
@@ -281,33 +322,28 @@ export function App() {
       }
     }
 
-    const surface = (repos: InvalidRepo[]) => {
-      for (const repo of repos) {
-        // A team repo not yet bound to a local folder is an expected state,
-        // surfaced gently in Settings — don't nag with a persistent error toast.
-        if (repo.reason === 'no-local-path') continue
-        if (shownRef.has(repo.name)) continue
-        shownRef.add(repo.name)
-        const key: MessageKey = repo.reason === 'missing'
-          ? 'toast.repoInvalidMissing'
-          : 'toast.repoInvalidNotGit'
-        showToast(t(key, { name: repo.name, path: repo.path }), 'error', {
-          persistent: true,
-          actions: [
-            {
-              label: t('toast.repointFolder'),
-              icon: <FolderOpen className="w-3.5 h-3.5" />,
-              onClick: () => repointFolder(repo.name),
-            },
-          ],
-        })
-      }
+    // The cross-checked rows, not the raw invalid list: a stale `repos:invalid`
+    // payload can still name a repository the user has deleted since, and its
+    // "re-point folder" action would call updateRepository on a name that is gone.
+    for (const row of repoSetup.rows) {
+      // No toast key means the state is expected and surfaced gently elsewhere (a
+      // team repo not yet bound to a local folder) — see REASON_META.
+      const toastKey = REASON_META[row.reason].toastKey
+      if (!toastKey) continue
+      if (shownRef.has(row.name)) continue
+      shownRef.add(row.name)
+      showToast(t(toastKey, { name: row.name, path: row.path }), 'error', {
+        persistent: true,
+        actions: [
+          {
+            label: t('toast.repointFolder'),
+            icon: <FolderOpen className="w-3.5 h-3.5" />,
+            onClick: () => repointFolder(row.name),
+          },
+        ],
+      })
     }
-
-    window.electronAPI.config.getInvalidRepos().then(surface).catch(() => {})
-    const unsubscribe = window.electronAPI.config.onInvalidRepos(surface)
-    return () => { unsubscribe() }
-  }, [loadConfig])
+  }, [configLoading, repoSetup, repoSetupDismissed, loadConfig, t])
 
   // A write-through to the cloud failed: the main process already re-synced the
   // caches from the DB, so the latest change may not have been saved. Tell the
@@ -478,45 +514,15 @@ export function App() {
         onClose={() => setSetupNeeded(false)}
       />
 
-      {/* No Repos Warning Modal */}
-      {showNoReposModal && (
-        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 animate-modal-backdrop">
-          <div className="bg-bg-secondary border border-line rounded-xl mx-4 max-w-md animate-modal-content">
-            {/* Header */}
-            <div className="flex items-center gap-3 px-5 pt-5 pb-4">
-              <div className="p-2 bg-yellow/10 rounded-lg">
-                <AlertTriangle className="w-4 h-4 text-yellow" />
-              </div>
-              <h3 className="text-base font-semibold">{t('app.configRequired.title')}</h3>
-            </div>
+      {/* Repositories that can't be used yet — none configured, or no usable folder.
+          Mounted only while open: the latch never re-opens it, and the wizard holds
+          a full-store subscription that would otherwise run for the whole session. */}
+      {showRepoWizard && <RepoSetupWizard setup={repoSetup} onClose={handleCloseRepoWizard} />}
 
-            {/* Body */}
-            <div className="px-5 pb-5">
-              <p className="text-text-secondary text-sm mb-5">
-                {t('app.configRequired.body')}
-              </p>
-
-              <div className="flex gap-2">
-                <button
-                  onClick={() => setShowNoReposModal(false)}
-                  className="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary border border-line rounded-lg hover:bg-surface-strong hover:text-ink transition-all"
-                >
-                  {t('app.later')}
-                </button>
-                <button
-                  onClick={handleGoToConfig}
-                  className="flex-1 px-3 py-1.5 text-xs font-medium text-yellow border border-yellow/20 rounded-lg hover:bg-yellow/10 transition-all"
-                >
-                  {t('app.configure')}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* What's New Modal (after auto-update) */}
-      <WhatsNewModal />
+      {/* What's New Modal (after auto-update) — held back rather than stacked on
+          the repository wizard's backdrop. It self-gates and only clears the
+          pending payload when the user closes it, so it comes back on its own. */}
+      {!showRepoWizard && <WhatsNewModal />}
 
       {/* Update Overlay */}
       <UpdateOverlay />

--- a/desktop/src/renderer/components/RepoSetupWizard.tsx
+++ b/desktop/src/renderer/components/RepoSetupWizard.tsx
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Check, FolderGit2, FolderOpen, Loader2, X } from 'lucide-react'
+import type { RepoSetup, RepoSetupReason } from '../utils/repoSetup'
+import { REASON_META, mergeRepoSetup } from '../utils/repoSetup'
+import { useConfig } from '../hooks/useConfig'
+import { useT } from '../i18n'
+
+interface RepoSetupWizardProps {
+  setup: RepoSetup
+  onClose: () => void
+}
+
+/** Per-row progress. Absent = untouched; the row shows its original reason. */
+interface RowState {
+  busy?: boolean
+  /** Set once the re-check confirmed the picked folder is a usable git repo. */
+  resolvedPath?: string
+  /** The re-check's verdict when the picked folder is still not usable. */
+  reason?: RepoSetupReason
+  error?: string
+}
+
+/** A repository added from this modal. The path is kept so an add that turned out
+ * unusable can show the folder it picked, next to the reason it is not usable. */
+interface AddedRepo {
+  name: string
+  path: string
+}
+
+interface RepoRowProps {
+  name: string
+  path?: string
+  /** Absent means the row is done — it renders as resolved, with no action. */
+  reason?: RepoSetupReason
+  state?: RowState
+  onChooseFolder?: () => void
+}
+
+/**
+ * One repository line. Shared by both modes so "this one is ready" is drawn once:
+ * a freshly added repository and a freshly re-bound one are the same statement.
+ */
+function RepoRow({ name, path, reason, state = {}, onChooseFolder }: RepoRowProps) {
+  const t = useT()
+  // No reason left to show IS the resolved state: a row with no reason at all
+  // (a repository just added) and one whose re-check came back clean read alike.
+  const shownReason = state.resolvedPath ? undefined : state.reason ?? reason
+  const shownPath = state.resolvedPath ?? path
+
+  return (
+    <div className="px-3 py-2 bg-surface border border-line-field rounded-lg">
+      <div className="flex items-center gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium truncate">{name}</div>
+          {shownPath && <div className="text-xs text-text-secondary/50 truncate">{shownPath}</div>}
+        </div>
+        {!shownReason ? (
+          <div className="flex items-center gap-1.5 text-xs text-green flex-shrink-0">
+            <Check className="w-3.5 h-3.5" />
+            {t('repoSetup.resolved')}
+          </div>
+        ) : (
+          <>
+            <span
+              className={`px-2 py-0.5 text-[11px] rounded-full flex-shrink-0 ${REASON_META[shownReason].severity === 'warning' ? 'bg-yellow/10 text-yellow' : 'bg-red/10 text-red'}`}
+            >
+              {t(REASON_META[shownReason].labelKey)}
+            </span>
+            <button
+              onClick={onChooseFolder}
+              disabled={state.busy}
+              className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-accent border border-accent/20 rounded-lg hover:bg-accent/10 transition-all disabled:opacity-40 flex-shrink-0"
+            >
+              {state.busy
+                ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                : <><FolderOpen className="w-3.5 h-3.5" />{t('repoSetup.chooseFolder')}</>}
+            </button>
+          </>
+        )}
+      </div>
+      {state.error && (
+        <div className="mt-2 px-3 py-2 bg-red/10 border border-red/20 rounded-lg text-xs text-red">
+          {state.error}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Launch onboarding for repositories that cannot be used yet: none configured at
+ * all, or configured with no local folder bound / a folder that has moved or is
+ * not a git repository. One modal for all of them — the user fixes each row in
+ * place and the modal stays open, so nothing here needs a restart.
+ *
+ * Mounted only while open (App holds the latch), so nothing here runs for the
+ * rest of the session once dismissed. Shell copied from InvitationOnboardingWizard;
+ * Escape and a backdrop click both mean "Later", never a silent dismissal of a
+ * state the user must eventually fix.
+ */
+export function RepoSetupWizard({ setup, onClose }: RepoSetupWizardProps) {
+  const { config, addRepository, updateRepository } = useConfig()
+  const t = useT()
+
+  const [rowStates, setRowStates] = useState<Record<string, RowState>>({})
+  const [added, setAdded] = useState<AddedRepo[]>([])
+  const [addBusy, setAddBusy] = useState(false)
+  const [addError, setAddError] = useState<string | null>(null)
+
+  // What the modal shows: the setup it opened with, with later payloads merged in
+  // rather than substituted for it. `repos:invalid` is re-emitted on a 20s timer
+  // and on window focus, so the incoming prop drops every row the user has just
+  // fixed — see mergeRepoSetup for the full rationale. Mounted only while open, so
+  // this snapshot is per-opening and the next launch starts from the live state.
+  const [displayed, setDisplayed] = useState<RepoSetup>(setup)
+  useEffect(() => {
+    setDisplayed((prev) => mergeRepoSetup(prev, setup))
+  }, [setup])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); onClose() }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  // Adding the first repository makes the config non-empty, which would flip the
+  // computed mode to 'fix' and swap the modal's whole body out from under the
+  // user mid-action. Once they have added something here, they stay in the flow
+  // they started, and see what they added, until they close it themselves.
+  const effectiveMode = added.length > 0 ? 'empty' : displayed.mode
+
+  /**
+   * Add a repository from a picked folder, then ASK THE MAIN PROCESS whether it is
+   * actually usable — `addRepository` only warns about a folder that does not exist
+   * or is not a git repository, so an unverified row would claim "Ready" for exactly
+   * what handleChooseFolder is careful not to claim. Repositories are keyed by name,
+   * so two folders sharing a basename would overwrite each other silently: the same
+   * guard Settings uses runs first.
+   */
+  const handleAddRepo = useCallback(async () => {
+    const folderPath = await window.electronAPI.dialog.openFolder()
+    if (!folderPath) return
+    const folderName = folderPath.split(/[\\/]/).pop() || ''
+    const name = folderName.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase()
+    if (!name) { setAddError(t('toast.invalidFolderName')); return }
+    if (config?.repositories?.[name]) { setAddError(t('toast.repoExists', { name })); return }
+    setAddBusy(true)
+    setAddError(null)
+    try {
+      await addRepository(name, folderPath, [])
+      const invalid = await window.electronAPI.config.getInvalidRepos()
+      const stillInvalid = invalid.find((repo) => repo.name === name)
+      setRowStates((prev) => ({
+        ...prev,
+        [name]: stillInvalid
+          ? { reason: stillInvalid.reason, error: t('repoSetup.error') }
+          : { resolvedPath: folderPath },
+      }))
+      setAdded((prev) => (prev.some((r) => r.name === name) ? prev : [...prev, { name, path: folderPath }]))
+    } catch (e) {
+      setAddError(e instanceof Error ? e.message : t('repoSetup.error'))
+    } finally {
+      setAddBusy(false)
+    }
+  }, [addRepository, config, t])
+
+  /**
+   * Bind a folder to an existing repository, then ASK THE MAIN PROCESS whether
+   * that fixed it. `updateRepository` writes the path without validating it, so
+   * a folder that is not a git repository would otherwise get a green check.
+   */
+  const handleChooseFolder = useCallback(async (name: string) => {
+    const folderPath = await window.electronAPI.dialog.openFolder()
+    if (!folderPath) return
+    setRowStates((prev) => ({ ...prev, [name]: { busy: true } }))
+    try {
+      await updateRepository(name, { path: folderPath })
+      const invalid = await window.electronAPI.config.getInvalidRepos()
+      const stillInvalid = invalid.find((repo) => repo.name === name)
+      setRowStates((prev) => ({
+        ...prev,
+        [name]: stillInvalid
+          ? { reason: stillInvalid.reason, error: t('repoSetup.error') }
+          : { resolvedPath: folderPath },
+      }))
+    } catch (e) {
+      setRowStates((prev) => ({
+        ...prev,
+        [name]: { error: e instanceof Error ? e.message : t('repoSetup.error') },
+      }))
+    }
+  }, [updateRepository, t])
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 animate-modal-backdrop"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-secondary border border-line rounded-xl w-full max-w-md mx-4 animate-modal-content"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-4">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-yellow/10 rounded-lg">
+              <FolderGit2 className="w-4 h-4 text-yellow" />
+            </div>
+            <h3 className="text-base font-semibold">
+              {t(effectiveMode === 'empty' ? 'repoSetup.title.empty' : 'repoSetup.title.fix')}
+            </h3>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 text-text-secondary hover:text-ink hover:bg-surface-strong rounded-lg transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body — scrollable, so a long list of repositories stays usable */}
+        <div className="px-5 pb-5 max-h-[50vh] overflow-y-auto">
+          <p className="text-text-secondary text-sm mb-4">
+            {t(effectiveMode === 'empty' ? 'repoSetup.body.empty' : 'repoSetup.body.fix')}
+          </p>
+
+          {effectiveMode === 'empty' ? (
+            <div className="space-y-3">
+              <button
+                onClick={handleAddRepo}
+                disabled={addBusy}
+                className="w-full flex items-center justify-center gap-2 py-3 text-sm border border-dashed border-line-strong rounded-lg text-text-secondary hover:border-accent/40 hover:text-ink transition-colors disabled:opacity-40"
+              >
+                {addBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <FolderOpen className="w-4 h-4" />}
+                {t('repoSetup.addRepo')}
+              </button>
+              {added.length > 0 && (
+                <div className="space-y-1.5">
+                  {added.map((repo) => (
+                    <RepoRow
+                      key={repo.name}
+                      name={repo.name}
+                      path={repo.path}
+                      state={rowStates[repo.name]}
+                      onChooseFolder={() => handleChooseFolder(repo.name)}
+                    />
+                  ))}
+                </div>
+              )}
+              {addError && (
+                <div className="px-3 py-2 bg-red/10 border border-red/20 rounded-lg text-xs text-red">
+                  {addError}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {displayed.rows.map((row) => (
+                <RepoRow
+                  key={row.name}
+                  name={row.name}
+                  path={row.path}
+                  reason={row.reason}
+                  state={rowStates[row.name]}
+                  onChooseFolder={() => handleChooseFolder(row.name)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-5 pb-5">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs font-medium text-text-secondary/50 hover:text-text-secondary transition-colors"
+          >
+            {t('app.later')}
+          </button>
+          <button
+            onClick={onClose}
+            className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-on-brand bg-accent hover:bg-accent-hover rounded-lg transition-all"
+          >
+            <Check className="w-3.5 h-3.5" />
+            {t('common.done')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/desktop/src/renderer/components/RepoSetupWizard.tsx
+++ b/desktop/src/renderer/components/RepoSetupWizard.tsx
@@ -17,6 +17,13 @@ interface RowState {
   resolvedPath?: string
   /** The re-check's verdict when the picked folder is still not usable. */
   reason?: RepoSetupReason
+  /**
+   * The write landed but its verdict could not be read back. Distinct from both
+   * outcomes above and load-bearing: without it, "we don't know" is indistinguishable
+   * from "no reason left to show", which is how the row would claim Ready for a
+   * folder nothing ever confirmed.
+   */
+  unverified?: boolean
   error?: string
 }
 
@@ -44,7 +51,10 @@ function RepoRow({ name, path, reason, state = {}, onChooseFolder }: RepoRowProp
   const t = useT()
   // No reason left to show IS the resolved state: a row with no reason at all
   // (a repository just added) and one whose re-check came back clean read alike.
+  // An unverified row is the exception — it has no reason either, but nothing
+  // confirmed it, so it must keep its action instead of reading as done.
   const shownReason = state.resolvedPath ? undefined : state.reason ?? reason
+  const isResolved = !shownReason && !state.unverified
   const shownPath = state.resolvedPath ?? path
 
   return (
@@ -54,18 +64,20 @@ function RepoRow({ name, path, reason, state = {}, onChooseFolder }: RepoRowProp
           <div className="text-sm font-medium truncate">{name}</div>
           {shownPath && <div className="text-xs text-text-secondary/50 truncate">{shownPath}</div>}
         </div>
-        {!shownReason ? (
+        {isResolved ? (
           <div className="flex items-center gap-1.5 text-xs text-green flex-shrink-0">
             <Check className="w-3.5 h-3.5" />
             {t('repoSetup.resolved')}
           </div>
         ) : (
           <>
-            <span
-              className={`px-2 py-0.5 text-[11px] rounded-full flex-shrink-0 ${REASON_META[shownReason].severity === 'warning' ? 'bg-yellow/10 text-yellow' : 'bg-red/10 text-red'}`}
-            >
-              {t(REASON_META[shownReason].labelKey)}
-            </span>
+            {shownReason && (
+              <span
+                className={`px-2 py-0.5 text-[11px] rounded-full flex-shrink-0 ${REASON_META[shownReason].severity === 'warning' ? 'bg-yellow/10 text-yellow' : 'bg-red/10 text-red'}`}
+              >
+                {t(REASON_META[shownReason].labelKey)}
+              </span>
+            )}
             <button
               onClick={onChooseFolder}
               disabled={state.busy}
@@ -132,12 +144,32 @@ export function RepoSetupWizard({ setup, onClose }: RepoSetupWizardProps) {
   const effectiveMode = added.length > 0 ? 'empty' : displayed.mode
 
   /**
-   * Add a repository from a picked folder, then ASK THE MAIN PROCESS whether it is
-   * actually usable — `addRepository` only warns about a folder that does not exist
-   * or is not a git repository, so an unverified row would claim "Ready" for exactly
-   * what handleChooseFolder is careful not to claim. Repositories are keyed by name,
-   * so two folders sharing a basename would overwrite each other silently: the same
-   * guard Settings uses runs first.
+   * Ask the main process whether `name` is usable now. Runs only AFTER the config
+   * write has landed, which is what makes its failure mode different: it is a
+   * failure to learn the verdict, never a failed write. Reporting it as a failed
+   * write would drop a repository that really was added, or leave a row that
+   * really was re-bound showing its old reason — so an unreadable verdict keeps
+   * the row listed and actionable, and claims nothing.
+   */
+  const recheck = useCallback(async (name: string, folderPath: string): Promise<RowState> => {
+    try {
+      const invalid = await window.electronAPI.config.getInvalidRepos()
+      const stillInvalid = invalid.find((repo) => repo.name === name)
+      return stillInvalid
+        ? { reason: stillInvalid.reason, error: t('repoSetup.error') }
+        : { resolvedPath: folderPath }
+    } catch (e) {
+      return { unverified: true, error: e instanceof Error ? e.message : t('repoSetup.unverified') }
+    }
+  }, [t])
+
+  /**
+   * Add a repository from a picked folder, then re-check it — `addRepository` only
+   * warns about a folder that does not exist or is not a git repository, so an
+   * unverified row would claim "Ready" for exactly what handleChooseFolder is
+   * careful not to claim. Repositories are keyed by name, so two folders sharing a
+   * basename would overwrite each other silently: the same guard Settings uses runs
+   * first. Only the write itself is caught here; see recheck for why.
    */
   const handleAddRepo = useCallback(async () => {
     const folderPath = await window.electronAPI.dialog.openFolder()
@@ -150,48 +182,46 @@ export function RepoSetupWizard({ setup, onClose }: RepoSetupWizardProps) {
     setAddError(null)
     try {
       await addRepository(name, folderPath, [])
-      const invalid = await window.electronAPI.config.getInvalidRepos()
-      const stillInvalid = invalid.find((repo) => repo.name === name)
-      setRowStates((prev) => ({
-        ...prev,
-        [name]: stillInvalid
-          ? { reason: stillInvalid.reason, error: t('repoSetup.error') }
-          : { resolvedPath: folderPath },
-      }))
-      setAdded((prev) => (prev.some((r) => r.name === name) ? prev : [...prev, { name, path: folderPath }]))
     } catch (e) {
       setAddError(e instanceof Error ? e.message : t('repoSetup.error'))
-    } finally {
       setAddBusy(false)
+      return
     }
-  }, [addRepository, config, t])
+    // The write landed: the repository is in the config whatever the re-check says,
+    // so it is listed from here on and only its verdict is still open.
+    const state = await recheck(name, folderPath)
+    setRowStates((prev) => ({ ...prev, [name]: state }))
+    setAdded((prev) => (prev.some((r) => r.name === name) ? prev : [...prev, { name, path: folderPath }]))
+    setAddBusy(false)
+  }, [addRepository, config, recheck, t])
 
   /**
-   * Bind a folder to an existing repository, then ASK THE MAIN PROCESS whether
-   * that fixed it. `updateRepository` writes the path without validating it, so
-   * a folder that is not a git repository would otherwise get a green check.
+   * Bind a folder to an existing repository, then re-check whether that fixed it.
+   * `updateRepository` writes the path without validating it, so a folder that is
+   * not a git repository would otherwise get a green check. A failed write keeps
+   * whatever the row already showed — replacing that state would strip the reason
+   * an added row has no prop to fall back on, leaving it green AND in error.
    */
   const handleChooseFolder = useCallback(async (name: string) => {
     const folderPath = await window.electronAPI.dialog.openFolder()
     if (!folderPath) return
-    setRowStates((prev) => ({ ...prev, [name]: { busy: true } }))
+    setRowStates((prev) => ({ ...prev, [name]: { ...prev[name], busy: true, error: undefined } }))
     try {
       await updateRepository(name, { path: folderPath })
-      const invalid = await window.electronAPI.config.getInvalidRepos()
-      const stillInvalid = invalid.find((repo) => repo.name === name)
-      setRowStates((prev) => ({
-        ...prev,
-        [name]: stillInvalid
-          ? { reason: stillInvalid.reason, error: t('repoSetup.error') }
-          : { resolvedPath: folderPath },
-      }))
     } catch (e) {
       setRowStates((prev) => ({
         ...prev,
-        [name]: { error: e instanceof Error ? e.message : t('repoSetup.error') },
+        [name]: {
+          ...prev[name],
+          busy: false,
+          error: e instanceof Error ? e.message : t('repoSetup.error'),
+        },
       }))
+      return
     }
-  }, [updateRepository, t])
+    const state = await recheck(name, folderPath)
+    setRowStates((prev) => ({ ...prev, [name]: state }))
+  }, [updateRepository, recheck, t])
 
   return (
     <div

--- a/desktop/src/renderer/store/index.ts
+++ b/desktop/src/renderer/store/index.ts
@@ -50,8 +50,9 @@ interface AppState {
   // Close agent modal
   closeAgentModal: CloseAgentModalData | null
 
-  // No repos warning modal
-  noReposWarningShown: boolean
+  // Launch repository-setup modal: dismissed for this session ("Later"). Session
+  // storage, so it survives a renderer reload but comes back on the next launch.
+  repoSetupDismissed: boolean
 
   selectedFile: { repoPath: string; path: string; status: string } | null
 
@@ -96,8 +97,8 @@ interface AppState {
   removeScriptTerminal: (id: string) => void
   updateScriptTerminalState: (id: string, state: 'running' | 'error') => void
 
-  // No repos warning modal actions
-  setNoReposWarningShown: (shown: boolean) => void
+  // Launch repository-setup modal actions
+  setRepoSetupDismissed: (dismissed: boolean) => void
 
   setSelectedFile: (file: { repoPath: string; path: string; status: string } | null) => void
   closeFilePreview: () => void
@@ -134,7 +135,7 @@ export const useStore = create<AppState>()(
         scriptTerminals: [],
 
         closeAgentModal: null,
-        noReposWarningShown: false,
+        repoSetupDismissed: false,
         selectedFile: null,
 
         // Actions
@@ -338,8 +339,8 @@ export const useStore = create<AppState>()(
             ),
           })),
 
-        // No repos warning modal actions
-        setNoReposWarningShown: (noReposWarningShown) => set({ noReposWarningShown }),
+        // Launch repository-setup modal actions
+        setRepoSetupDismissed: (repoSetupDismissed) => set({ repoSetupDismissed }),
 
         setSelectedFile: (selectedFile) => set({ selectedFile }),
         closeFilePreview: () => set({ selectedFile: null }),
@@ -352,6 +353,7 @@ export const useStore = create<AppState>()(
           activeTerminalId: state.activeTerminalId,
           splitTerminalId: state.splitTerminalId,
           rightPaneTerminalIds: state.rightPaneTerminalIds,
+          repoSetupDismissed: state.repoSetupDismissed,
         }),
       }
     ),

--- a/desktop/src/renderer/utils/repoSetup.test.ts
+++ b/desktop/src/renderer/utils/repoSetup.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest'
+import type { InvalidRepo } from '../../preload'
+import type { RepositoryConfig } from '../../types'
+import { REASON_META, buildRepoSetup, mergeRepoSetup, needsRepoSetup } from './repoSetup'
+
+function repo(overrides: Partial<RepositoryConfig> = {}): RepositoryConfig {
+  return { path: '/Users/me/Documents/repo', keywords: [], ...overrides }
+}
+
+function invalid(name: string, reason: InvalidRepo['reason'], path = ''): InvalidRepo {
+  return { name, path, reason }
+}
+
+const REPOS: Record<string, RepositoryConfig> = {
+  'magic-slash': repo({ path: '/Users/me/Documents/magic-slash' }),
+  'poppins-pex': repo({ path: '/Users/me/Documents/poppins-pex' }),
+  'design-system': repo({ path: '', needsLocalPath: true }),
+}
+
+describe('REASON_META', () => {
+  it('never toasts a repository that just has no folder bound yet', () => {
+    // The whole "no double signal" rule lives in this null: a team repo the user
+    // has not bound on this machine is surfaced in the modal and in Settings,
+    // never as a persistent error toast on top of them.
+    expect(REASON_META['no-local-path'].toastKey).toBeNull()
+    expect(REASON_META['no-local-path'].severity).toBe('warning')
+  })
+
+  it('toasts the states the user has to act on', () => {
+    expect(REASON_META['missing'].toastKey).toBe('toast.repoInvalidMissing')
+    expect(REASON_META['not-git'].toastKey).toBe('toast.repoInvalidNotGit')
+  })
+
+  it('orders unbound first, then missing, then not-git', () => {
+    expect(REASON_META['no-local-path'].priority).toBeLessThan(REASON_META['missing'].priority)
+    expect(REASON_META['missing'].priority).toBeLessThan(REASON_META['not-git'].priority)
+  })
+})
+
+describe('buildRepoSetup', () => {
+  it('asks for a first repository when the account has none', () => {
+    const result = buildRepoSetup({}, [])
+    expect(result.mode).toBe('empty')
+    expect(result.rows).toEqual([])
+    expect(needsRepoSetup(result)).toBe(true)
+  })
+
+  it('stays silent while the config has not loaded yet', () => {
+    // A null config is "not known yet", not "empty" — mapping it to 'empty'
+    // would flash an "add a repository" modal at a user who has ten.
+    for (const cfg of [null, undefined]) {
+      const result = buildRepoSetup(cfg, [invalid('magic-slash', 'missing')])
+      expect(result.mode).toBe('fix')
+      expect(result.rows).toEqual([])
+      expect(needsRepoSetup(result)).toBe(false)
+    }
+  })
+
+  it('stays silent when every configured path is valid', () => {
+    const result = buildRepoSetup(REPOS, [])
+    expect(result.mode).toBe('fix')
+    expect(result.rows).toEqual([])
+    expect(needsRepoSetup(result)).toBe(false)
+  })
+
+  it('lists a team repository with no local folder bound', () => {
+    const result = buildRepoSetup(REPOS, [invalid('design-system', 'no-local-path')])
+    expect(result.rows).toEqual([{ name: 'design-system', path: '', reason: 'no-local-path' }])
+    expect(needsRepoSetup(result)).toBe(true)
+  })
+
+  it('lists a repository whose folder has disappeared', () => {
+    const result = buildRepoSetup(REPOS, [invalid('magic-slash', 'missing', '/gone/magic-slash')])
+    expect(result.rows).toEqual([{ name: 'magic-slash', path: '/gone/magic-slash', reason: 'missing' }])
+  })
+
+  it('lists a repository pointing at a folder that is not a git repository', () => {
+    const result = buildRepoSetup(REPOS, [invalid('poppins-pex', 'not-git', '/Users/me/Downloads')])
+    expect(result.rows).toEqual([{ name: 'poppins-pex', path: '/Users/me/Downloads', reason: 'not-git' }])
+  })
+
+  it('ignores a repository the user no longer has in their config', () => {
+    // A stale 'repos:invalid' payload can still name a repo deleted since — a
+    // row for it would offer a "choose folder" button that writes into nothing.
+    const result = buildRepoSetup(REPOS, [invalid('deleted-repo', 'missing')])
+    expect(result.rows).toEqual([])
+  })
+
+  it('keeps a single row when the same repository is reported twice', () => {
+    const result = buildRepoSetup(REPOS, [
+      invalid('magic-slash', 'missing', '/gone/magic-slash'),
+      invalid('magic-slash', 'not-git', '/other/magic-slash'),
+    ])
+    expect(result.rows).toEqual([{ name: 'magic-slash', path: '/gone/magic-slash', reason: 'missing' }])
+  })
+
+  it('shows unbound repositories first, then missing, then not-git', () => {
+    const repos = {
+      ...REPOS,
+      'api': repo({ path: '/Users/me/Downloads' }),
+      'aaa-unbound': repo({ path: '', needsLocalPath: true }),
+    }
+    const result = buildRepoSetup(repos, [
+      invalid('api', 'not-git'),
+      invalid('magic-slash', 'missing'),
+      invalid('design-system', 'no-local-path'),
+      invalid('poppins-pex', 'missing'),
+      invalid('aaa-unbound', 'no-local-path'),
+    ])
+    expect(result.rows.map((r) => r.name)).toEqual([
+      'aaa-unbound',
+      'design-system',
+      'magic-slash',
+      'poppins-pex',
+      'api',
+    ])
+  })
+})
+
+describe('mergeRepoSetup', () => {
+  const OPENED_WITH = buildRepoSetup(REPOS, [
+    invalid('design-system', 'no-local-path'),
+    invalid('magic-slash', 'missing', '/gone/magic-slash'),
+  ])
+
+  it('keeps a row the user has just fixed', () => {
+    // `repos:invalid` is re-emitted every 20s and on window focus, and a fixed
+    // repository is exactly what drops out of it. Removing the row would erase
+    // the green "Ready" the user's own action just produced.
+    const merged = mergeRepoSetup(OPENED_WITH, buildRepoSetup(REPOS, [
+      invalid('design-system', 'no-local-path'),
+    ]))
+    expect(merged.rows.map((r) => r.name)).toEqual(['design-system', 'magic-slash'])
+  })
+
+  it('keeps the last row when every repository has been fixed', () => {
+    // The empty-list-under-a-"fix-these"-heading case.
+    const merged = mergeRepoSetup(OPENED_WITH, buildRepoSetup(REPOS, []))
+    expect(merged.rows).toEqual(OPENED_WITH.rows)
+  })
+
+  it('adds a repository that only shows up in a later payload', () => {
+    // An organization's repositories land after the connectivity check, well
+    // after the modal has opened — a late arrival still has to be surfaced.
+    const merged = mergeRepoSetup(OPENED_WITH, buildRepoSetup(REPOS, [
+      invalid('poppins-pex', 'not-git', '/Users/me/Downloads'),
+    ]))
+    expect(merged.rows.map((r) => r.name)).toEqual(['design-system', 'magic-slash', 'poppins-pex'])
+    expect(merged.rows[2]).toEqual({ name: 'poppins-pex', path: '/Users/me/Downloads', reason: 'not-git' })
+  })
+
+  it('updates a displayed row in place when its reason changes', () => {
+    const merged = mergeRepoSetup(OPENED_WITH, buildRepoSetup(REPOS, [
+      invalid('magic-slash', 'not-git', '/Users/me/Downloads'),
+    ]))
+    expect(merged.rows).toEqual([
+      { name: 'design-system', path: '', reason: 'no-local-path' },
+      { name: 'magic-slash', path: '/Users/me/Downloads', reason: 'not-git' },
+    ])
+  })
+
+  it('never duplicates a repository, however many payloads name it', () => {
+    let merged = mergeRepoSetup(OPENED_WITH, buildRepoSetup(REPOS, [
+      invalid('poppins-pex', 'not-git', '/Users/me/Downloads'),
+    ]))
+    merged = mergeRepoSetup(merged, buildRepoSetup(REPOS, [
+      invalid('design-system', 'no-local-path'),
+      invalid('magic-slash', 'missing', '/gone/magic-slash'),
+      invalid('poppins-pex', 'not-git', '/Users/me/Downloads'),
+    ]))
+    expect(merged.rows.map((r) => r.name)).toEqual(['design-system', 'magic-slash', 'poppins-pex'])
+  })
+
+  it('pins the mode so the modal never swaps its body out mid-action', () => {
+    // Adding the first repository makes the config non-empty, which flips the
+    // computed mode to 'fix'.
+    const opened = buildRepoSetup({}, [])
+    const merged = mergeRepoSetup(opened, buildRepoSetup(REPOS, [invalid('design-system', 'no-local-path')]))
+    expect(merged.mode).toBe('empty')
+    expect(merged.rows.map((r) => r.name)).toEqual(['design-system'])
+  })
+
+  it('returns the displayed setup untouched when a poll reports the status quo', () => {
+    // Identity, not just equality: a 20s poll that says nothing new must not
+    // re-render the open modal.
+    const same = buildRepoSetup(REPOS, [
+      invalid('design-system', 'no-local-path'),
+      invalid('magic-slash', 'missing', '/gone/magic-slash'),
+    ])
+    expect(mergeRepoSetup(OPENED_WITH, same)).toBe(OPENED_WITH)
+    expect(mergeRepoSetup(OPENED_WITH, buildRepoSetup(REPOS, []))).toBe(OPENED_WITH)
+  })
+})

--- a/desktop/src/renderer/utils/repoSetup.ts
+++ b/desktop/src/renderer/utils/repoSetup.ts
@@ -1,0 +1,167 @@
+import type { MessageKey } from '../../i18n'
+import type { InvalidRepo } from '../../preload'
+import type { RepositoryConfig } from '../../types'
+
+/** Why the main process considers a configured repository unusable. */
+export type RepoSetupReason = InvalidRepo['reason']
+
+/**
+ * What the launch onboarding modal is being opened FOR: an account with no
+ * repository at all ('empty', so the only sensible action is "add one"), or an
+ * account whose repositories exist but need a folder bound or re-bound ('fix').
+ */
+export type RepoSetupMode = 'empty' | 'fix'
+
+/** One repository the user has to act on, as the modal presents it. */
+export interface RepoSetupRow {
+  name: string
+  path: string
+  reason: RepoSetupReason
+}
+
+/** What the launch modal shows: which flow it is in, and the rows to act on. */
+export interface RepoSetup {
+  mode: RepoSetupMode
+  rows: RepoSetupRow[]
+}
+
+/** Everything the UI decides per reason, so a new reason is one row to fill in. */
+interface ReasonMeta {
+  /**
+   * Row order. A team repo never bound on this machine comes first because it is
+   * the most common case and the cheapest to fix; a folder that has gone missing
+   * next; "not a git repo" last, since that one usually means the user pointed at
+   * the wrong place and needs to think about it.
+   */
+  priority: number
+  /** Badge tone on the row. */
+  severity: 'warning' | 'error'
+  /** Badge label on the row. */
+  labelKey: MessageKey
+  /**
+   * Launch toast for the reason, or null when the state is expected and must not
+   * nag — a team repo with no folder bound yet is surfaced gently, in the modal
+   * and in Settings, never as a persistent error toast.
+   */
+  toastKey: MessageKey | null
+}
+
+/**
+ * The single place a reason's meaning lives. Kept exhaustive on purpose: adding a
+ * reason in the main process fails to compile here until ordering, tone, label and
+ * toast policy have all been decided, instead of silently defaulting to "not a git
+ * repository" in the toast and to red in the modal.
+ */
+export const REASON_META: Record<RepoSetupReason, ReasonMeta> = {
+  'no-local-path': {
+    priority: 0,
+    severity: 'warning',
+    labelKey: 'repoSetup.reason.noLocalPath',
+    toastKey: null,
+  },
+  'missing': {
+    priority: 1,
+    severity: 'error',
+    labelKey: 'repoSetup.reason.missing',
+    toastKey: 'toast.repoInvalidMissing',
+  },
+  'not-git': {
+    priority: 2,
+    severity: 'error',
+    labelKey: 'repoSetup.reason.notGit',
+    toastKey: 'toast.repoInvalidNotGit',
+  },
+}
+
+/**
+ * Decide what the launch repository-setup modal should show.
+ *
+ * The invalid list comes from the main process (it is the only side that can
+ * stat the filesystem), and the config is what the renderer holds. Cross-checking
+ * the two matters: a repo can be deleted locally while an older `repos:invalid`
+ * payload still names it, and listing a repository the user no longer has would
+ * offer a "choose folder" button that writes into nothing.
+ *
+ * A null/undefined config is deliberately NOT treated as "no repositories": on
+ * launch the config arrives asynchronously, and mapping that first frame to
+ * `empty` would flash an "add a repository" modal at users who have ten.
+ */
+export function buildRepoSetup(
+  repositories: Record<string, RepositoryConfig> | null | undefined,
+  invalid: InvalidRepo[],
+): RepoSetup {
+  if (!repositories) return { mode: 'fix', rows: [] }
+
+  if (Object.keys(repositories).length === 0) return { mode: 'empty', rows: [] }
+
+  const seen = new Set<string>()
+  const rows: RepoSetupRow[] = []
+  for (const repo of invalid) {
+    if (!(repo.name in repositories)) continue
+    if (seen.has(repo.name)) continue
+    seen.add(repo.name)
+    rows.push({ name: repo.name, path: repo.path, reason: repo.reason })
+  }
+
+  rows.sort((a, b) =>
+    REASON_META[a.reason].priority - REASON_META[b.reason].priority || a.name.localeCompare(b.name))
+
+  return { mode: 'fix', rows }
+}
+
+/**
+ * Fold a freshly computed setup into the one the open modal is already showing.
+ *
+ * `repos:invalid` is re-emitted every 20s and on every window focus, so the live
+ * setup is a moving target while the modal is open. Rendering it directly would
+ * make a row the user has just fixed vanish mid-session — the green "Ready" state
+ * erased by the very success that produced it, and an empty list under a "fix
+ * these" heading when it was the last row. So the modal keeps the snapshot it
+ * opened with and merges into it:
+ *
+ * - a displayed row is NEVER dropped, whatever later payloads say. Its absence is
+ *   the expected outcome of a successful fix, not a reason to hide the proof;
+ * - a repository that shows up later and is not displayed yet is APPENDED — an
+ *   organization's repositories only land once the connectivity check passes, and
+ *   a late arrival still has to be surfaced. Appending (rather than re-sorting the
+ *   whole list) keeps the rows the user is aiming at from moving under the cursor;
+ * - a displayed row's reason and path still follow later payloads, so a row the
+ *   user has not touched never shows a verdict the main process has superseded.
+ *
+ * The mode comes from the snapshot: the body the modal opened with is the body it
+ * closes with, for the same reason the wizard pins `effectiveMode`.
+ *
+ * Returns the displayed setup unchanged (same identity) when nothing moved, so a
+ * poll that reports the status quo costs no re-render.
+ */
+export function mergeRepoSetup(displayed: RepoSetup, incoming: RepoSetup): RepoSetup {
+  const incomingByName = new Map(incoming.rows.map((row) => [row.name, row] as const))
+  let changed = false
+
+  const rows = displayed.rows.map((row) => {
+    const update = incomingByName.get(row.name)
+    if (!update) return row
+    if (update.reason === row.reason && update.path === row.path) return row
+    changed = true
+    return { ...row, path: update.path, reason: update.reason }
+  })
+
+  const seen = new Set(displayed.rows.map((row) => row.name))
+  for (const row of incoming.rows) {
+    if (seen.has(row.name)) continue
+    seen.add(row.name)
+    rows.push(row)
+    changed = true
+  }
+
+  return changed ? { mode: displayed.mode, rows } : displayed
+}
+
+/**
+ * Whether the modal has anything to say: no repository at all is worth one even
+ * though it produces no rows, and rows are worth one even though the user already
+ * has repositories.
+ */
+export function needsRepoSetup(setup: RepoSetup): boolean {
+  return setup.mode === 'empty' || setup.rows.length > 0
+}


### PR DESCRIPTION
## Description

On launch the desktop app gave no clear signal when a configured repository had no local folder bound, or pointed at a broken path. The `no-local-path` reason was skipped outright when surfacing invalid repos, so an org repository synced from the cloud without a local folder produced **no signal at all** — it was only visible if the user opened Settings. `missing` / `not-git` paths only produced a persistent toast.

This adds a single onboarding modal that surfaces every repository needing setup and lets the user bind a folder in place, without closing the modal or restarting. It replaces the old "no repositories configured" modal. Renderer + i18n only — no main-process change.

## Related Issue

Fixes #168

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **New `desktop/src/renderer/utils/repoSetup.ts`** — pure, DOM-free logic: `buildRepoSetup()` (mode `empty` vs `fix`, rows cross-checked against `config.repositories`, deduped, ordered by reason), `mergeRepoSetup()` (snapshot merge, see below) and `REASON_META`, an exhaustive `Record<reason, { priority, severity, labelKey, toastKey }>` that replaces four scattered ternaries. Adding a fourth reason in the main process now fails to compile until its ordering, tone, label and toast policy are decided.
- **New `desktop/src/renderer/components/RepoSetupWizard.tsx`** — the modal. `empty` mode offers "Add a repository"; `fix` mode lists one row per repository with a reason badge and a "Choose folder" button. Both write paths re-query `config.getInvalidRepos()` **after** the write, because `updateRepository` performs no path validation in the main process — without that round-trip, binding a non-git folder would show a green check. Shell, Escape/backdrop handling and tokens follow `InvitationOnboardingWizard`.
- **`desktop/src/renderer/App.tsx`** — launch sequencing gated on `profileChecked` **and** a new `setupChecked` resolve latch (the slower `setup.getStatus()` could otherwise mount `SetupWizard` on top of the new modal); `WhatsNewModal` is held back while the wizard is open and re-reads its pending payload on remount. The old `showNoReposModal` / `hasNoRepos` / `handleGoToConfig` block is removed. The toast loop now iterates the config-cross-checked rows instead of the raw `repos:invalid` payload, and its dedupe ref is pre-seeded with the rows the modal lists, so those repositories never double-signal at launch.
- **`desktop/src/renderer/store/index.ts`** — `repoSetupDismissed` added to the `magic-slash-session` (sessionStorage) partialize, so "Later" survives a renderer reload but not an app restart. `noReposWarningShown` removed.
- **`desktop/src/i18n/{en,fr}.ts`** — new `repoSetup.*` block; `app.configRequired.title`, `app.configRequired.body` and `app.configure` removed (their only call site was the deleted modal). `app.later` and `common.done` are reused rather than duplicated.

The modal snapshots its rows on open and merges later `repos:invalid` payloads into that snapshot instead of replacing it. `connectivity:check` re-emits on a 20s interval and on window focus, so a live list would make a just-fixed row vanish from the open modal — and could leave the "fix" heading above an empty list. Merging keeps a fixed row visible while still surfacing org repositories that land after `connectivity: ok`.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

`npm test` — 826 tests pass across 62 files, including 22 new cases in `repoSetup.test.ts` covering `buildRepoSetup`, `mergeRepoSetup` and the `REASON_META` toast policy. `npm run lint:js` — 0 errors (3 pre-existing `no-explicit-any` warnings in `pages/Config/RepoPage.tsx`, untouched). `cd desktop && npm run typecheck` — clean.

**Not verified**: the app was not launched, so the modal's visual layout and the folder-picker round-trip are covered by types and tests only. The launch-modal sequencing, the sessionStorage dismiss policy and the toast suppression all live in `App.tsx` and are unreachable from the Node-only Vitest environment. The steps below are the manual pass a reviewer should run.

### Test Steps

1. `npm run desktop` from the worktree root. With every configured repository path valid, confirm **no modal appears** at launch.
2. Point one repository's `"path"` in `~/.config/magic-slash/config.json` at a directory that does not exist, then relaunch. The modal opens listing that repository with a red badge — and **no persistent error toast** is raised for it.
3. Click "Choose folder" on that row and pick a real git repository. The row flips to a green resolved state **and the modal stays open**. Leave the app idle for ~30 seconds (the connectivity poll re-emits `repos:invalid`) and confirm the row is still displayed.
4. Repeat step 3 but pick a directory that is **not** a git repository. The row must show an error and its new reason — not a green check.
5. Set `"repositories": {}` and relaunch: the same modal opens in "add" mode. Add a folder, then add a second folder whose basename matches the first — the duplicate is refused instead of silently overwriting the first entry.
6. Click "Later": the modal closes. Reload the renderer (Cmd+R) — it stays closed. **Quit the app entirely** and relaunch — it appears again while paths are still missing (sessionStorage, so a reload is not enough to re-test this).

## Screenshots

Not included — the modal reuses the existing wizard shell and design tokens verbatim (`InvitationOnboardingWizard`), with no new visual language.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

`CHANGELOG.md` is not updated here — in this repo it is only written by `chore(release)` commits at version-bump time.

Two follow-ups found while working, both deliberately left out of scope:

- The folder-to-repository-name derivation now exists in three places and they have already drifted: `pages/Config/index.tsx` splits on `/` only, while the wizards split on `/[\\/]/`, so Windows paths yield different names. Worth extracting.
- The modal is not bounded to a launch window: a repository that breaks mid-session opens it over the user's work as long as it has not been dismissed. The old toast path is suppressed for those repositories, so this replaces one signal with another rather than adding one. Defensible, but broader than the issue asked for.
