### PR TITLE
[#173] Answer agent questions from the menu bar panel

### DIFF
--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -931,6 +931,18 @@ export const en = {
   'tray.popover.account': 'Account and settings',
   'tray.popover.quit': 'Quit the app',
 
+  // ── Pending questions, answered from the panel ───────────────────────────
+  // "Allow" and "Deny" are ours, not the TUI's: a permission prompt reaches us as
+  // a one-line notification, never as the wording of its own buttons.
+  'tray.question.waiting': '{count} awaiting an answer',
+  'tray.question.allow': 'Allow',
+  'tray.question.deny': 'Deny',
+  'tray.question.openAgent': 'Open the agent',
+  // Shown when the question was answered elsewhere between two polls. Nothing was
+  // written to the agent — that is the point of saying so.
+  'tray.question.stale': 'Already answered — nothing was sent',
+  'tray.question.unsupported': 'Answer this one in the app',
+
   // ── Compact relative time (agent info sidebar) ───────────────────────────
   // Abbreviations, one key per unit: French shortens a day to "j" and a week to
   // "sem", so a shared suffix table would not survive translation.

--- a/desktop/src/i18n/fr.ts
+++ b/desktop/src/i18n/fr.ts
@@ -936,6 +936,14 @@ export const fr: Record<keyof typeof en, string> = {
   'tray.popover.account': 'Compte et réglages',
   'tray.popover.quit': 'Quitter l’application',
 
+  // ── Questions en attente, répondues depuis le panneau ────────────────────
+  'tray.question.waiting': '{count} en attente de réponse',
+  'tray.question.allow': 'Autoriser',
+  'tray.question.deny': 'Refuser',
+  'tray.question.openAgent': 'Ouvrir l’agent',
+  'tray.question.stale': 'Déjà répondu — rien n’a été envoyé',
+  'tray.question.unsupported': 'À répondre dans l’application',
+
   // ── Temps relatif compact (barre d'infos de l'agent) ─────────────────────
   'relative.now': 'à l’instant',
   'relative.minutes': '{count} min',

--- a/desktop/src/main/hooks/claude-hooks-config.test.ts
+++ b/desktop/src/main/hooks/claude-hooks-config.test.ts
@@ -14,7 +14,7 @@ vi.mock('os', async (importOriginal) => {
   return { ...actual, default: { ...actual, homedir: () => TMP_HOME }, homedir: () => TMP_HOME }
 })
 
-import { configureClaudeHooks } from './claude-hooks-config'
+import { configureClaudeHooks, removeClaudeHooks } from './claude-hooks-config'
 
 const SETTINGS = path.join(TMP_HOME, '.claude', 'settings.json')
 const SPOOL = path.join(TMP_HOME, '.config', 'magic-slash', 'pending-skills.ndjson')
@@ -305,5 +305,112 @@ describe('the permission allowlist', () => {
     configureClaudeHooks()
     configureClaudeHooks()
     expect(new Set(allow()).size).toBe(allow().length)
+  })
+})
+
+/**
+ * The hooks that put an agent's pending question in the menu bar panel.
+ *
+ * Two of them capture (the AskUserQuestion tool call, and the Notification a
+ * permission prompt raises) and three clear. All five are ADDITIONAL entries on
+ * events that already carry the state-reporting hook, which is what most of these
+ * tests are actually guarding.
+ */
+describe('the pending-question hooks', () => {
+  const hooksFor = (event: string): Hook[] => (readSettings().hooks[event] as Hook[]) ?? []
+  const matching = (event: string, fragment: string): Hook[] =>
+    hooksFor(event).filter((h) => h.hooks!.some((x) => x.command!.includes(fragment)))
+  const captures = (event: string) => matching(event, '/question?id=')
+  const clears = (event: string) => matching(event, '/question/clear?id=')
+
+  it('captures the AskUserQuestion tool call, scoped by matcher', () => {
+    configureClaudeHooks()
+    const hooks = captures('PreToolUse')
+    expect(hooks).toHaveLength(1)
+    // Unscoped, this would POST the payload of every single tool call.
+    expect(hooks[0].matcher).toBe('AskUserQuestion')
+  })
+
+  it('captures Notification, which has no tool to match on', () => {
+    configureClaudeHooks()
+    const hooks = captures('Notification')
+    expect(hooks).toHaveLength(1)
+    expect(hooks[0].matcher).toBeUndefined()
+  })
+
+  it('POSTs the hook stdin as the request body', () => {
+    configureClaudeHooks()
+    const command = captures('Notification')[0].hooks![0].command!
+    expect(command).toContain('-X POST')
+    expect(command).toContain('--data-binary @-')
+    // A blocked agent is waiting on this hook: it must not be able to hang.
+    expect(command).toContain('--max-time 2')
+  })
+
+  it('clears on the question\'s own PostToolUse, a new prompt, and the end of the turn', () => {
+    configureClaudeHooks()
+    expect(clears('PostToolUse')).toHaveLength(1)
+    expect(clears('PostToolUse')[0].matcher).toBe('AskUserQuestion')
+    expect(clears('UserPromptSubmit')).toHaveLength(1)
+    expect(clears('Stop')).toHaveLength(1)
+  })
+
+  // The clear is bound to events precisely so it never has to be bound to state:
+  // the generic PreToolUse hook reports `working` at the same instant the capture
+  // fires, so a state-driven clear would erase the question it just received.
+  it('never clears on PreToolUse, whatever the matcher', () => {
+    configureClaudeHooks()
+    expect(clears('PreToolUse')).toHaveLength(0)
+  })
+
+  it('leaves the state reporting on every event it shares alone', () => {
+    configureClaudeHooks()
+    for (const [event, state] of [
+      ['PreToolUse', 'working'],
+      ['Notification', 'waiting'],
+      ['PostToolUse', 'working'],
+      ['UserPromptSubmit', 'working'],
+      ['Stop', 'completed'],
+    ]) {
+      const commands = hooksFor(event).flatMap((h) => h.hooks!.map((x) => x.command!))
+      expect(commands.some((c) => c.includes(`state=${state}`))).toBe(true)
+    }
+  })
+
+  it('stays one entry per event across repeated configuration', () => {
+    configureClaudeHooks()
+    configureClaudeHooks()
+    configureClaudeHooks()
+    expect(captures('PreToolUse')).toHaveLength(1)
+    expect(captures('Notification')).toHaveLength(1)
+    expect(clears('PostToolUse')).toHaveLength(1)
+    expect(clears('UserPromptSubmit')).toHaveLength(1)
+    expect(clears('Stop')).toHaveLength(1)
+  })
+
+  it('is a silent no-op when the app is not listening', () => {
+    // No MAGIC_SLASH_PORT: the guard short-circuits and the hook exits 0, so a
+    // closed app can never make an agent's question hook fail.
+    configureClaudeHooks()
+    const command = captures('Notification')[0].hooks![0].command!
+    expect(() => run(command, '{"hook_event_name":"Notification","message":"x"}', 'claude-1')).not.toThrow()
+  })
+
+  it('is removed by removeClaudeHooks, along with every other Magic Slash hook', () => {
+    fs.mkdirSync(path.join(TMP_HOME, '.claude'), { recursive: true })
+    fs.writeFileSync(SETTINGS, JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'mine.sh' }] }] },
+    }))
+
+    configureClaudeHooks()
+    removeClaudeHooks()
+
+    const settings = readSettings()
+    const remaining = Object.values(settings.hooks ?? {})
+      .flatMap((entries) => (entries as Hook[]).flatMap((h) => h.hooks!.map((x) => x.command!)))
+    expect(remaining.some((c) => c.includes('magic-slash-desktop'))).toBe(false)
+    expect(remaining.some((c) => c.includes('/question'))).toBe(false)
+    // The user's own hook is untouched — the filter is by marker, not by event.
+    expect(remaining).toContain('mine.sh')
   })
 })

--- a/desktop/src/main/hooks/claude-hooks-config.ts
+++ b/desktop/src/main/hooks/claude-hooks-config.ts
@@ -315,6 +315,52 @@ function getPromptSkillHookConfig(): HookConfig {
   }
 }
 
+/**
+ * The hooks that drive the menu bar panel's pending-question card.
+ *
+ * `question` ships the hook's own stdin to the app, so the panel can show WHAT the
+ * agent is asking (see main/questions/pending-questions.ts). `question/clear` tells
+ * the app the agent is no longer blocked, so the panel drops the card.
+ *
+ * ⚠️ The clears are bound to EVENTS, never to state. The generic PreToolUse hook
+ * reports `working` at the very instant the AskUserQuestion capture fires, and their
+ * order is not guaranteed — clearing on a state change would erase the question that
+ * just arrived. Hence three separate event registrations (the question's own
+ * PostToolUse, a new user prompt, and the end of the turn) instead.
+ *
+ * `--data-binary @-` makes curl read stdin itself — no `cat`, no temp file, and the
+ * payload reaches the app byte for byte, parsed on the app side rather than mangled
+ * by shell quoting here.
+ *
+ * `--max-time 2` is the load-bearing flag: these hooks run on the critical path of a
+ * blocked agent. If the app is not listening (closed, or restarting), the connection
+ * refusal is immediate; the timeout covers the pathological case of a socket that
+ * accepts and never answers, which would otherwise hang the agent indefinitely.
+ * `|| true` makes every failure a no-op, as with every other hook here.
+ *
+ * Both routes share one builder so the guard, the timeout and the marker exist once:
+ * these commands swallow their own errors, so a divergent copy would fail silently.
+ *
+ * @param route `question` to capture, `question/clear` to clear.
+ * @param options.post Send the hook's stdin as the request body.
+ * @param options.matcher Tool-name pattern, or omitted for events that have no tool.
+ */
+function getQuestionHookConfig(
+  route: 'question' | 'question/clear',
+  options: { post?: boolean; matcher?: string } = {}
+): HookConfig {
+  const body = options.post ? '-X POST --data-binary @- ' : ''
+  const command = `[ -n "$MAGIC_SLASH_TERMINAL_ID" ] && [ -n "$MAGIC_SLASH_PORT" ] && curl -s --max-time 2 ${body}"http://127.0.0.1:$MAGIC_SLASH_PORT/${route}?id=$MAGIC_SLASH_TERMINAL_ID" > /dev/null 2>&1 || true # ${MAGIC_SLASH_HOOK_MARKER}`
+
+  return {
+    ...(options.matcher ? { matcher: options.matcher } : {}),
+    hooks: [{
+      type: 'command',
+      command
+    }]
+  }
+}
+
 function isMagicSlashHook(hookConfig: HookConfig): boolean {
   return hookConfig.hooks?.some(h => h.command?.includes(MAGIC_SLASH_HOOK_MARKER)) ?? false
 }
@@ -389,6 +435,21 @@ export function configureClaudeHooks(options?: { atlassian?: boolean }): void {
     //   - the typed slash command, which never reaches a tool call.
     settings.hooks.PreToolUse!.push(getSkillHookConfig())
     settings.hooks.UserPromptSubmit!.push(getPromptSkillHookConfig())
+
+    // Pending questions, for the menu bar panel. Five more ADDITIONAL entries on
+    // events already hooked above — pushed, never assigned, or the state reporting
+    // that shares those events would be replaced by these.
+    //
+    // Capture: the AskUserQuestion tool call (scoped by matcher, since PreToolUse
+    // fires on every tool), and Notification, which is how a permission prompt
+    // announces itself.
+    settings.hooks.PreToolUse!.push(getQuestionHookConfig('question', { post: true, matcher: 'AskUserQuestion' }))
+    settings.hooks.Notification!.push(getQuestionHookConfig('question', { post: true }))
+    // Clear: the question was answered in the terminal (its PostToolUse), the user
+    // moved on to something else, or the turn ended.
+    settings.hooks.PostToolUse!.push(getQuestionHookConfig('question/clear', { matcher: 'AskUserQuestion' }))
+    settings.hooks.UserPromptSubmit!.push(getQuestionHookConfig('question/clear'))
+    settings.hooks.Stop!.push(getQuestionHookConfig('question/clear'))
 
     // Configure permissions for magic-slash skills (MCP tools + common commands)
     if (!settings.permissions) {

--- a/desktop/src/main/hooks/status-server.test.ts
+++ b/desktop/src/main/hooks/status-server.test.ts
@@ -9,6 +9,8 @@ import {
   setAgentProvider,
   setWorktreeFilesWriter,
   setSkillCallback,
+  setQuestionCallback,
+  setClearQuestionCallback,
 } from './status-server'
 
 describe('parseStatusLinePayload', () => {
@@ -108,6 +110,21 @@ describe('read-back endpoints', () => {
           res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf-8') }))
         })
         .on('error', reject)
+    })
+
+  const httpPost = (path: string, body: string): Promise<{ status: number; body: string }> =>
+    new Promise((resolve, reject) => {
+      const req = http.request(
+        `http://127.0.0.1:${getServerPort()}${path}`,
+        { method: 'POST' },
+        (res) => {
+          const chunks: Buffer[] = []
+          res.on('data', (c: Buffer) => chunks.push(c))
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf-8') }))
+        },
+      )
+      req.on('error', reject)
+      req.end(body)
     })
 
   beforeAll(async () => {
@@ -224,6 +241,60 @@ describe('read-back endpoints', () => {
       const { status } = await httpGet('/skill?id=term-1')
       expect(status).toBe(200)
       expect(calls).toHaveLength(0)
+    })
+  })
+
+  describe('the question routes', () => {
+    let received: Array<{ id: string; body: string }> = []
+    let cleared: string[] = []
+
+    beforeEach(() => {
+      received = []
+      cleared = []
+      setQuestionCallback((id, body) => received.push({ id, body }))
+      setClearQuestionCallback((id) => cleared.push(id))
+    })
+
+    it('POST /question forwards the raw hook payload, unparsed', async () => {
+      const payload = JSON.stringify({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'Which one?', options: [{ label: 'A' }] }] },
+      })
+      const { status } = await httpPost('/question?id=term-1', payload)
+      expect(status).toBe(200)
+      expect(received).toEqual([{ id: 'term-1', body: payload }])
+    })
+
+    // A hook must never stall the agent it reports on, so an unusable body is
+    // still a 200 — the callback decides what to do with it.
+    it('POST /question answers 200 for a body that is not JSON', async () => {
+      const { status } = await httpPost('/question?id=term-1', 'not json at all')
+      expect(status).toBe(200)
+      expect(received).toEqual([{ id: 'term-1', body: 'not json at all' }])
+    })
+
+    it('POST /question answers 200 and skips the callback for an empty body', async () => {
+      const { status } = await httpPost('/question?id=term-1', '')
+      expect(status).toBe(200)
+      expect(received).toHaveLength(0)
+    })
+
+    it('POST /question ignores sidebar terminals', async () => {
+      const { status } = await httpPost('/question?id=sidebar-1', '{"hook_event_name":"Notification"}')
+      expect(status).toBe(200)
+      expect(received).toHaveLength(0)
+    })
+
+    it('GET /question/clear forwards the terminal id', async () => {
+      const { status } = await httpGet('/question/clear?id=term-1')
+      expect(status).toBe(200)
+      expect(cleared).toEqual(['term-1'])
+    })
+
+    it('GET /question/clear ignores sidebar terminals', async () => {
+      await httpGet('/question/clear?id=sidebar-1')
+      expect(cleared).toHaveLength(0)
     })
   })
 })

--- a/desktop/src/main/hooks/status-server.ts
+++ b/desktop/src/main/hooks/status-server.ts
@@ -39,6 +39,13 @@ type CommandStartCallback = (terminalId: string, command: string) => void
 type CommandEndCallback = (terminalId: string, exitCode: number) => void
 type RepositoriesCallback = (terminalId: string, repositories: string[]) => void
 type UsageCallback = (terminalId: string, usage: TerminalUsage) => void
+/**
+ * A question hook fired: `body` is the raw hook payload from stdin, forwarded
+ * unparsed so the parsing (and its failure modes) live with the question store.
+ */
+type QuestionCallback = (terminalId: string, body: string) => void
+/** The agent is no longer blocked — see the clear hooks in claude-hooks-config. */
+type ClearQuestionCallback = (terminalId: string) => void
 /** terminalId is undefined for sessions started outside the app (no agent). */
 type SkillCallback = (terminalId: string | undefined, skill: string) => void
 // Read-back providers: unlike the callbacks above (terminal → app writes), these let a
@@ -61,6 +68,8 @@ let commandStartCallback: CommandStartCallback | null = null
 let commandEndCallback: CommandEndCallback | null = null
 let repositoriesCallback: RepositoriesCallback | null = null
 let usageCallback: UsageCallback | null = null
+let questionCallback: QuestionCallback | null = null
+let clearQuestionCallback: ClearQuestionCallback | null = null
 let skillCallback: SkillCallback | null = null
 let configProvider: ConfigProvider | null = null
 let agentProvider: AgentProvider | null = null
@@ -94,6 +103,14 @@ export function setUsageCallback(callback: UsageCallback) {
   usageCallback = callback
 }
 
+export function setQuestionCallback(callback: QuestionCallback) {
+  questionCallback = callback
+}
+
+export function setClearQuestionCallback(callback: ClearQuestionCallback) {
+  clearQuestionCallback = callback
+}
+
 export function setSkillCallback(callback: SkillCallback) {
   skillCallback = callback
 }
@@ -110,7 +127,7 @@ export function setWorktreeFilesWriter(writer: WorktreeFilesWriter) {
   worktreeFilesWriter = writer
 }
 
-// Read the full request body (used by the POST /usage route)
+// Read the full request body (used by the POST /usage and POST /question routes)
 function readRequestBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = []
@@ -214,6 +231,57 @@ export function startStatusServer(): Promise<number> {
               res.end('OK')
             })
           return
+        } else if (url.pathname === '/question') {
+          // An agent is blocked on a question — the hook POSTs its stdin payload
+          // verbatim (AskUserQuestion tool input, or a Notification message).
+          //
+          // Never fails loudly: a hook that errors or hangs would stall the agent
+          // it is reporting on, so every path here answers 200 and the parsing
+          // happens behind the callback.
+          const terminalId = url.searchParams.get('id')
+
+          // Ignore sidebar terminals (VS Code extension)
+          if (terminalId?.startsWith('sidebar-')) {
+            res.writeHead(200)
+            res.end('OK')
+            return
+          }
+
+          // `.finally` rather than a 200 in each branch: "every path answers 200" is
+          // the rule here, so it is written once instead of relying on three copies.
+          readRequestBody(req)
+            .then((body) => {
+              if (terminalId && body) questionCallback?.(terminalId, body)
+            })
+            .catch((e) => {
+              console.error('[Questions] Failed to handle question payload:', e)
+            })
+            .finally(() => {
+              res.writeHead(200)
+              res.end('OK')
+            })
+          return
+        } else if (url.pathname === '/question/clear') {
+          // The agent moved on (answered in the app, new prompt, or turn finished).
+          //
+          // ⚠️ This is the ONLY status-server route allowed to clear a question.
+          // Doing it from /status would race the generic PreToolUse hook, which
+          // reports `working` at the same instant AskUserQuestion is captured.
+          const terminalId = url.searchParams.get('id')
+
+          // Ignore sidebar terminals (VS Code extension)
+          if (terminalId?.startsWith('sidebar-')) {
+            res.writeHead(200)
+            res.end('OK')
+            return
+          }
+
+          if (terminalId && clearQuestionCallback) {
+            clearQuestionCallback(terminalId)
+          }
+
+          res.writeHead(200)
+          res.end('OK')
         } else if (url.pathname === '/status') {
           const terminalId = url.searchParams.get('id')
           const state = url.searchParams.get('state')

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -2,12 +2,14 @@ import { app, BrowserWindow, Notification, ipcMain, dialog, Menu, shell, globalS
 import { join } from 'path'
 import { setupConfigHandlers } from './ipc/config-handlers'
 import { setupTerminalHandlers, cleanupTerminals } from './ipc/terminal-handlers'
-import { startStatusServer, stopStatusServer, setStateCallback, setMetadataCallback, setCommandStartCallback, setCommandEndCallback, setRepositoriesCallback, setUsageCallback, setSkillCallback, setConfigProvider, setAgentProvider, setWorktreeFilesWriter } from './hooks/status-server'
+import { startStatusServer, stopStatusServer, setStateCallback, setMetadataCallback, setCommandStartCallback, setCommandEndCallback, setRepositoriesCallback, setUsageCallback, setSkillCallback, setQuestionCallback, setClearQuestionCallback, setConfigProvider, setAgentProvider, setWorktreeFilesWriter } from './hooks/status-server'
+import { ingestQuestionPayload, getPendingQuestion, clearPendingQuestion } from './questions/pending-questions'
+import { answerPendingQuestion } from './questions/answer-question'
 import { recordSkillInvocation } from './usage/skill-invocations'
 import { installShellIntegration } from './hooks/shell-integration'
 import { configureClaudeHooks, configureStatusLine } from './hooks/claude-hooks-config'
-import { setStatusServerPort, setInnerStatusLine, updateTerminalStateFromHook, updateTerminalMetadataFromHook, updateTerminalUsageFromHook, updateTerminalRepositoriesFromHook } from './pty/terminal-manager'
-import type { TerminalUsage, TrayState, TrayUpdate } from '../types'
+import { setStatusServerPort, setInnerStatusLine, updateTerminalStateFromHook, updateTerminalMetadataFromHook, updateTerminalUsageFromHook, updateTerminalRepositoriesFromHook, writeToTerminal, getTerminalBuffer } from './pty/terminal-manager'
+import type { TerminalUsage, TrayAnswerChoice, TrayAnswerResult, TrayState, TrayUpdate } from '../types'
 import { setupAutoUpdater, setUpdaterMainWindow, checkForUpdatesOnStartup, isUpdating, getUpdateStatus } from './updater'
 import { updateSkills } from './skills-updater'
 import { setupSkillsHandlers } from './ipc/skills-handlers'
@@ -375,8 +377,40 @@ function setupTrayHandlers() {
       ticketId: a.ticketId,
       title: a.title,
       createdAt: a.createdAt.getTime(),
+      // This .map() drops anything not listed, so a new field has to be added here
+      // as well as to AgentSummary or the panel simply never sees it.
+      pendingQuestion: a.pendingQuestion,
     })),
   }))
+
+  /**
+   * Answer a pending question from the panel, without activating the app.
+   *
+   * The token is the whole safety mechanism. Answer in the main window (or let the
+   * agent move on) and the store is cleared, so a click on a card the panel has not
+   * refreshed yet finds no match and writes NOTHING to the PTY — the alternative
+   * being keystrokes landing in whatever the agent is doing now.
+   *
+   * `keysFor` returning null is the second gate: an unsupported question or an index
+   * we cannot place is not approximated.
+   *
+   * The decision itself lives in `answerPendingQuestion` so it can be unit-tested;
+   * this handler only supplies the store and the PTY.
+   */
+  ipcMain.handle('tray:answerQuestion', async (
+    _event,
+    { id, token, choice }: { id: string; token: string; choice: TrayAnswerChoice },
+  ): Promise<TrayAnswerResult> => {
+    const result = answerPendingQuestion(id, token, choice, {
+      getQuestion: getPendingQuestion,
+      write: writeToTerminal,
+      clear: clearPendingQuestion,
+    })
+    // Refresh the tray immediately: the agent's state is hook-driven and will not
+    // leave `waiting` on its own just because we typed.
+    if (result.ok) aggregator?.update()
+    return result
+  })
 
   ipcMain.handle('tray:resize', async (_event, { height }: { height: number }) => {
     resizePopover(height)
@@ -557,6 +591,25 @@ async function initializeHooksAndSessions() {
           id: terminalId,
           metadata: { usage }
         })
+      }
+    })
+
+    // A question an agent is blocked on, from the capture hooks. The payload is
+    // forwarded raw and parsed by the store; the buffer is handed over as a callback
+    // so it is only read for the payloads that actually build a preview from it.
+    setQuestionCallback((terminalId: string, body: string) => {
+      const question = ingestQuestionPayload(terminalId, body, () => getTerminalBuffer(terminalId))
+      // Only nudge the tray when something was actually stored: the fingerprint
+      // now carries the question token, so this is what makes the panel repaint.
+      if (question && aggregator) {
+        aggregator.update()
+      }
+    })
+
+    setClearQuestionCallback((terminalId: string) => {
+      clearPendingQuestion(terminalId)
+      if (aggregator) {
+        aggregator.update()
       }
     })
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -399,8 +399,15 @@ function setupTrayHandlers() {
    */
   ipcMain.handle('tray:answerQuestion', async (
     _event,
-    { id, token, choice }: { id: string; token: string; choice: TrayAnswerChoice },
+    payload: { id: string; token: string; choice: TrayAnswerChoice },
   ): Promise<TrayAnswerResult> => {
+    // Guard the envelope BEFORE destructuring it. `answerPendingQuestion` validates
+    // the three fields, but it never gets the chance if unpacking a null payload has
+    // already thrown — and a TypeError crossing back over IPC rejects the renderer's
+    // invoke() instead of giving it the documented `{ ok: false }`.
+    if (typeof payload !== 'object' || payload === null) return { ok: false }
+    const { id, token, choice } = payload
+
     const result = answerPendingQuestion(id, token, choice, {
       getQuestion: getPendingQuestion,
       write: writeToTerminal,

--- a/desktop/src/main/ipc/terminal-handlers.test.ts
+++ b/desktop/src/main/ipc/terminal-handlers.test.ts
@@ -54,6 +54,11 @@ vi.mock('../config/agents', () => ({
 
 vi.mock('../config/activity-history', () => ({ addHistoryEntry: vi.fn() }))
 
+const clearPendingQuestion = vi.fn()
+vi.mock('../questions/pending-questions', () => ({
+  clearPendingQuestion: (...args: unknown[]) => clearPendingQuestion(...args),
+}))
+
 const recordUsageSnapshot = vi.fn()
 vi.mock('../usage/usage-events', () => ({
   recordUsageSnapshot: (...args: unknown[]) => recordUsageSnapshot(...args),
@@ -200,5 +205,29 @@ describe('the status contract with the skills', () => {
     const fromStatuses: string[] = ['started', 'committed', 'ready_for_pr', 'pr_created',
       'ci_green', 'review', 'review_changes_requested', 'review_addressed', 'merged']
     expect([...produced].sort()).toEqual([...fromStatuses].sort())
+  })
+})
+
+describe('pending question cleared on a human write (terminal:write)', () => {
+  it('drops the pending question before writing, so a late panel click is a no-op', async () => {
+    await invoke('terminal:write', { id: 'claude-1', data: 'y' })
+
+    expect(clearPendingQuestion).toHaveBeenCalledWith('claude-1')
+  })
+
+  it('clears on every keystroke, not only on Enter', async () => {
+    // The user may start answering in the main window without submitting yet. The
+    // panel's card is already out of date at that point: the TUI selection has moved.
+    for (const data of ['\x1b[B', 'a', '\r']) {
+      clearPendingQuestion.mockClear()
+      await invoke('terminal:write', { id: 'claude-1', data })
+      expect(clearPendingQuestion).toHaveBeenCalledWith('claude-1')
+    }
+  })
+
+  it('ignores a write with no data, which cannot be an answer', async () => {
+    await invoke('terminal:write', { id: 'claude-1', data: undefined })
+
+    expect(clearPendingQuestion).not.toHaveBeenCalled()
   })
 })

--- a/desktop/src/main/ipc/terminal-handlers.ts
+++ b/desktop/src/main/ipc/terminal-handlers.ts
@@ -17,6 +17,7 @@ import {
   updateTerminalRepositoriesFromHook,
   type TerminalMetadata,
 } from '../pty/terminal-manager'
+import { clearPendingQuestion } from '../questions/pending-questions'
 import { resolveAgentCwd } from '../pty/agent-cwd'
 import {
   saveAgent,
@@ -485,6 +486,16 @@ export function setupTerminalHandlers(
   // Write to terminal
   ipcMain.handle('terminal:write', async (_event, { id, data }) => {
     if (typeof id !== 'string' || typeof data !== 'string') return
+    // The user is typing in the terminal, so whatever the menu bar panel is still
+    // showing for this agent is answered (or being answered) right here. Dropping it
+    // now is what makes a late click on the panel's card a no-op (AC4).
+    //
+    // ⚠️ THIS BELONGS IN THIS HANDLER, NOT IN writeToTerminal(). That function is
+    // shared: pr-review-handlers.ts and script-handlers.ts call it for writes the APP
+    // makes on its own, which say nothing about the user having answered anything —
+    // moving the clear down there would silently wipe legitimate pending questions.
+    // Only this handler means "a human typed into that terminal".
+    clearPendingQuestion(id)
     writeToTerminal(id, data)
   })
 

--- a/desktop/src/main/pty/terminal-manager.ts
+++ b/desktop/src/main/pty/terminal-manager.ts
@@ -10,6 +10,7 @@ import { withDetectedBranch } from './initial-metadata'
 import { expandPath } from '../config/validation'
 import { resolveAgentCwd } from './agent-cwd'
 import { getCommonPaths } from '../utils/paths'
+import { clearPendingQuestion, clearAllPendingQuestions } from '../questions/pending-questions'
 import type { TerminalMetadata, TerminalState, LaunchMode, TerminalUsage } from '../../types'
 export type { TerminalMetadata, TerminalState }
 
@@ -291,6 +292,8 @@ export function createTerminal(
   disposables.push(ptyProcess.onExit(({ exitCode }) => {
     terminal.state = exitCode === 0 ? 'completed' : 'error'
     displayBuffers.delete(id)
+    // Nothing can answer a question whose process is gone.
+    clearPendingQuestion(id)
     onExit(exitCode)
   }))
 
@@ -299,17 +302,25 @@ export function createTerminal(
   return terminal
 }
 
-export function writeToTerminal(id: string, data: string): void {
+/**
+ * Returns whether the data actually reached a PTY.
+ *
+ * An unknown id is a silent no-op, which is fine for the callers that fire and
+ * forget — but the menu bar panel reports back to the user whether their answer
+ * was delivered, and "written nowhere" must not read as success there.
+ */
+export function writeToTerminal(id: string, data: string): boolean {
   const terminal = terminals.get(id)
-  if (terminal) {
-    try {
-      terminal.pty.write(data)
-    } catch (e) {
-      console.error(`[writeToTerminal] Failed to write to terminal ${id}:`, e)
-    }
-    // State changes are now handled exclusively by Claude Code hooks
-    // via updateTerminalStateFromHook() - no automatic state change on Enter
+  if (!terminal) return false
+  try {
+    terminal.pty.write(data)
+  } catch (e) {
+    console.error(`[writeToTerminal] Failed to write to terminal ${id}:`, e)
+    return false
   }
+  // State changes are now handled exclusively by Claude Code hooks
+  // via updateTerminalStateFromHook() - no automatic state change on Enter
+  return true
 }
 
 export function resizeTerminal(id: string, cols: number, rows: number): void {
@@ -341,6 +352,7 @@ export function killTerminal(id: string): void {
     displayBuffers.delete(id)
     lastActivityTime.delete(id)
     restartTrackers.delete(id)
+    clearPendingQuestion(id)
   }
 }
 
@@ -403,6 +415,7 @@ export function cleanupAllTerminals(): void {
   lastActivityTime.clear()
   ptyDisposables.clear()
   restartTrackers.clear()
+  clearAllPendingQuestions()
 }
 
 // Get the display buffer for a terminal (used for reconnection after refresh)
@@ -487,6 +500,12 @@ export function launchClaude(
 
     // Handle exit - auto-restart with backoff if not intentionally killed
     disposables.push(ptyProcess.onExit(({ exitCode }) => {
+      // Cleared here, before any of the branches below, because all of them mean the
+      // same thing for a pending question: the process that asked it is gone. A
+      // restarted Claude Code has no memory of the prompt either, so keystrokes aimed
+      // at it would land in a fresh session.
+      clearPendingQuestion(id)
+
       // Check if this was an intentional kill
       if (intentionallyKilled.has(id)) {
         intentionallyKilled.delete(id)

--- a/desktop/src/main/questions/answer-keys.test.ts
+++ b/desktop/src/main/questions/answer-keys.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { keysFor, answerableOptionCount } from './answer-keys'
+import type { TrayAnswerChoice, TrayQuestion } from '../../types'
+
+const ask = (overrides: Partial<TrayQuestion> = {}): TrayQuestion => ({
+  token: 't',
+  kind: 'ask',
+  prompt: 'Which database?',
+  options: [{ label: 'Postgres' }, { label: 'MySQL' }, { label: 'SQLite' }],
+  receivedAt: Date.now(),
+  ...overrides,
+})
+
+const permission = (overrides: Partial<TrayQuestion> = {}): TrayQuestion => ({
+  token: 't',
+  kind: 'permission',
+  prompt: 'Claude needs your permission to use Bash',
+  options: [],
+  receivedAt: Date.now(),
+  ...overrides,
+})
+
+const option = (index: number): TrayAnswerChoice => ({ kind: 'option', index })
+
+describe('keysFor', () => {
+  it('sends Enter alone for the first option (the row already highlighted)', () => {
+    expect(keysFor(ask(), option(0))).toBe('\r')
+  })
+
+  it('sends one arrow per row to walk down to the option, then Enter', () => {
+    expect(keysFor(ask(), option(1))).toBe('\x1b[B\r')
+    expect(keysFor(ask(), option(2))).toBe('\x1b[B\x1b[B\r')
+  })
+
+  it('refuses an index past the last option rather than writing an approximation', () => {
+    expect(keysFor(ask(), option(3))).toBeNull()
+    expect(keysFor(ask(), option(-1))).toBeNull()
+    expect(keysFor(ask(), option(1.5))).toBeNull()
+  })
+
+  it('refuses everything for a question v1 cannot drive', () => {
+    expect(keysFor(ask({ unsupported: true }), option(0))).toBeNull()
+    expect(keysFor(permission({ unsupported: true }), { kind: 'deny' })).toBeNull()
+  })
+
+  it('denies with a bare Escape, independent of how many options there are', () => {
+    expect(keysFor(permission(), { kind: 'deny' })).toBe('\x1b')
+    expect(keysFor(permission({ options: [{ label: 'a' }, { label: 'b' }] }), { kind: 'deny' })).toBe('\x1b')
+  })
+
+  it('does not offer a refusal on an AskUserQuestion (Escape would interrupt it)', () => {
+    expect(keysFor(ask(), { kind: 'deny' })).toBeNull()
+  })
+
+  it('treats a permission Allow as the first row of an implicit one-option list', () => {
+    expect(answerableOptionCount(permission())).toBe(1)
+    expect(keysFor(permission(), option(0))).toBe('\r')
+    expect(keysFor(permission(), option(1))).toBeNull()
+  })
+})

--- a/desktop/src/main/questions/answer-keys.ts
+++ b/desktop/src/main/questions/answer-keys.ts
@@ -1,0 +1,72 @@
+import type { TrayAnswerChoice, TrayQuestion } from '../../types'
+
+/**
+ * Turning a click in the menu bar panel into keystrokes for the Claude Code TUI.
+ *
+ * THE FORMULA LIVES HERE AND NOWHERE ELSE
+ * ---------------------------------------------------------------------------
+ * Claude Code has no API for "answer the pending question", so the panel answers
+ * the only way anything answers a TUI: by typing. Which keys, exactly, is the one
+ * assumption in this feature that cannot be verified from code — it depends on how
+ * the current Claude Code build draws its selection list. It is therefore reduced
+ * to the three constants below and a single function, so a manual check against a
+ * live build can correct it in one place instead of hunting call sites.
+ *
+ * ⚠️ NOT YET VALIDATED AGAINST A LIVE CLAUDE CODE BUILD. The sequences match the
+ * standard behaviour of the TUI's list prompts (highlight starts on the first row,
+ * arrows move it, Enter selects, Escape cancels), and are unit-tested for shape,
+ * but the confirming keystroke spike has to happen in the app in dev mode.
+ *
+ * OFF-BY-ONE IN THE TICKET, DELIBERATELY NOT REPRODUCED
+ * ---------------------------------------------------------------------------
+ * The ticket states both "option 1 → `\r`" and "option i → `'\x1b[B'.repeat(i)`
+ * + `\r`". Those contradict each other: option 1 needs ZERO arrows, so the
+ * exponent is `i - 1`, not `i`. We implement `i - 1` — expressed here as
+ * `repeat(index)` on a 0-based index, which is the same thing without the
+ * opportunity to get it wrong again.
+ */
+
+/** Enter — selects the highlighted row. */
+const SUBMIT = '\r'
+/** Down arrow — moves the highlight one row down. */
+const DOWN = '\x1b[B'
+/**
+ * Escape — cancels the prompt. Deliberately position-independent: a refusal must
+ * not depend on counting rows we cannot see, which is the whole point of using it.
+ */
+const CANCEL = '\x1b'
+
+/**
+ * How many options can be selected by position.
+ *
+ * A permission prompt carries no options: we never see the TUI's own wording, so
+ * the panel offers its own Allow (the highlighted first row) and Deny (Escape).
+ * Allow is therefore index 0 of an implicit one-option list.
+ */
+export function answerableOptionCount(question: TrayQuestion): number {
+  if (question.kind === 'permission' && question.options.length === 0) return 1
+  return question.options.length
+}
+
+/**
+ * The keystrokes that answer `question` with `choice`, or `null` when we refuse to
+ * guess.
+ *
+ * `null` is not a failure to be worked around: an approximate write into a live
+ * agent's PTY is worse than no write at all, so an out-of-range index or a
+ * question v1 cannot drive both stop here.
+ */
+export function keysFor(question: TrayQuestion, choice: TrayAnswerChoice): string | null {
+  if (question.unsupported) return null
+
+  if (choice.kind === 'deny') {
+    // Only a permission prompt can be refused: on an AskUserQuestion, Escape
+    // interrupts the agent rather than answering it.
+    return question.kind === 'permission' ? CANCEL : null
+  }
+
+  if (!Number.isInteger(choice.index) || choice.index < 0) return null
+  if (choice.index >= answerableOptionCount(question)) return null
+
+  return DOWN.repeat(choice.index) + SUBMIT
+}

--- a/desktop/src/main/questions/answer-question.test.ts
+++ b/desktop/src/main/questions/answer-question.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { answerPendingQuestion, type AnswerDeps } from './answer-question'
+import type { TrayQuestion } from '../../types'
+
+/**
+ * These tests exist for one acceptance criterion: "a late click on a stale option
+ * writes NOTHING to the PTY". Every case therefore asserts on the write spy, not
+ * just on the returned result — a refusal that still wrote would satisfy `ok: false`
+ * while breaking the actual guarantee.
+ */
+
+const ASK: TrayQuestion = {
+  token: 'tok-1',
+  kind: 'ask',
+  prompt: 'Which branch?',
+  options: [{ label: 'main' }, { label: 'develop' }],
+  receivedAt: 0,
+}
+
+const PERMISSION: TrayQuestion = {
+  token: 'tok-2',
+  kind: 'permission',
+  prompt: 'Claude needs your permission to use Bash',
+  options: [],
+  receivedAt: 0,
+}
+
+let write: Mock<(id: string, keys: string) => boolean>
+let clear: Mock<(id: string) => void>
+
+function deps(question: TrayQuestion | undefined): AnswerDeps {
+  return { getQuestion: () => question, write, clear }
+}
+
+beforeEach(() => {
+  write = vi.fn(() => true)
+  clear = vi.fn()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('answerPendingQuestion', () => {
+  it('writes the keystrokes and clears the question on a matching token', () => {
+    const result = answerPendingQuestion('term-1', 'tok-1', { kind: 'option', index: 1 }, deps(ASK))
+    expect(result).toEqual({ ok: true })
+    expect(write).toHaveBeenCalledWith('term-1', '\x1b[B\r')
+    expect(clear).toHaveBeenCalledWith('term-1')
+  })
+
+  it('writes NOTHING when the token no longer matches', () => {
+    // The panel is up to 2s stale: the user answered in the main window and a new
+    // question already took this agent's slot.
+    const result = answerPendingQuestion('term-1', 'tok-old', { kind: 'option', index: 0 }, deps(ASK))
+    expect(result).toEqual({ ok: false })
+    expect(write).not.toHaveBeenCalled()
+    expect(clear).not.toHaveBeenCalled()
+  })
+
+  it('writes NOTHING when the question is already gone', () => {
+    const result = answerPendingQuestion('term-1', 'tok-1', { kind: 'option', index: 0 }, deps(undefined))
+    expect(result).toEqual({ ok: false })
+    expect(write).not.toHaveBeenCalled()
+  })
+
+  it('writes NOTHING when no keystrokes can be derived', () => {
+    // Out of range, an unsupported question, and denying an AskUserQuestion (where
+    // Escape would interrupt the agent rather than answer it).
+    expect(answerPendingQuestion('t', 'tok-1', { kind: 'option', index: 9 }, deps(ASK)).ok).toBe(false)
+    expect(answerPendingQuestion('t', 'tok-1', { kind: 'deny' }, deps(ASK)).ok).toBe(false)
+    expect(
+      answerPendingQuestion('t', 'tok-1', { kind: 'option', index: 0 }, deps({ ...ASK, unsupported: true })).ok,
+    ).toBe(false)
+    expect(write).not.toHaveBeenCalled()
+  })
+
+  it('writes NOTHING on a malformed id or token', () => {
+    for (const [id, token] of [['', 'tok-1'], ['term-1', ''], [null, 'tok-1'], ['term-1', undefined]]) {
+      expect(answerPendingQuestion(id as string, token as string, { kind: 'option', index: 0 }, deps(ASK)).ok)
+        .toBe(false)
+    }
+    expect(write).not.toHaveBeenCalled()
+  })
+
+  it('refuses a permission prompt with Escape, and keeps Allow at the highlighted row', () => {
+    expect(answerPendingQuestion('t', 'tok-2', { kind: 'deny' }, deps(PERMISSION))).toEqual({ ok: true })
+    expect(write).toHaveBeenCalledWith('t', '\x1b')
+
+    write.mockClear()
+    expect(answerPendingQuestion('t', 'tok-2', { kind: 'option', index: 0 }, deps(PERMISSION))).toEqual({ ok: true })
+    expect(write).toHaveBeenCalledWith('t', '\r')
+  })
+
+  it('reports failure and keeps the question when the terminal is gone', () => {
+    // writeToTerminal no-ops on an unknown id. Reporting success would make the card
+    // disappear as if the agent had been advanced.
+    write.mockReturnValue(false)
+    const result = answerPendingQuestion('term-1', 'tok-1', { kind: 'option', index: 0 }, deps(ASK))
+    expect(result).toEqual({ ok: false })
+    expect(clear).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/src/main/questions/answer-question.test.ts
+++ b/desktop/src/main/questions/answer-question.test.ts
@@ -72,6 +72,22 @@ describe('answerPendingQuestion', () => {
     expect(write).not.toHaveBeenCalled()
   })
 
+  it('writes NOTHING on a malformed choice, instead of throwing out of the IPC handler', () => {
+    // `choice` crosses IPC from the renderer, so its type annotation guarantees
+    // nothing at runtime. keysFor reads choice.kind directly.
+    const malformed = [
+      undefined, null, 'deny', 42, {}, { kind: 'nope' },
+      { kind: 'option' }, { kind: 'option', index: '1' }, { kind: 'option', index: 1.5 },
+    ]
+    for (const choice of malformed) {
+      expect(() =>
+        answerPendingQuestion('term-1', 'tok-1', choice as never, deps(ASK)),
+      ).not.toThrow()
+      expect(answerPendingQuestion('term-1', 'tok-1', choice as never, deps(ASK)).ok).toBe(false)
+    }
+    expect(write).not.toHaveBeenCalled()
+  })
+
   it('writes NOTHING on a malformed id or token', () => {
     for (const [id, token] of [['', 'tok-1'], ['term-1', ''], [null, 'tok-1'], ['term-1', undefined]]) {
       expect(answerPendingQuestion(id as string, token as string, { kind: 'option', index: 0 }, deps(ASK)).ok)

--- a/desktop/src/main/questions/answer-question.ts
+++ b/desktop/src/main/questions/answer-question.ts
@@ -1,0 +1,61 @@
+import type { TrayAnswerChoice, TrayAnswerResult, TrayQuestion } from '../../types'
+import { keysFor } from './answer-keys'
+
+/**
+ * The staleness guard: what stands between a click in the menu bar panel and a
+ * keystroke in a live agent's terminal.
+ *
+ * WHY THIS IS A MODULE AND NOT AN IPC HANDLER BODY
+ * ---------------------------------------------------------------------------
+ * The panel polls every 2s, so the question it shows is always slightly behind
+ * reality: the user can answer in the main window, or the agent can move on, in the
+ * gap between the paint and the click. The ticket's requirement is absolute — a late
+ * click must write NOTHING — and a requirement stated that way has to be testable.
+ * Inside `ipcMain.handle` it would not be, so the decision lives here and
+ * `main/index.ts` only supplies the terminal-facing side effects.
+ *
+ * ORDER MATTERS: every check happens BEFORE the write
+ * ---------------------------------------------------------------------------
+ * Token first, then keystrokes, then the write. Nothing reaches the PTY until the
+ * question the user clicked on is provably the one still pending.
+ */
+export interface AnswerDeps {
+  /** The question currently pending for this agent, if any. */
+  getQuestion: (id: string) => TrayQuestion | undefined
+  /** Writes into the agent's PTY. Returns false when the terminal is gone. */
+  write: (id: string, keys: string) => boolean
+  /** Drops the pending question once it has been answered. */
+  clear: (id: string) => void
+}
+
+export function answerPendingQuestion(
+  id: string,
+  token: string,
+  choice: TrayAnswerChoice,
+  deps: AnswerDeps,
+): TrayAnswerResult {
+  if (typeof id !== 'string' || typeof token !== 'string' || !id || !token) return { ok: false }
+
+  const question = deps.getQuestion(id)
+  if (!question || question.token !== token) {
+    console.error(`[Questions] Ignoring a stale answer for ${id}`)
+    return { ok: false }
+  }
+
+  const keys = keysFor(question, choice)
+  if (keys === null) {
+    console.error(`[Questions] Refusing to answer ${id}: no keystrokes for this choice`)
+    return { ok: false }
+  }
+
+  // A terminal that has since exited takes the answer nowhere. Reporting success
+  // would leave the panel claiming the agent was advanced when it was not — and the
+  // card would vanish, hiding the failure. Keep the question instead.
+  if (!deps.write(id, keys)) {
+    console.error(`[Questions] Answer for ${id} reached no terminal`)
+    return { ok: false }
+  }
+
+  deps.clear(id)
+  return { ok: true }
+}

--- a/desktop/src/main/questions/answer-question.ts
+++ b/desktop/src/main/questions/answer-question.ts
@@ -28,6 +28,23 @@ export interface AnswerDeps {
   clear: (id: string) => void
 }
 
+/**
+ * Whether `choice` is really a `TrayAnswerChoice`.
+ *
+ * The type annotation is erased at runtime and this value crosses IPC from the
+ * renderer, so it is untrusted input. `keysFor` reads `choice.kind` directly: without
+ * this gate a malformed payload throws a TypeError out of the IPC handler instead of
+ * returning the `{ ok: false }` the panel is documented to receive.
+ */
+function isAnswerChoice(choice: unknown): choice is TrayAnswerChoice {
+  if (typeof choice !== 'object' || choice === null) return false
+  const kind = (choice as { kind?: unknown }).kind
+  if (kind === 'deny') return true
+  if (kind !== 'option') return false
+  // Range is checked in keysFor, against the question's own option count.
+  return Number.isInteger((choice as { index?: unknown }).index)
+}
+
 export function answerPendingQuestion(
   id: string,
   token: string,
@@ -35,6 +52,10 @@ export function answerPendingQuestion(
   deps: AnswerDeps,
 ): TrayAnswerResult {
   if (typeof id !== 'string' || typeof token !== 'string' || !id || !token) return { ok: false }
+  if (!isAnswerChoice(choice)) {
+    console.error(`[Questions] Refusing to answer ${id}: malformed choice payload`)
+    return { ok: false }
+  }
 
   const question = deps.getQuestion(id)
   if (!question || question.token !== token) {

--- a/desktop/src/main/questions/pending-questions.test.ts
+++ b/desktop/src/main/questions/pending-questions.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  buildPreview,
+  clearAllPendingQuestions,
+  clearPendingQuestion,
+  getPendingQuestion,
+  ingestQuestionPayload,
+  setFromAskQuestion,
+  setFromNotification,
+} from './pending-questions'
+
+const askPayload = (questions: unknown) =>
+  JSON.stringify({
+    hook_event_name: 'PreToolUse',
+    tool_name: 'AskUserQuestion',
+    tool_input: { questions },
+  })
+
+const ONE_QUESTION = [
+  {
+    question: 'Which database should the API use?',
+    header: 'Database',
+    options: [
+      { label: 'Postgres', description: 'Managed on RDS' },
+      { label: 'SQLite', description: 'Local only' },
+    ],
+  },
+]
+
+beforeEach(() => {
+  clearAllPendingQuestions()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('setFromAskQuestion', () => {
+  it('extracts the prompt and its options', () => {
+    const question = setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))
+    expect(question).not.toBeNull()
+    expect(question!.kind).toBe('ask')
+    expect(question!.prompt).toBe('Which database should the API use?')
+    expect(question!.options).toEqual([
+      { label: 'Postgres', description: 'Managed on RDS' },
+      { label: 'SQLite', description: 'Local only' },
+    ])
+    expect(question!.unsupported).toBeUndefined()
+  })
+
+  it('falls back to the header when the question text is missing', () => {
+    const question = setFromAskQuestion('term-1', {
+      tool_input: { questions: [{ header: 'Database', options: [{ label: 'Postgres' }] }] },
+    })
+    expect(question!.prompt).toBe('Database')
+  })
+
+  it('marks multi-question and multiSelect calls unsupported instead of dropping them', () => {
+    const multi = setFromAskQuestion('term-1', {
+      tool_input: { questions: [...ONE_QUESTION, { question: 'And the cache?', options: [{ label: 'Redis' }] }] },
+    })
+    expect(multi!.unsupported).toBe(true)
+    expect(multi!.prompt).toBe('Which database should the API use?')
+
+    const multiSelect = setFromAskQuestion('term-2', {
+      tool_input: { questions: [{ ...ONE_QUESTION[0], multiSelect: true }] },
+    })
+    expect(multiSelect!.unsupported).toBe(true)
+  })
+
+  it('marks a question with no readable option unsupported', () => {
+    const question = setFromAskQuestion('term-1', {
+      tool_input: { questions: [{ question: 'Free text?', options: [{ description: 'no label' }] }] },
+    })
+    expect(question!.options).toEqual([])
+    expect(question!.unsupported).toBe(true)
+  })
+
+  it('returns null for a payload with no question at all', () => {
+    expect(setFromAskQuestion('term-1', { tool_input: { questions: [] } })).toBeNull()
+    expect(setFromAskQuestion('term-1', { tool_input: {} })).toBeNull()
+    expect(setFromAskQuestion('term-1', {})).toBeNull()
+    expect(getPendingQuestion('term-1')).toBeUndefined()
+  })
+})
+
+describe('setFromNotification', () => {
+  it('stores a permission prompt with its preview, denial enabled', () => {
+    const question = setFromNotification(
+      'term-1',
+      { message: 'Claude needs your permission to use Bash' },
+      () => 'rm -rf build/',
+    )
+    expect(question!.kind).toBe('permission')
+    expect(question!.prompt).toBe('Claude needs your permission to use Bash')
+    expect(question!.preview).toBe('rm -rf build/')
+    // The panel renders its own Allow / Deny for these.
+    expect(question!.options).toEqual([])
+    // Recognised as a permission request, so it may be answered from the panel.
+    expect(question!.unsupported).toBeUndefined()
+  })
+
+  it('ignores the idle nudge, which is not a question', () => {
+    expect(setFromNotification('term-1', { message: 'Claude is waiting for your input' })).toBeNull()
+    expect(getPendingQuestion('term-1')).toBeUndefined()
+  })
+
+  it('shows an unrecognised notification but marks it unsupported, so nothing is written', () => {
+    // Neither the idle nudge nor anything we can read as a permission request. Losing
+    // it would cost the feature; offering an Allow button would send a bare Enter into
+    // a terminal that may not be showing a prompt. It is shown, not driven.
+    const question = setFromNotification('term-1', { message: 'Some future wording' }, () => 'tail')
+    expect(question!.kind).toBe('permission')
+    expect(question!.unsupported).toBe(true)
+    expect(question!.preview).toBe('tail')
+  })
+
+  it('recognises a permission request whatever the surrounding wording', () => {
+    for (const message of [
+      'Claude needs your permission to use Bash',
+      'Approve this edit?',
+      'Allow Claude to run the command?',
+      "Autoriser l'accès au fichier ?",
+    ]) {
+      expect(setFromNotification('term-1', { message })!.unsupported).toBeUndefined()
+    }
+  })
+
+  it('returns null when there is no message', () => {
+    expect(setFromNotification('term-1', {})).toBeNull()
+    expect(setFromNotification('term-1', { message: '   ' })).toBeNull()
+  })
+})
+
+describe('ingestQuestionPayload', () => {
+  it('routes PreToolUse to the AskUserQuestion parser', () => {
+    const question = ingestQuestionPayload('term-1', askPayload(ONE_QUESTION))
+    expect(question!.kind).toBe('ask')
+    expect(getPendingQuestion('term-1')).toEqual(question)
+  })
+
+  it('routes Notification to the permission parser and only then reads the buffer', () => {
+    const bufferProvider = vi.fn(() => 'npm run deploy')
+    const question = ingestQuestionPayload(
+      'term-1',
+      JSON.stringify({ hook_event_name: 'Notification', message: 'Claude needs your permission to use Bash' }),
+      bufferProvider,
+    )
+    expect(question!.preview).toBe('npm run deploy')
+    expect(bufferProvider).toHaveBeenCalledTimes(1)
+  })
+
+  // The buffer runs to ~100KB and this hook is on the critical path of a blocked
+  // agent, so the idle nudge — the most frequent Notification of all — must not pay
+  // for a preview that is thrown away.
+  it('never touches the buffer for a notification it discards', () => {
+    const bufferProvider = vi.fn(() => 'npm run deploy')
+    expect(
+      ingestQuestionPayload(
+        'term-1',
+        JSON.stringify({ hook_event_name: 'Notification', message: 'Claude is waiting for your input' }),
+        bufferProvider,
+      ),
+    ).toBeNull()
+    expect(bufferProvider).not.toHaveBeenCalled()
+  })
+
+  it('swallows an unparseable body without storing anything', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(ingestQuestionPayload('term-1', 'not json')).toBeNull()
+    expect(getPendingQuestion('term-1')).toBeUndefined()
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it('ignores an event it does not handle', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(ingestQuestionPayload('term-1', JSON.stringify({ hook_event_name: 'Stop' }))).toBeNull()
+    expect(getPendingQuestion('term-1')).toBeUndefined()
+    spy.mockRestore()
+  })
+})
+
+describe('the store itself', () => {
+  it('mints a distinct token per question', () => {
+    const first = setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))!
+    const second = setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))!
+    expect(second.token).not.toBe(first.token)
+  })
+
+  it('keeps one question per agent, the newest winning', () => {
+    setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))
+    const second = setFromNotification('term-1', { message: 'Claude needs your permission to use Bash' })!
+    expect(getPendingQuestion('term-1')).toEqual(second)
+  })
+
+  it('keeps agents independent', () => {
+    const one = setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))!
+    setFromAskQuestion('term-2', JSON.parse(askPayload(ONE_QUESTION)))
+    clearPendingQuestion('term-2')
+    expect(getPendingQuestion('term-1')).toEqual(one)
+    expect(getPendingQuestion('term-2')).toBeUndefined()
+  })
+
+  it('expires a question after 30 minutes, on read', () => {
+    vi.useFakeTimers()
+    setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))
+    vi.advanceTimersByTime(29 * 60 * 1000)
+    expect(getPendingQuestion('term-1')).toBeDefined()
+    vi.advanceTimersByTime(2 * 60 * 1000)
+    expect(getPendingQuestion('term-1')).toBeUndefined()
+  })
+
+  it('clearAll empties every agent (app shutdown)', () => {
+    setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))
+    setFromAskQuestion('term-2', JSON.parse(askPayload(ONE_QUESTION)))
+    clearAllPendingQuestions()
+    expect(getPendingQuestion('term-1')).toBeUndefined()
+    expect(getPendingQuestion('term-2')).toBeUndefined()
+  })
+})
+
+describe('buildPreview', () => {
+  it('strips ANSI, trims trailing blank lines and keeps the last 15', () => {
+    const buffer = `\x1b[2J\x1b[H${Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n')}\n\n\n`
+    const preview = buildPreview(buffer)!
+    const lines = preview.split('\n')
+    expect(lines).toHaveLength(15)
+    expect(lines[0]).toBe('line 6')
+    expect(lines[14]).toBe('line 20')
+    expect(preview).not.toContain('\x1b')
+  })
+
+  it('returns undefined for nothing worth showing', () => {
+    expect(buildPreview(null)).toBeUndefined()
+    expect(buildPreview('')).toBeUndefined()
+    expect(buildPreview('\n\n  \n')).toBeUndefined()
+  })
+})

--- a/desktop/src/main/questions/pending-questions.ts
+++ b/desktop/src/main/questions/pending-questions.ts
@@ -1,0 +1,245 @@
+import { randomUUID } from 'crypto'
+import { stripAnsi } from '../../strip-ansi'
+import type { TrayQuestion, TrayQuestionOption } from '../../types'
+
+/**
+ * The one question each agent is currently blocked on.
+ *
+ * WHY A MODULE-LEVEL MAP AND NO SWEEPER
+ * ---------------------------------------------------------------------------
+ * Same shape as `displayBuffers` / `restartTrackers` in pty/terminal-manager.ts:
+ * a plain Map keyed by terminal id, emptied by whoever ends the thing it belongs
+ * to. The TTL is applied lazily on read rather than by a `setInterval`, and that
+ * is enough here because the only reader is the tray aggregator's existing 3s
+ * poll — an expired entry cannot survive more than one tick of being looked at.
+ *
+ * WHAT CLEARS AN ENTRY — AND WHAT MUST NOT
+ * ---------------------------------------------------------------------------
+ * Clearing is bound to EVENTS, never to agent state:
+ *   - the `PostToolUse` (AskUserQuestion) / `UserPromptSubmit` / `Stop` hooks;
+ *   - the user typing in the terminal (`terminal:write`, the IPC handler only);
+ *   - the terminal exiting or being killed;
+ *   - the 30-minute TTL below.
+ *
+ * ⚠️ Never from the `/status` route or any state transition. The generic
+ * `PreToolUse` hook flips the agent to `working` at the same instant the
+ * AskUserQuestion capture hook fires, and their order is not guaranteed — a
+ * state-driven clear would routinely erase the question that just arrived.
+ */
+const pendingQuestions = new Map<string, TrayQuestion>()
+
+/** After half an hour, a question nobody answered is stale by any measure. */
+const QUESTION_TTL_MS = 30 * 60 * 1000
+
+/** How much terminal tail a permission preview keeps. */
+const PREVIEW_LINES = 15
+
+/**
+ * How much of the buffer's tail is even looked at.
+ *
+ * A display buffer runs to ~100KB (DISPLAY_BUFFER_MAX_SIZE in pty/terminal-manager)
+ * and only the last PREVIEW_LINES lines are ever shown, so stripping and splitting
+ * the whole thing is work thrown away on a path a blocked agent is waiting on. This
+ * window is far wider than 15 lines, so the leading fragment it may cut mid-escape
+ * sequence always falls in a line that gets dropped anyway. It also bounds the
+ * preview crossing IPC, which PREVIEW_LINES alone does not: a TUI redrawing with
+ * bare `\r` can pile a lot of output into a single line.
+ */
+const PREVIEW_SCAN_CHARS = 16384
+
+/**
+ * Notifications that are NOT a question.
+ *
+ * `Notification` fires for everything Claude Code wants to tell the user, and the
+ * only signal in the payload is a free-text `message`. This one is the idle nudge:
+ * the most frequent notification of all, and definitely not a prompt.
+ */
+const NON_QUESTION_NOTIFICATION = /waiting for your input/i
+
+/**
+ * Notifications we are confident enough about to ANSWER, not merely show.
+ *
+ * The distinction matters because answering means writing a bare `\r` into the
+ * PTY. On a message we misread, that Enter lands in a terminal that may not be
+ * showing a prompt at all — so an unrecognised wording gets stored `unsupported`
+ * instead: the card, the preview and "open the agent", with no button that drives
+ * the terminal. Showing too much is cheap; injecting a keystroke on a guess is not.
+ *
+ * Kept deliberately loose (any phrasing built around "permission") so a reworded
+ * release still matches. The ticket's second open question stands: capture the real
+ * payloads of both a permission prompt and a routine notification to firm this up.
+ */
+const ANSWERABLE_NOTIFICATION = /permission|approve|allow|autoris/i
+
+interface AskQuestionOption {
+  label?: unknown
+  description?: unknown
+}
+
+interface AskQuestion {
+  question?: unknown
+  header?: unknown
+  multiSelect?: unknown
+  options?: unknown
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
+}
+
+function parseOptions(raw: unknown): TrayQuestionOption[] {
+  if (!Array.isArray(raw)) return []
+  const options: TrayQuestionOption[] = []
+  for (const entry of raw) {
+    const option = entry as AskQuestionOption
+    const label = asString(option?.label)
+    if (!label) continue
+    const description = asString(option?.description)
+    options.push(description ? { label, description } : { label })
+  }
+  return options
+}
+
+/**
+ * The last lines of a terminal buffer, ANSI-stripped — what the agent is actually
+ * showing. Used as the permission preview: the alternative, reading
+ * `transcript_path`, couples us to a file format we do not own.
+ */
+export function buildPreview(buffer: string | null | undefined): string | undefined {
+  if (!buffer) return undefined
+  const lines = stripAnsi(buffer.slice(-PREVIEW_SCAN_CHARS))
+    .split(/\r?\n/)
+    .map((line) => line.replace(/\s+$/, ''))
+  // Trailing blank lines are the norm in a TUI buffer and would eat the preview.
+  while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
+  if (lines.length === 0) return undefined
+  return lines.slice(-PREVIEW_LINES).join('\n')
+}
+
+function store(terminalId: string, question: Omit<TrayQuestion, 'token' | 'receivedAt'>): TrayQuestion {
+  // A fresh token per question, so an answer aimed at the previous one is rejected
+  // rather than applied to whatever replaced it.
+  const stored: TrayQuestion = { ...question, token: randomUUID(), receivedAt: Date.now() }
+  // One question per agent: a new one supersedes whatever was there. The agent can
+  // only be blocked on its most recent prompt anyway.
+  pendingQuestions.set(terminalId, stored)
+  return stored
+}
+
+/**
+ * An `AskUserQuestion` tool call, from the `PreToolUse` hook payload
+ * (`{ tool_input: { questions: [{ question, header, multiSelect, options }] } }`).
+ *
+ * Several questions in one call, `multiSelect`, and the free-text "Other" option
+ * are all out of scope for v1: they are stored as `unsupported` rather than
+ * dropped, so the panel still shows what is being asked and offers "Open agent".
+ */
+export function setFromAskQuestion(terminalId: string, payload: unknown): TrayQuestion | null {
+  const toolInput = (payload as { tool_input?: { questions?: unknown } })?.tool_input
+  const questions = toolInput?.questions
+  if (!Array.isArray(questions) || questions.length === 0) return null
+
+  const first = questions[0] as AskQuestion
+  const prompt = asString(first?.question) ?? asString(first?.header)
+  if (!prompt) return null
+
+  const options = parseOptions(first?.options)
+  const unsupported = questions.length > 1 || first?.multiSelect === true || options.length === 0
+
+  // No refusal is offered on an `ask`: Escape would interrupt the agent rather
+  // than answer it. That follows from `kind` alone — see answer-keys.keysFor.
+  return store(terminalId, {
+    kind: 'ask',
+    prompt,
+    options,
+    ...(unsupported ? { unsupported: true } : {}),
+  })
+}
+
+/**
+ * A `Notification` hook payload (`{ message }`), treated as a permission prompt.
+ *
+ * `preview` carries the terminal tail because the message itself is a one-liner
+ * ("Claude needs your permission to use Bash") that never says WHAT is being
+ * asked — AC3 wants the real prompt next to the Allow / Deny buttons.
+ *
+ * The buffer arrives as a callback, read only AFTER the guards below: the idle
+ * nudge is the most frequent Notification of all, and it is the one case where
+ * building a preview is guaranteed to be wasted.
+ *
+ * A message that is not the idle nudge but that we cannot positively identify as a
+ * permission request is still surfaced — as `unsupported`, so the panel shows it and
+ * sends the user to the agent rather than writing an Enter into the PTY on a guess.
+ */
+export function setFromNotification(
+  terminalId: string,
+  payload: unknown,
+  bufferProvider?: () => string | null | undefined,
+): TrayQuestion | null {
+  const message = asString((payload as { message?: unknown })?.message)
+  if (!message) return null
+  if (NON_QUESTION_NOTIFICATION.test(message)) return null
+
+  const preview = buildPreview(bufferProvider?.())
+  const unsupported = !ANSWERABLE_NOTIFICATION.test(message)
+
+  return store(terminalId, {
+    kind: 'permission',
+    prompt: message,
+    // The panel renders its own Allow / Deny for a permission (see answer-keys).
+    options: [],
+    ...(preview ? { preview } : {}),
+    ...(unsupported ? { unsupported: true } : {}),
+  })
+}
+
+/**
+ * Route a raw hook body to the right parser.
+ *
+ * `bufferProvider` is a callback rather than a string so the terminal buffer is
+ * only read for the payloads that need it — and, more importantly, so this module
+ * does not import terminal-manager, which imports this one to clear on exit.
+ * Turning that buffer into a preview stays in here, with `buildPreview`.
+ */
+export function ingestQuestionPayload(
+  terminalId: string,
+  body: string,
+  bufferProvider?: () => string | null | undefined,
+): TrayQuestion | null {
+  let payload: unknown
+  try {
+    payload = JSON.parse(body)
+  } catch (e) {
+    console.error('[Questions] Failed to parse hook payload:', e)
+    return null
+  }
+
+  const event = (payload as { hook_event_name?: unknown })?.hook_event_name
+  if (event === 'PreToolUse') {
+    return setFromAskQuestion(terminalId, payload)
+  }
+  if (event === 'Notification') {
+    return setFromNotification(terminalId, payload, bufferProvider)
+  }
+  console.error(`[Questions] Ignoring hook payload with unexpected event: ${String(event)}`)
+  return null
+}
+
+/** The agent's pending question, or `undefined` — expired entries are dropped here. */
+export function getPendingQuestion(terminalId: string): TrayQuestion | undefined {
+  const question = pendingQuestions.get(terminalId)
+  if (!question) return undefined
+  if (Date.now() - question.receivedAt > QUESTION_TTL_MS) {
+    pendingQuestions.delete(terminalId)
+    return undefined
+  }
+  return question
+}
+
+export function clearPendingQuestion(terminalId: string): void {
+  pendingQuestions.delete(terminalId)
+}
+
+export function clearAllPendingQuestions(): void {
+  pendingQuestions.clear()
+}

--- a/desktop/src/main/tray/agent-state-aggregator.ts
+++ b/desktop/src/main/tray/agent-state-aggregator.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'events'
 import { getAllTerminals, type TerminalState } from '../pty/terminal-manager'
+import { getPendingQuestion } from '../questions/pending-questions'
+import type { TrayQuestion } from '../../types'
 import type { AggregateState } from './tray-icons'
 
 export interface AgentSummary {
@@ -10,6 +12,8 @@ export interface AgentSummary {
   title: string
   repositories: string[]
   createdAt: Date
+  /** The question this agent is blocked on, if any (see main/questions/). */
+  pendingQuestion?: TrayQuestion
 }
 
 export class AgentStateAggregator extends EventEmitter {
@@ -37,6 +41,7 @@ export class AgentStateAggregator extends EventEmitter {
         title: t.metadata?.title || t.name,
         repositories: t.repositories,
         createdAt: t.createdAt,
+        pendingQuestion: getPendingQuestion(t.id),
       }))
   }
 
@@ -73,9 +78,13 @@ export class AgentStateAggregator extends EventEmitter {
     }
 
     // Build a fingerprint that captures individual agent states and titles
-    // so we detect changes even when the aggregate state stays the same
+    // so we detect changes even when the aggregate state stays the same.
+    //
+    // The question token is part of it because a question typically arrives on an
+    // agent that is ALREADY `waiting` — same state, same title, so without the
+    // token nothing here would look changed and the panel would never be told.
     const newFingerprint = terminals
-      .map(t => `${t.id}:${t.state}:${t.metadata?.title || t.name}`)
+      .map(t => `${t.id}:${t.state}:${t.metadata?.title || t.name}:${getPendingQuestion(t.id)?.token ?? ''}`)
       .join('|')
 
     const changed = newState !== this.currentState

--- a/desktop/src/main/windows/popover-window.ts
+++ b/desktop/src/main/windows/popover-window.ts
@@ -14,7 +14,11 @@ const POPOVER_WIDTH = 320
  * past it the list scrolls inside the panel instead.
  */
 const MIN_HEIGHT = 120
-const MAX_HEIGHT = 600
+// Raised from 600 for the question cards: the renderer widens its own scroller when
+// an agent is blocked on a question (see the max-h switch in TrayPopover), and a card
+// plus the rows below it can now report past the old ceiling. The two caps move
+// together — this one only ever clamps what the renderer already limited.
+const MAX_HEIGHT = 720
 
 export function createPopoverWindow(): BrowserWindow {
   if (popoverWindow && !popoverWindow.isDestroyed()) {

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
-import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole, OrgSharedConfig, OrgActivity, OrgAgent, OrgAgentChange, RealtimeStatus, SkillCounts, UsageStats, TelemetryHealth, ThemeId, LanguageId, SetupStatus, McpServerId, PrerequisiteId, TrayState } from '../types'
+import type { TerminalMetadata, RepositoryConfig, UserProfile, ClaudeAccount, SpendSummary, Config, AuthStatus, GitHubAuthStatus, Org, Member, Invitation, MembershipRole, OrgSharedConfig, OrgActivity, OrgAgent, OrgAgentChange, RealtimeStatus, SkillCounts, UsageStats, TelemetryHealth, ThemeId, LanguageId, SetupStatus, McpServerId, PrerequisiteId, TrayState, TrayAnswerChoice, TrayAnswerResult } from '../types'
 
 export type TerminalState = 'idle' | 'working' | 'waiting' | 'completed' | 'error'
 
@@ -338,6 +338,15 @@ const trayApi = {
   /** Height in CSS pixels the panel measured for itself; main clamps it. */
   resize: (height: number) => ipcRenderer.invoke('tray:resize', { height }),
   showWindow: () => ipcRenderer.invoke('tray:showWindow'),
+  /**
+   * Answer an agent's pending question by injecting keystrokes into its PTY.
+   *
+   * `token` comes from the question the panel is displaying: main compares it to
+   * what it holds and writes nothing at all if they differ, so a click on a card
+   * that went stale between two polls is harmless rather than misdirected.
+   */
+  answerQuestion: (id: string, token: string, choice: TrayAnswerChoice): Promise<TrayAnswerResult> =>
+    ipcRenderer.invoke('tray:answerQuestion', { id, token, choice }),
   focusAgent: (id: string) => ipcRenderer.invoke('tray:focusAgent', id),
   openSettings: () => ipcRenderer.invoke('tray:openSettings'),
   quit: () => ipcRenderer.invoke('tray:quit'),

--- a/desktop/src/renderer/hooks/useScriptRunner.ts
+++ b/desktop/src/renderer/hooks/useScriptRunner.ts
@@ -2,11 +2,8 @@ import { useCallback } from 'react'
 import { useStore } from '../store'
 import { showToast } from '../components/Toast'
 import type { ScriptTerminalInfo } from '../../types'
-
-// Strip ANSI escape codes from terminal output
-function stripAnsi(str: string): string {
-  return str.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
-}
+// Shared with the main process (menu bar panel previews) — see src/strip-ansi.ts.
+import { stripAnsi } from '../../strip-ansi'
 
 // Parse test results from terminal output (Vitest, Jest, Mocha)
 function parseTestResults(buffer: string): { passed: number; failed: number; total: number } | null {

--- a/desktop/src/renderer/pages/TrayPopover/QuestionCard.tsx
+++ b/desktop/src/renderer/pages/TrayPopover/QuestionCard.tsx
@@ -1,0 +1,110 @@
+import { ExternalLink, MessageCircleQuestion } from 'lucide-react'
+import type { Translate } from '../../i18n'
+import type { TrayAnswerChoice, TrayQuestion } from '../../../types'
+
+/**
+ * How many options the panel is willing to render as buttons.
+ *
+ * Not a data limit — the store keeps every option, so indexes stay truthful — but a
+ * layout one: the panel is 300-odd pixels wide inside a menu bar dropdown, and a
+ * question with more branches than this is better answered where there is room for
+ * it. "Open the agent" is always there for exactly that.
+ */
+const MAX_OPTIONS = 4
+
+/** Shared by every option button, so only the accent treatment differs. */
+const OPTION_BUTTON =
+  'w-full text-left px-2 py-1.5 rounded-lg text-[12px] border transition-colors'
+
+/**
+ * An agent's pending question, answerable in place.
+ *
+ * The whole reason this exists is that the panel is a non-activating NSPanel: a
+ * click here answers the agent WITHOUT bringing Magic Slash to the front, which is
+ * the entire point of the ticket. Nothing in here may focus a window.
+ *
+ * A permission prompt gets Allow / Deny plus a monospace preview of the terminal
+ * tail — the notification itself only says permission is needed, never what for.
+ * An `AskUserQuestion` gets its own options and no refusal: Escape would interrupt
+ * the agent rather than answer it.
+ */
+export function QuestionCard({
+  question,
+  onAnswer,
+  onOpenAgent,
+  t,
+}: {
+  question: TrayQuestion
+  onAnswer: (choice: TrayAnswerChoice) => void
+  onOpenAgent: () => void
+  t: Translate
+}) {
+  const isPermission = question.kind === 'permission'
+  // A permission prompt carries no options of its own: the panel offers its own
+  // Allow, which is the row the TUI already has highlighted.
+  const options = isPermission && question.options.length === 0
+    ? [{ label: t('tray.question.allow') }]
+    : question.options.slice(0, MAX_OPTIONS)
+
+  return (
+    // No horizontal margin: the list already insets its children (px-2) and spaces
+    // them (gap-1), so the card lines up with the agent rows on its own.
+    <div className="rounded-lg border border-accent/40 bg-accent/10 px-2.5 py-2">
+      <div className="flex items-start gap-1.5">
+        <MessageCircleQuestion className="w-3.5 h-3.5 mt-0.5 shrink-0 text-accent" />
+        <p className="flex-1 text-[12px] leading-snug text-ink">{question.prompt}</p>
+      </div>
+
+      {question.preview && (
+        // The real prompt, as the terminal is showing it. `break-all` because a
+        // command line has no spaces to wrap on and would otherwise widen the panel.
+        <pre className="mt-1.5 max-h-24 overflow-y-auto rounded-lg bg-surface-sunken px-2 py-1.5 font-mono text-[10px] leading-relaxed text-text-secondary whitespace-pre-wrap break-all">
+          {question.preview}
+        </pre>
+      )}
+
+      {question.unsupported ? (
+        <p className="mt-1.5 text-[11px] text-text-secondary">{t('tray.question.unsupported')}</p>
+      ) : (
+        <div className="mt-1.5 flex flex-col gap-1">
+          {options.map((option, index) => (
+            <button
+              key={`${index}-${option.label}`}
+              onClick={() => onAnswer({ kind: 'option', index })}
+              title={option.description}
+              className={`${OPTION_BUTTON} border-accent/40 bg-accent/15 text-ink hover:bg-accent/25`}
+            >
+              <span className="font-medium">{option.label}</span>
+              {option.description && (
+                <span className="block truncate text-[10px] text-text-secondary">
+                  {option.description}
+                </span>
+              )}
+            </button>
+          ))}
+
+          {/* Only a permission can be refused: Escape on an AskUserQuestion
+              would interrupt the agent instead of answering it. */}
+          {isPermission && (
+            <button
+              onClick={() => onAnswer({ kind: 'deny' })}
+              className={`${OPTION_BUTTON} border-line text-text-secondary hover:bg-red/10 hover:text-red`}
+            >
+              <span className="font-medium">{t('tray.question.deny')}</span>
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Always available: it is the answer to everything v1 cannot do here —
+          several questions at once, multiSelect, "Other", a fifth option. */}
+      <button
+        onClick={onOpenAgent}
+        className="mt-1.5 flex items-center gap-1 text-[11px] text-text-secondary hover:text-accent transition-colors"
+      >
+        <ExternalLink className="w-3 h-3 shrink-0" />
+        <span>{t('tray.question.openAgent')}</span>
+      </button>
+    </div>
+  )
+}

--- a/desktop/src/renderer/pages/TrayPopover/index.tsx
+++ b/desktop/src/renderer/pages/TrayPopover/index.tsx
@@ -4,7 +4,8 @@ import { AgentStateBadge } from '../../components/AgentStateBadge'
 import { stateHoverBgColors } from '../../utils/stateColors'
 import { displayNameFromEmail } from '../../utils/displayName'
 import { useT, type Translate } from '../../i18n'
-import type { TrayAgent, TrayState, TrayUpdate } from '../../../types'
+import { QuestionCard } from './QuestionCard'
+import type { TrayAgent, TrayAnswerChoice, TrayState, TrayUpdate } from '../../../types'
 
 const EMPTY: TrayState = { version: '', update: { phase: 'idle' }, agents: [] }
 
@@ -108,6 +109,7 @@ export function TrayPopover() {
   const t = useT()
   const [{ version, update, agents }, setState] = useState<TrayState>(EMPTY)
   const [account, setAccount] = useState<string | null>(null)
+  const [staleAnswer, setStaleAnswer] = useState(false)
   const panelRef = useRef<HTMLDivElement>(null)
 
   const load = useCallback(async () => {
@@ -117,6 +119,37 @@ export function TrayPopover() {
       // A poll that fails (main tearing down) leaves the last frame on screen.
     }
   }, [])
+
+  /**
+   * Answer an agent without leaving the panel.
+   *
+   * The card is dropped locally straight away rather than waiting for the next
+   * poll: the agent's state does NOT flip back from `waiting` on its own — it is
+   * the hooks that drive that — so an optimistic removal is the only thing that
+   * makes the click feel like it did something. `load()` then reconciles.
+   *
+   * A `stale` result means main compared the token and wrote nothing at all. The
+   * card is gone either way (the question really is over), so all that is left to
+   * do is say the answer was not sent.
+   */
+  const answer = useCallback(async (agent: TrayAgent, choice: TrayAnswerChoice) => {
+    const question = agent.pendingQuestion
+    if (!question) return
+
+    setStaleAnswer(false)
+    setState(prev => ({
+      ...prev,
+      agents: prev.agents.map(a => (a.id === agent.id ? { ...a, pendingQuestion: undefined } : a)),
+    }))
+
+    try {
+      const result = await window.electronAPI.tray.answerQuestion(agent.id, question.token, choice)
+      if (!result.ok) setStaleAnswer(true)
+    } catch {
+      setStaleAnswer(true)
+    }
+    load()
+  }, [load])
 
   /**
    * Who is signed in. Not part of the poll on purpose: resolving it can refresh an
@@ -141,6 +174,9 @@ export function TrayPopover() {
     const refresh = () => {
       load()
       loadAccount()
+      // Reopening the panel is a fresh look at the agents: a notice about an answer
+      // that missed has no business surviving into it.
+      setStaleAnswer(false)
     }
     window.addEventListener('focus', refresh)
     return () => window.removeEventListener('focus', refresh)
@@ -167,6 +203,11 @@ export function TrayPopover() {
     observer.observe(panel)
     return () => observer.disconnect()
   }, [])
+
+  // Agents blocked on a question first, each group keeping the order main sent it —
+  // so the list does not reshuffle under the cursor on every 2s poll.
+  const blocked = agents.filter(a => a.pendingQuestion)
+  const ordered = [...blocked, ...agents.filter(a => !a.pendingQuestion)]
 
   return (
     <div
@@ -199,8 +240,22 @@ export function TrayPopover() {
         </div>
       </div>
 
-      {/* Every agent in the app, whatever it is doing */}
-      <div className="max-h-[380px] overflow-y-auto">
+      {/* How many agents are blocked on something, when any are. Only ever shown
+          with a card below it, so it needs no state of its own. */}
+      {blocked.length > 0 && (
+        <div className="px-3.5 py-1.5 border-b border-line text-[11px] font-medium text-accent">
+          {t('tray.question.waiting', { count: blocked.length })}
+        </div>
+      )}
+
+      {/* Every agent in the app, whatever it is doing.
+
+          The cap grows only while a question is on screen: a card is far taller than
+          a row, and at 380px it would open inside a scroller instead of being read at
+          a glance. With nothing blocked the panel keeps exactly the height it had
+          before this feature. 560px stays under MAX_HEIGHT in popover-window once the
+          header, the counter and the footer are added. */}
+      <div className={`${blocked.length > 0 ? 'max-h-[560px]' : 'max-h-[380px]'} overflow-y-auto`}>
         {agents.length === 0 ? (
           <div className="px-3.5 py-6 text-center text-[13px] text-text-secondary">
             {t('tray.popover.empty')}
@@ -209,8 +264,23 @@ export function TrayPopover() {
           // px-2 like the sidebar's nav: the rounded rows sit inset from the
           // panel's edge instead of running into its border.
           <div className="flex flex-col gap-1 px-2 py-2">
-            {agents.map(agent => (
-              <AgentRow key={agent.id} agent={agent} t={t} />
+            {staleAnswer && (
+              <p className="px-2 py-1 text-[11px] text-text-secondary">{t('tray.question.stale')}</p>
+            )}
+            {ordered.map(agent => (
+              // An agent with nothing pending renders exactly as it always did:
+              // the row, and no card.
+              <div key={agent.id} className="flex flex-col gap-1">
+                <AgentRow agent={agent} t={t} />
+                {agent.pendingQuestion && (
+                  <QuestionCard
+                    question={agent.pendingQuestion}
+                    onAnswer={choice => answer(agent, choice)}
+                    onOpenAgent={() => window.electronAPI.tray.focusAgent(agent.id)}
+                    t={t}
+                  />
+                )}
+              </div>
             ))}
           </div>
         )}

--- a/desktop/src/strip-ansi.ts
+++ b/desktop/src/strip-ansi.ts
@@ -1,0 +1,13 @@
+/**
+ * Strip ANSI escape codes from terminal output.
+ *
+ * Lives at the src root, next to the other pure cross-process helpers
+ * (repoMatch, urls, claude-theme), because BOTH sides need it: the renderer parses
+ * script output with it (renderer/hooks/useScriptRunner.ts, its original home) and
+ * the main process builds the permission-prompt preview with it
+ * (main/questions/pending-questions.ts). There must stay exactly one of these —
+ * two regexes drifting apart is how a preview ends up full of escape sequences.
+ */
+export function stripAnsi(str: string): string {
+  return str.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
+}

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -888,6 +888,59 @@ export interface ScriptTerminalInfo {
   state: 'running' | 'error'
 }
 
+/** One selectable answer of an `AskUserQuestion` call. */
+export interface TrayQuestionOption {
+  label: string
+  description?: string
+}
+
+/**
+ * A question an agent is blocked on, surfaced in the menu bar panel so it can be
+ * answered without bringing the app to the front (see main/questions/).
+ *
+ * `token` is what makes a late click safe: it is minted per question, and
+ * `tray:answerQuestion` compares it against the store BEFORE writing anything to
+ * the PTY. Answer the same question in the main window and the store is cleared,
+ * so a click on the panel's now-stale card writes nothing at all.
+ *
+ * `unsupported` marks a question v1 cannot answer from the panel (several
+ * questions in one call, `multiSelect`, no readable option): the card is still
+ * shown, but only offers "Open agent".
+ */
+export interface TrayQuestion {
+  token: string
+  /** `ask` = an AskUserQuestion tool call; `permission` = a permission prompt. */
+  kind: 'ask' | 'permission'
+  prompt: string
+  /**
+   * Empty for `permission`: the panel renders Allow / Deny from its own catalogue
+   * rather than parroting the TUI's wording, which we never see.
+   */
+  options: TrayQuestionOption[]
+  /** Last lines of the terminal, ANSI-stripped — the real prompt, for permissions. */
+  preview?: string
+  receivedAt: number
+  unsupported?: boolean
+}
+
+/**
+ * What the user clicked on a question card. `index` is 0-based, and refers to
+ * `TrayQuestion.options` (for a permission, index 0 is Allow).
+ */
+export type TrayAnswerChoice =
+  | { kind: 'option'; index: number }
+  | { kind: 'deny' }
+
+/**
+ * Outcome of `tray:answerQuestion`. `ok: false` always means nothing at all was
+ * written to the PTY — which is the only distinction the panel acts on. Why it
+ * refused (a stale token, or keystrokes we would have had to guess) is logged in
+ * main rather than carried here, since no caller branches on it.
+ */
+export interface TrayAnswerResult {
+  ok: boolean
+}
+
 /**
  * One row of the menu bar panel (renderer/pages/TrayPopover). A flattened
  * AgentSummary: `createdAt` is a number because it crosses IPC, where a Date
@@ -900,6 +953,8 @@ export interface TrayAgent {
   ticketId: string
   title: string
   createdAt: number
+  /** Absent for the overwhelmingly common case: an agent nobody is waiting on. */
+  pendingQuestion?: TrayQuestion
 }
 
 /**

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -201,6 +201,39 @@ fi
 echo ""
 
 # ============================================
+# 4c. HOOKS CLEANUP
+# ============================================
+# Every hook the desktop app writes ends its command with the marker below (see
+# desktop/src/main/hooks/claude-hooks-config.ts), which is what makes this filter
+# safe: hooks the user wrote themselves share the same events and must survive.
+#
+# The app removes its own hooks on request, but uninstalling can happen with the
+# app already gone — in which case nothing else would ever take them out, and
+# Claude Code would keep curling a port that answers no more.
+echo "4c. Removing Magic Slash hooks..."
+echo ""
+
+if [ -f "$CLAUDE_SETTINGS" ] && jq -e '.hooks' "$CLAUDE_SETTINGS" > /dev/null 2>&1; then
+  TMP_SETTINGS=$(mktemp)
+  jq '
+    .hooks |= (
+      with_entries(
+        .value |= [ .[] | select(
+          ([.hooks[]?.command // ""] | any(contains("magic-slash-desktop"))) | not
+        ) ]
+      )
+      | with_entries(select(.value | length > 0))
+    ) |
+    if (.hooks | length) == 0 then del(.hooks) else . end
+  ' "$CLAUDE_SETTINGS" > "$TMP_SETTINGS" && mv "$TMP_SETTINGS" "$CLAUDE_SETTINGS"
+  echo "   ✓ Magic Slash hooks removed"
+else
+  echo "   - No hooks to remove"
+fi
+
+echo ""
+
+# ============================================
 # 5. BACKUP CLEANUP (OPTIONAL)
 # ============================================
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Description

When an agent asks a question while you are in another app, the only signal today is a system notification and a `waiting` state on the tray icon — the question content itself is nowhere. Dismissing or ignoring that notification means the answer waits until you come back to the main window.

This surfaces the pending question in the menu bar panel, so it can be answered without bringing Magic Slash to the front. Claude Code only reports *that* an agent is waiting, so the content has to be captured through new hooks, and the answer has to go back through the only channel available: the PTY.

Scope is structured `AskUserQuestion` calls and permission prompts. Free-text answers are out of scope for v1; multi-question calls, `multiSelect` and the "Other" option are surfaced but fall back to "Open the agent" rather than being answered from the panel.

## Related Issue

Fixes #173

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **Capture** — two new hooks POST their stdin to the status server: a `PreToolUse` scoped `matcher: 'AskUserQuestion'` (carrying the full `tool_input.questions[]`) and a second `Notification` hook (carrying `message` plus an ANSI-stripped tail of the PTY display buffer). New routes `POST /question` and `GET /question/clear` in `main/hooks/status-server.ts`.
- **Store** — `main/questions/pending-questions.ts` keeps one pending question per terminal, each with a `randomUUID()` token, and expires it lazily after 30 minutes. Clearing is bound to *events*, never to state transitions: `PostToolUse` scoped to `AskUserQuestion`, `UserPromptSubmit`, `Stop`, a human write into the terminal, and terminal exit. The generic `PreToolUse` hook flips the agent to `working` at the same moment the question arrives and the ordering is not guaranteed, so a state-driven clear would erase the question we just received.
- **Answer** — `main/questions/answer-keys.ts` turns a click into keystrokes (`\r` for the highlighted row, arrow-downs plus `\r` for the others, a position-independent `\x1b` to refuse). `main/questions/answer-question.ts` holds the staleness guard: the token is compared before anything is written, so a late click writes nothing at all.
- **State** — `AgentSummary`/`TrayAgent` gain an optional `pendingQuestion`, and the question token joins the aggregator fingerprint. Without that, a question landing on an agent already in `waiting` would change nothing the aggregator can see and the tray would not refresh.
- **UI** — new `QuestionCard.tsx` (prompt, up to 4 option buttons, Deny on a permission, a monospace preview, and always an "Open the agent" escape hatch), agents with a question sorted first, a pending count in the panel header, and a taller scroller *only* while a card is on screen so a panel with no question keeps exactly the height it has today.
- **`writeToTerminal` now returns a boolean** — it silently no-ops on an unknown id, and the panel must not report an answer as delivered when it reached no terminal.
- **`stripAnsi` extracted** to `desktop/src/strip-ansi.ts` (it already existed in `useScriptRunner.ts`) so the main process reuses it instead of carrying a second copy.
- **`install/uninstall.sh` now removes hooks.** It only cleaned `.permissions.allow` before, so *no* hook was ever removed — not the new ones and not the existing ones. Marker-filtered, same shape as the permissions cleanup next to it.
- **i18n** — six `tray.question.*` keys in `en.ts` and `fr.ts`.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [x] Tested installation script
- [ ] Tested affected slash commands

Automated: 880 tests pass (`npm test`), `tsc --noEmit` is clean, ESLint reports 0 errors. New unit tests cover both hook payload shapes, the TTL boundary, token uniqueness, every keystroke sequence and refusal path, the staleness guard (each case asserting on the write spy, not just the return value), hook idempotency across reinstalls, the removal path, and a regression test pinning that nothing ever clears on `PreToolUse`. The `uninstall.sh` jq filter was exercised by hand against a representative `settings.json`.

The first checkbox is deliberately unchecked: see the note about the keystroke spike below.

### Test Steps

1. Run `npm run desktop` from this worktree, then start an agent in the app and let it call `AskUserQuestion` — running any `/magic:*` skill is enough.
2. Switch to another application and open the panel from the menu bar icon: the question should appear as a card at the top of the list, with its prompt, its options and a pending count in the header, within 3 seconds.
3. Click one of the options. The agent must advance **without** the app coming to the front. This is the step worth doing first — if the selection lands on the wrong row, the three constants at the top of `desktop/src/main/questions/answer-keys.ts` are the only thing to change.
4. Trigger a permission prompt (ask the agent to run `npm test`, for instance). The card should offer Allow and Deny alongside an extract of what the terminal is actually showing.
5. Staleness check: with a question showing in the panel, answer it in the main window instead, then click the now-outdated option in the panel. Nothing must reach the PTY — the panel should report the question is no longer current and reload.
6. Regression check: an agent with no pending question should render exactly as it does today, and the panel should keep its current height.
7. From the repo root, `npm test` and `npm run lint`.

## Screenshots

Not included — the panel only renders a card while an agent is genuinely blocked on a question, so a meaningful capture needs the live run described above.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

**The keystroke spike is not done, and it is the riskiest part of this PR.** The issue called for validating `\r` / `\x1b[B` / `\x1b` against a real Claude Code build before building the rest. The sequences are unit-tested for shape only; whether the current TUI starts its highlight on the first row and treats Escape as a refusal needs the manual run in step 3 above. Acceptance criteria 2 and 3 rest on that. The whole assumption is confined to three constants and one function so a correction is a one-line change.

**The off-by-one in the issue is deliberately not reproduced.** It states both "option 1 → `\r`" and "option i → `'\x1b[B'.repeat(i)` + `\r`", which contradict each other: option 1 needs zero arrows. The implementation uses `repeat(index)` on a 0-based index, documented in the file header.

**The real `Notification` payloads were never captured.** Permission detection is a heuristic over free text (`/permission|approve|allow|autoris/i`). A message that is neither the idle nudge nor recognisably a permission request is still shown, but marked `unsupported` — the card and the preview appear with no button that could drive the PTY, because an Enter written into a terminal that is not showing a prompt is worse than a card the user has to open the agent for.

**Possible race on the permission preview.** The `Notification` hook can fire before the TUI has painted its permission box, in which case the preview shows the output from just before it. No settle delay was added.

**Pre-existing gap left in place:** `removeClaudeHooks()` has no production caller, so the new `uninstall.sh` block is the only remover — and unlike that function it does not restore the previous `statusLine`, which can end up pointing at a script the uninstaller deleted. Out of scope here, worth its own issue.

**New local surface:** any process on the machine can `POST /question` and make a card appear whose Allow click writes into a real PTY. Same trust model as the existing `/status` route (loopback-only), but this is the first route whose payload leads to a PTY write.

Also of note: options beyond the fourth are truncated with no "N more" hint.
