### PR TITLE
fix(desktop): keep a notification from replacing a pending question

### DIFF
--- a/desktop/src/main/questions/pending-questions.test.ts
+++ b/desktop/src/main/questions/pending-questions.test.ts
@@ -130,6 +130,49 @@ describe('setFromNotification', () => {
     expect(setFromNotification('term-1', {})).toBeNull()
     expect(setFromNotification('term-1', { message: '   ' })).toBeNull()
   })
+
+  it('never replaces a pending ask, whatever the wording', () => {
+    // The regression: Claude Code announces an AskUserQuestion with a permission
+    // notification of its own, which used to overwrite the question and its options
+    // with a bare Allow / Deny.
+    const ask = setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))
+    const notification = setFromNotification(
+      'term-1',
+      { message: 'Claude needs your permission to use AskUserQuestion' },
+      () => 'tail',
+    )
+    expect(notification).toBeNull()
+    expect(getPendingQuestion('term-1')).toEqual(ask)
+  })
+
+  it('does not read the terminal buffer for a notification it drops', () => {
+    setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))
+    const bufferProvider = vi.fn(() => 'tail')
+    setFromNotification('term-1', { message: 'Claude needs your permission to use Bash' }, bufferProvider)
+    expect(bufferProvider).not.toHaveBeenCalled()
+  })
+
+  it('takes the slot back once the ask is gone', () => {
+    setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))
+    clearPendingQuestion('term-1')
+    const question = setFromNotification('term-1', { message: 'Claude needs your permission to use Bash' })
+    expect(question!.kind).toBe('permission')
+  })
+
+  it('takes the slot back once the ask has expired', () => {
+    vi.useFakeTimers()
+    setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))
+    vi.advanceTimersByTime(31 * 60 * 1000)
+    const question = setFromNotification('term-1', { message: 'Claude needs your permission to use Bash' })
+    expect(question!.kind).toBe('permission')
+  })
+
+  it("leaves another agent's permission prompt alone", () => {
+    setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))
+    const question = setFromNotification('term-2', { message: 'Claude needs your permission to use Bash' })
+    expect(question!.kind).toBe('permission')
+    expect(getPendingQuestion('term-1')!.kind).toBe('ask')
+  })
 })
 
 describe('ingestQuestionPayload', () => {
@@ -188,9 +231,11 @@ describe('the store itself', () => {
     expect(second.token).not.toBe(first.token)
   })
 
+  // The one exception is a notification landing on a pending ask, which is dropped
+  // rather than stored — see setFromNotification.
   it('keeps one question per agent, the newest winning', () => {
-    setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))
-    const second = setFromNotification('term-1', { message: 'Claude needs your permission to use Bash' })!
+    setFromNotification('term-1', { message: 'Claude needs your permission to use Bash' })
+    const second = setFromAskQuestion('term-1', JSON.parse(askPayload(ONE_QUESTION)))!
     expect(getPendingQuestion('term-1')).toEqual(second)
   })
 

--- a/desktop/src/main/questions/pending-questions.ts
+++ b/desktop/src/main/questions/pending-questions.ts
@@ -170,6 +170,18 @@ export function setFromAskQuestion(terminalId: string, payload: unknown): TrayQu
  * A message that is not the idle nudge but that we cannot positively identify as a
  * permission request is still surfaced — as `unsupported`, so the panel shows it and
  * sends the user to the agent rather than writing an Enter into the PTY on a guess.
+ *
+ * ⚠️ A NOTIFICATION NEVER REPLACES A LIVE `ask`
+ * ---------------------------------------------------------------------------
+ * Both hooks feed the same one-question-per-agent slot, and Claude Code announces an
+ * `AskUserQuestion` prompt with a Notification of its own ("Claude needs your
+ * permission to use AskUserQuestion") — which matches ANSWERABLE_NOTIFICATION and
+ * used to overwrite the question that had just been captured. The panel then showed a
+ * bare Allow / Deny and none of what was actually being asked.
+ *
+ * Hook order is not guaranteed, so the rule is stated as precedence rather than
+ * timing: an `ask` carries the real prompt and its options, which no notification
+ * ever can, and it is cleared by its own PostToolUse — so nothing strands it here.
  */
 export function setFromNotification(
   terminalId: string,
@@ -179,6 +191,9 @@ export function setFromNotification(
   const message = asString((payload as { message?: unknown })?.message)
   if (!message) return null
   if (NON_QUESTION_NOTIFICATION.test(message)) return null
+  // Checked before the preview is built: reading the buffer for a payload we are
+  // about to drop is work on the critical path of a blocked agent.
+  if (getPendingQuestion(terminalId)?.kind === 'ask') return null
 
   const preview = buildPreview(bufferProvider?.())
   const unsupported = !ANSWERABLE_NOTIFICATION.test(message)


### PR DESCRIPTION
## Description

The menu bar panel showed a bare Allow / Deny card instead of the question an agent was actually asking. Claude Code announces an `AskUserQuestion` prompt with a `Notification` of its own ("Claude needs your permission to use AskUserQuestion"), which matches `ANSWERABLE_NOTIFICATION` and lands in the same one-question-per-agent slot as the `PreToolUse` capture. Last write won, so the real prompt and its options were replaced by a generic permission card — the user saw two buttons and none of what was being asked.

A notification now never replaces a pending `ask`. The rule is stated as precedence rather than timing, because hook order is not guaranteed: an `ask` carries the real prompt and its options, which no notification ever can, and it is cleared by its own `PostToolUse`, so nothing can strand it in the slot.

## Related Issue

No issue — reported directly in a live session while testing the menu bar panel.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- `setFromNotification` (`desktop/src/main/questions/pending-questions.ts`) returns `null` when the terminal already has a pending question of kind `ask`, instead of overwriting it.
- The guard runs before `buildPreview`, so a payload that is about to be dropped never costs a terminal-buffer read on the critical path of a blocked agent.
- The precedence rule and the regression it fixes are documented on `setFromNotification`, next to the existing note explaining why clears are bound to events rather than to state.
- Tests: the regression itself, the buffer left unread on a dropped notification, the slot reclaimed after a `clear` and after the 30-minute TTL, and agent isolation. The existing "one question per agent, the newest winning" test now demonstrates the rule with notification → `ask`, the direction that is still allowed.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

`npm test` passes (883 tests, 65 files) and `tsc --noEmit` is clean on `desktop/`. The behaviour itself has not yet been confirmed against a running build — the steps below are what does that.

### Test Steps

1. Run `npm run desktop`, start an agent in the app, and let it reach a prompt that calls `AskUserQuestion` (typing `/magic:pr` in the agent is enough — it asks which base branch to use).
2. Open the menu bar panel: the agent's card shows the question text and one button per option. Expected: it stays that way. Before this fix it flipped to a bare **Allow / Deny** card within a second or so, losing the question.
3. Click one of the options: the agent takes that answer and the card disappears, without Magic Slash coming to the front.
4. Now trigger a real permission prompt in the same agent (a command that needs approval, e.g. `git push` on a repo where it is not allowlisted). Expected: the card still shows **Allow / Deny** with the terminal tail as preview — the permission path is unchanged.
5. Optional: `npm test` for the unit coverage of the precedence rule.

## Screenshots

Not applicable — the change is in the main process; the card's rendering is untouched.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

Deliberately left out: grafting the notification's `preview` onto an `ask` marked `unsupported`. The tray aggregator's fingerprint (`desktop/src/main/tray/agent-state-aggregator.ts`) keys on the question `token` alone, so enriching a stored question in place would not repaint the panel, and minting a new token to force the repaint would invalidate an answer the user is in the middle of clicking. Worth its own change if we want it.
