### PR TITLE
[#179] fix(desktop): key agents on their app id so writes cannot duplicate rows

### DIFF
--- a/desktop/src/main/config/command-history.ts
+++ b/desktop/src/main/config/command-history.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import { CONFIG_DIR } from './paths'
 
-const CONFIG_DIR = path.join(os.homedir(), '.config', 'magic-slash')
 const HISTORY_FILE = path.join(CONFIG_DIR, 'command-history.json')
 const MAX_COMMANDS_PER_REPO = 500
 

--- a/desktop/src/main/config/config.ts
+++ b/desktop/src/main/config/config.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto'
 import type { Config, RepositoryConfig, LanguageId, LaunchMode, OrgSharedConfig, ThemeId } from '../../types'
 import { DEFAULT_REPOSITORY_FIELDS, DEFAULT_SPOTLIGHT, isValidSpotlightConfig } from './defaults'
 import { expandPath } from './validation'
+import { CONFIG_DIR } from './paths'
 import { getStore, reportWriteError } from '../store/Store'
 
 /** Settings input where each field can be its normal type, 'default', or null (to reset) */
@@ -34,7 +35,6 @@ const isOneOf = (allowed: string[]) => (v: unknown) => typeof v === 'string' && 
 const isBool = (v: unknown) => typeof v === 'boolean'
 const isString = (v: unknown) => typeof v === 'string'
 
-const CONFIG_DIR = path.join(os.homedir(), '.config', 'magic-slash')
 const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json')
 
 /**

--- a/desktop/src/main/config/paths.test.ts
+++ b/desktop/src/main/config/paths.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import * as path from 'path'
+import * as os from 'os'
+import { CONFIG_DIR, STABLE_CONFIG_DIR, resolveConfigDir } from './paths'
+
+const STABLE = '/home/me/.config/magic-slash'
+
+describe('resolveConfigDir', () => {
+  it('keeps the stable dir when no dev server is running', () => {
+    expect(resolveConfigDir(STABLE, undefined)).toBe(STABLE)
+  })
+
+  it('suffixes the dir when VITE_DEV_SERVER_URL is set', () => {
+    expect(resolveConfigDir(STABLE, 'http://localhost:5173/')).toBe(`${STABLE}-dev`)
+  })
+
+  // An empty string is what a shell exports for an unset variable, and it must not
+  // move the installed app's config out from under it.
+  it('treats an empty dev server url as not-dev', () => {
+    expect(resolveConfigDir(STABLE, '')).toBe(STABLE)
+  })
+})
+
+describe('STABLE_CONFIG_DIR', () => {
+  // Baked into ~/.claude/settings.json (statusline path, skill spool, Read()
+  // permission) and hardcoded by the /magic:* skills, so it can never move.
+  it('is always ~/.config/magic-slash', () => {
+    expect(STABLE_CONFIG_DIR).toBe(path.join(os.homedir(), '.config', 'magic-slash'))
+  })
+
+  // Asserting `CONFIG_DIR === resolveConfigDir(STABLE_CONFIG_DIR, env)` would only
+  // restate the definition. What is worth pinning is that the per-instance dir is
+  // always a sibling of the stable one — an installer or an uninstaller that walks
+  // ~/.config/magic-slash* reaches both.
+  it('is the base CONFIG_DIR is derived from', () => {
+    expect(CONFIG_DIR.startsWith(STABLE_CONFIG_DIR)).toBe(true)
+  })
+})

--- a/desktop/src/main/config/paths.ts
+++ b/desktop/src/main/config/paths.ts
@@ -1,0 +1,37 @@
+import * as path from 'path'
+import * as os from 'os'
+
+/**
+ * The one config dir every build shares, whatever build it is.
+ *
+ * Anything whose path is handed to Claude Code belongs here and never gets the dev
+ * suffix: the statusline wrapper, the skill spool and the `Read()` permission are
+ * written into ~/.claude/settings.json, a single file shared by every build AND by
+ * plain `claude` sessions. Making them per-instance would mean the build that
+ * launched last repoints every session at its own dir, and the statusline marker
+ * would stop matching the other build's wrapper — each would then bake the other's
+ * wrapper in as "the user's original statusline", nesting them.
+ */
+export const STABLE_CONFIG_DIR = path.join(os.homedir(), '.config', 'magic-slash')
+
+/**
+ * Resolve the per-instance config dir. Split out from the constant below so it can
+ * be tested without an env var and a module reload.
+ *
+ * @param devServerUrl VITE_DEV_SERVER_URL — set only by `npm run desktop`.
+ */
+export function resolveConfigDir(stableDir: string, devServerUrl: string | undefined): string {
+  return devServerUrl ? `${stableDir}-dev` : stableDir
+}
+
+/**
+ * Where this instance keeps the state it must NOT share with another running app:
+ * cloud-session.enc, port, outbox.ndjson, command-history.json. (Not config.json —
+ * settings live in Supabase; CONFIG_FILE survives only as a path in an error toast.)
+ *
+ * The dev build gets its own copy. Sharing them with the installed app is what made
+ * both instances hydrate the same session, restore the same agent roster and write
+ * it to the same rows — the duplicate agents of issue #179 — and made the hooks of
+ * every Claude session report into whichever app started last (one shared port file).
+ */
+export const CONFIG_DIR = resolveConfigDir(STABLE_CONFIG_DIR, process.env.VITE_DEV_SERVER_URL)

--- a/desktop/src/main/config/profile.test.ts
+++ b/desktop/src/main/config/profile.test.ts
@@ -31,7 +31,7 @@ describe('readProfile', () => {
   let readProfile: typeof import('./profile').readProfile
 
   beforeEach(async () => {
-    vi.doMock('./config', () => ({ CONFIG_DIR: tmpDir }))
+    vi.doMock('./paths', () => ({ STABLE_CONFIG_DIR: tmpDir }))
     vi.resetModules()
     const mod = await import('./profile')
     readProfile = mod.readProfile
@@ -220,7 +220,7 @@ describe('writeProfile', () => {
   let writeProfile: typeof import('./profile').writeProfile
 
   beforeEach(async () => {
-    vi.doMock('./config', () => ({ CONFIG_DIR: tmpDir }))
+    vi.doMock('./paths', () => ({ STABLE_CONFIG_DIR: tmpDir }))
     vi.resetModules()
     const mod = await import('./profile')
     writeProfile = mod.writeProfile
@@ -274,7 +274,7 @@ describe('writeProfile', () => {
     const nestedDir = path.join(tmpDir, 'nested', 'dir')
 
     // Re-mock with nested dir
-    vi.doMock('./config', () => ({ CONFIG_DIR: nestedDir }))
+    vi.doMock('./paths', () => ({ STABLE_CONFIG_DIR: nestedDir }))
     vi.resetModules()
 
     return import('./profile').then(mod => {
@@ -359,7 +359,7 @@ describe('round-trip writeProfile -> readProfile', () => {
   let writeProfile: typeof import('./profile').writeProfile
 
   beforeEach(async () => {
-    vi.doMock('./config', () => ({ CONFIG_DIR: tmpDir }))
+    vi.doMock('./paths', () => ({ STABLE_CONFIG_DIR: tmpDir }))
     vi.resetModules()
     const mod = await import('./profile')
     readProfile = mod.readProfile
@@ -463,7 +463,7 @@ describe('buildMarkdownBody via writeProfile', () => {
   let writeProfile: typeof import('./profile').writeProfile
 
   beforeEach(async () => {
-    vi.doMock('./config', () => ({ CONFIG_DIR: tmpDir }))
+    vi.doMock('./paths', () => ({ STABLE_CONFIG_DIR: tmpDir }))
     vi.resetModules()
     const mod = await import('./profile')
     writeProfile = mod.writeProfile

--- a/desktop/src/main/config/profile.ts
+++ b/desktop/src/main/config/profile.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import type { UserProfile } from '../../types'
-import { CONFIG_DIR } from './config'
+import { STABLE_CONFIG_DIR } from './paths'
 import { getStore } from '../store/Store'
 
-const PROFILE_PATH = path.join(CONFIG_DIR, 'profile.md')
+// STABLE_CONFIG_DIR, never the dev-suffixed one: the /magic:* skills read this file
+// at ~/.config/magic-slash/profile.md, a path they hardcode.
+const PROFILE_PATH = path.join(STABLE_CONFIG_DIR, 'profile.md')
 
 /**
  * Sync the cloud profile down to the local profile.md file so the /magic:* skills
@@ -39,8 +41,8 @@ export function readProfile(): UserProfile | null {
 }
 
 export function writeProfile(profile: UserProfile): void {
-  if (!fs.existsSync(CONFIG_DIR)) {
-    fs.mkdirSync(CONFIG_DIR, { recursive: true })
+  if (!fs.existsSync(STABLE_CONFIG_DIR)) {
+    fs.mkdirSync(STABLE_CONFIG_DIR, { recursive: true })
   }
 
   const yaml = buildYamlFrontmatter(profile)

--- a/desktop/src/main/hooks/claude-hooks-config.ts
+++ b/desktop/src/main/hooks/claude-hooks-config.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import { STABLE_CONFIG_DIR } from '../config/paths'
 
 const CLAUDE_SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json')
 const MAGIC_SLASH_HOOK_MARKER = 'magic-slash-desktop'
@@ -8,9 +9,13 @@ const MAGIC_SLASH_HOOK_MARKER = 'magic-slash-desktop'
 // StatusLine integration: a wrapper script captures Claude Code's statusline JSON
 // (cost, context usage, model) and POSTs it to the local status server, then relays
 // the user's original statusline so nothing is lost.
-const MAGIC_SLASH_CONFIG_DIR = path.join(os.homedir(), '.config', 'magic-slash')
-const STATUSLINE_SCRIPT_PATH = path.join(MAGIC_SLASH_CONFIG_DIR, 'statusline.sh')
-const STATUSLINE_BACKUP_PATH = path.join(MAGIC_SLASH_CONFIG_DIR, 'statusline-original.json')
+//
+// Everything this module writes lands in ~/.claude/settings.json, one file shared by
+// every build and by plain `claude` sessions, so every path here is the STABLE one:
+// a dev-suffixed statusline path would stop matching STATUSLINE_MARKER and each build
+// would bake the other's wrapper in as "the user's original", nesting them.
+const STATUSLINE_SCRIPT_PATH = path.join(STABLE_CONFIG_DIR, 'statusline.sh')
+const STATUSLINE_BACKUP_PATH = path.join(STABLE_CONFIG_DIR, 'statusline-original.json')
 const STATUSLINE_MARKER = 'magic-slash/statusline.sh'
 
 // Where the skill-telemetry hook spools its records, for the app to drain later (see
@@ -66,7 +71,7 @@ const MAGIC_SLASH_BASE_PERMISSIONS = [
   // Skill reference files. Absolute, because Claude Code does not expand $HOME here.
   `Read(${path.join(os.homedir(), '.claude', 'skills', 'magic-*')})`,
   // Magic Slash config
-  `Read(${path.join(os.homedir(), '.config', 'magic-slash', '*')})`,
+  `Read(${path.join(STABLE_CONFIG_DIR, '*')})`,
   // Desktop communication
   'Bash(*http://127.0.0.1:*)',
   // GitHub MCP tools
@@ -492,8 +497,8 @@ export function configureClaudeHooks(options?: { atlassian?: boolean }): void {
 export function configureStatusLine(): string {
   try {
     // Ensure config dir exists
-    if (!fs.existsSync(MAGIC_SLASH_CONFIG_DIR)) {
-      fs.mkdirSync(MAGIC_SLASH_CONFIG_DIR, { recursive: true })
+    if (!fs.existsSync(STABLE_CONFIG_DIR)) {
+      fs.mkdirSync(STABLE_CONFIG_DIR, { recursive: true })
     }
 
     const claudeDir = path.dirname(CLAUDE_SETTINGS_PATH)

--- a/desktop/src/main/hooks/status-server.ts
+++ b/desktop/src/main/hooks/status-server.ts
@@ -1,8 +1,8 @@
 import * as http from 'http'
 import * as fs from 'fs'
-import * as os from 'os'
 import * as path from 'path'
 import { URL } from 'url'
+import { CONFIG_DIR } from '../config/paths'
 import type { TerminalUsage } from '../../types'
 
 /**
@@ -12,8 +12,11 @@ import type { TerminalUsage } from '../../types'
  * reaches PTYs the app spawned itself — a Claude Code started from an external
  * terminal never inherits it. Publishing the port to a well-known file lets any
  * local process find the server, so hooks keep working outside the app.
+ *
+ * Per-instance (CONFIG_DIR, not the stable dir): one shared file means the last app
+ * started wins it, and every session's hooks then report into that one.
  */
-const PORT_FILE = path.join(os.homedir(), '.config', 'magic-slash', 'port')
+const PORT_FILE = path.join(CONFIG_DIR, 'port')
 
 function publishPort(port: number): void {
   try {
@@ -514,15 +517,23 @@ export function startStatusServer(): Promise<number> {
 
 export function stopStatusServer(): Promise<void> {
   return new Promise((resolve) => {
-    unpublishPort()
-    if (server) {
-      server.close(() => {
-        server = null
-        serverPort = 0
-        resolve()
-      })
-    } else {
+    // Only a process that published the file may remove it. This is not
+    // hypothetical: `before-quit` is registered at module scope and runs in every
+    // instance, including the one that loses the single-instance lock and quits
+    // without ever calling startStatusServer (see index.ts). Same build means the
+    // same CONFIG_DIR, so an unconditional unpublish there would delete the port
+    // file of the instance that is actually serving — and the winner only writes
+    // it at startup, so nothing would restore it until the next launch.
+    if (!server) {
       resolve()
+      return
     }
+
+    unpublishPort()
+    server.close(() => {
+      server = null
+      serverPort = 0
+      resolve()
+    })
   })
 }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -48,6 +48,32 @@ let aggregator: AgentStateAggregator | null = null
 let prReviewWatcher: PRReviewWatcher | null = null
 let dailyDigest: DailyDigestScheduler | null = null
 
+// Electron derives userData from the app name, which both builds resolve to
+// `magic-slash-desktop` (desktop/package.json's `name`; `build.productName` only names
+// the .app bundle). So they share userData AND the instance lock it holds: without
+// moving the dev build first, the lock below would turn `npm run desktop` into a no-op
+// whenever the installed app is running. Must happen before the app is ready.
+if (process.env.VITE_DEV_SERVER_URL) {
+  app.setPath('userData', `${app.getPath('userData')}-dev`)
+}
+
+/**
+ * One instance per build.
+ *
+ * Two of them hydrate the same session and restore the same agent roster, then write
+ * it to the same rows — that is how agents ended up duplicated (issue #179). Claimed
+ * here, at module scope, so the loser quits before whenReady() builds a store or opens
+ * the status server. The dev build has its own userData (above) and so its own lock:
+ * this never stops a developer from running dev alongside the installed app.
+ */
+const hasInstanceLock = app.requestSingleInstanceLock()
+if (!hasInstanceLock) {
+  app.quit()
+} else {
+  // A second launch means the user wants the window, not another process.
+  app.on('second-instance', revealMainWindow)
+}
+
 function createMenu() {
   const isMac = process.platform === 'darwin'
 
@@ -346,6 +372,26 @@ function setupHandlers() {
   })
 }
 
+/**
+ * Bring the app back to the front, rebuilding the window if it is gone.
+ *
+ * The two ways a user asks for that — clicking the dock icon ('activate') and
+ * relaunching an app that already holds the instance lock ('second-instance') —
+ * want exactly the same thing, so they share this rather than each keeping their
+ * own copy of "show it, or create it and re-point the updater at it".
+ */
+function revealMainWindow(): void {
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) mainWindow.restore()
+    focusMainWindow()
+    return
+  }
+  createWindow()
+  // Terminal sessions are restored by the connectivity gate once the backend is
+  // reachable + hydrated (see connectivity-handlers.ts), not here.
+  if (mainWindow) setUpdaterMainWindow(mainWindow)
+}
+
 /** Show and focus the main window, then run an optional callback. */
 function focusMainWindow(callback?: (win: BrowserWindow) => void): void {
   if (!mainWindow) return
@@ -471,6 +517,9 @@ function setupQuickLaunchHandlers() {
 }
 
 app.whenReady().then(async () => {
+  // app.quit() above only schedules the exit; nothing here may run in the loser.
+  if (!hasInstanceLock) return
+
   // Wire the single source of truth (Supabase). Config, agents and history are
   // hydrated from the DB after auth + connectivity are established (via the
   // connectivity gate). Nothing is persisted locally.
@@ -540,20 +589,7 @@ app.whenReady().then(async () => {
     console.error('[Init] Failed to initialize hooks and sessions:', err)
   })
 
-  app.on('activate', () => {
-    if (mainWindow) {
-      mainWindow.show()
-      mainWindow.focus()
-    } else {
-      createWindow()
-      // Connect updater to new window
-      if (mainWindow) {
-        setUpdaterMainWindow(mainWindow)
-      }
-      // Terminal sessions are restored by the connectivity gate once the backend
-      // is reachable + hydrated (see connectivity-handlers.ts), not here.
-    }
-  })
+  app.on('activate', revealMainWindow)
 })
 
 // Deferred initialization - runs after window is shown

--- a/desktop/src/main/store/CloudStore.test.ts
+++ b/desktop/src/main/store/CloudStore.test.ts
@@ -45,6 +45,9 @@ import { CloudStore } from './CloudStore'
 // recorded so tests can assert what was sent.
 
 type QueryResult = { data?: unknown; error?: unknown }
+// A result may be a promise, which is how a test parks a query mid-chain and
+// interleaves another call with it (the builder adopts whatever it is given).
+type PendingResult = QueryResult | PromiseLike<QueryResult>
 
 interface RecordedCall {
   table: string
@@ -53,11 +56,16 @@ interface RecordedCall {
 }
 
 function makeClient(
-  resultsByTable: Record<string, QueryResult>,
+  resultsByTable: Record<string, PendingResult>,
   // Keyed by function name. Separate from the table map because an RPC is not a
   // table and shares no builder chain with one: `client.rpc()` resolves straight
   // to { data, error }.
   resultsByRpc: Record<string, QueryResult> = {},
+  // What an `upsert(...).select(...)` chain resolves to, keyed by table. Separate
+  // from the read map because PostgREST returns the UPSERTED rows there, which is
+  // a different set from what a plain select on the same table yields — and
+  // CloudStore rebuilds its app id → uuid binding from it.
+  resultsByUpsert: Record<string, PendingResult> = {},
 ) {
   const calls: RecordedCall[] = []
   const inserts: Record<string, unknown[]> = {}
@@ -66,6 +74,7 @@ function makeClient(
 
   function builder(table: string) {
     const result = resultsByTable[table] ?? { data: [], error: null }
+    let upserted = false
     const record = (method: string, args: unknown[]) => calls.push({ table, method, args })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const b: any = {
@@ -90,11 +99,12 @@ function makeClient(
       upsert: (payload: unknown, ...args: unknown[]) => {
         record('upsert', [payload, ...args])
         ;(upserts[table] ??= []).push(payload)
+        upserted = true
         return b
       },
       delete: (...args: unknown[]) => { record('delete', args); return b },
       then: (resolve: (v: QueryResult) => unknown, reject?: (e: unknown) => unknown) =>
-        Promise.resolve(result).then(resolve, reject),
+        Promise.resolve(upserted ? resultsByUpsert[table] ?? result : result).then(resolve, reject),
     }
     return b
   }
@@ -306,6 +316,7 @@ describe('appendHistory', () => {
 describe('agents', () => {
   const agentRow = (id: string, appId: string, owner: string) => ({
     id,
+    app_agent_id: appId,
     org_id: ORG,
     owner_id: owner,
     name: `Agent ${appId}`,
@@ -383,8 +394,13 @@ describe('agents', () => {
     await store.loadAgents()
     await store.archiveAgent('claude-1')
 
-    const payload = (updates.agents[0] as { archived_at: string })
+    const payload = (updates.agents[0] as { archived_at: string; app_agent_id: string | null })
     expect(typeof payload.archived_at).toBe('string')
+    // The app id is released in the same statement. App ids are
+    // `claude-${Date.now()}`, so keeping it here would let the next agent that
+    // reuses one conflict onto this row and resurrect it — archived, therefore
+    // invisible in every read path, yet the row every write lands on.
+    expect(payload.app_agent_id).toBeNull()
 
     // Scoped by owner_id so closing an agent can never reach a teammate's row,
     // and by `archived_at is null` so a second close is a no-op.
@@ -410,8 +426,8 @@ describe('agents', () => {
     expect(calls.filter((c) => c.table === 'agents')).toEqual([])
   })
 
-  it('an app id reused after archiving mints a new row instead of resurrecting the old one', async () => {
-    const { client, upserts } = makeClient({
+  it('an app id reused after archiving cannot land on the archived row', async () => {
+    const { client, updates, upserts } = makeClient({
       memberships: membershipsOk,
       agents: { data: [agentRow('uuid-1', 'claude-1', UID)], error: null },
     })
@@ -422,8 +438,178 @@ describe('agents', () => {
     await store.archiveAgent('claude-1')
     await store.saveAgents([{ id: 'claude-1', name: 'Reborn', repositories: [] } as Agent])
 
+    // Two halves of one guarantee, and neither is a uuid the client chose: the
+    // archive released the app id, and the write claims it again with no `id` of
+    // its own. So the conflict target `(owner_id, app_agent_id)` matches nothing
+    // — the archived row no longer holds the id — and the database inserts a new
+    // row rather than reviving a closed agent.
+    expect((updates.agents[0] as Record<string, unknown>).app_agent_id).toBeNull()
+
     const rows = upserts.agents[0] as Array<Record<string, unknown>>
-    expect(rows[0].id).not.toBe('uuid-1')
+    expect(rows[0]).not.toHaveProperty('id')
+    expect(rows[0].app_agent_id).toBe('claude-1')
+  })
+
+  // ── identity lives in the database (issue #179) ────────────────────────────
+  //
+  // The app id used to be bound to a row uuid in this process's memory alone, and
+  // a cache miss minted a fresh uuid for an agent that already had one — so a
+  // second app instance, or a save landing mid-hydration, duplicated the whole
+  // roster. Migration 20260814090000 moves the identity into a column with a
+  // unique index; these tests are what keep the client writing to it.
+
+  it('saveAgents sends no id and conflicts on the app id, not on the primary key', async () => {
+    const { client, calls, upserts } = makeClient({
+      memberships: membershipsOk,
+      agents: { data: [], error: null },
+    })
+    h.state.client = client
+
+    await new CloudStore().saveAgents([{ id: 'claude-1', name: 'Agent A', repositories: [] } as Agent])
+
+    const rows = upserts.agents[0] as Array<Record<string, unknown>>
+    // Omitted, not null: on an update the row keeps the uuid it has, and on an
+    // insert the column default mints one. A client that names a primary key is
+    // a client that can invent a second identity for one agent.
+    expect(rows[0]).not.toHaveProperty('id')
+    expect(rows[0].app_agent_id).toBe('claude-1')
+
+    const upsert = calls.find((c) => c.table === 'agents' && c.method === 'upsert')
+    expect(upsert?.args[1]).toEqual({ onConflict: 'owner_id,app_agent_id' })
+  })
+
+  it('loadAgents takes the agent id from the column, and only then from the jsonb', async () => {
+    const { client, calls } = makeClient({
+      memberships: membershipsOk,
+      agents: {
+        data: [
+          // The column is the identity; the jsonb copy is kept for readers that
+          // predate it and must never override it.
+          { ...agentRow('uuid-1', 'claude-1', UID), metadata: { __app: { id: 'claude-stale' } } },
+          // A row written before the column existed, and not re-saved since.
+          { ...agentRow('uuid-2', 'claude-2', UID), app_agent_id: null },
+        ],
+        error: null,
+      },
+    })
+    h.state.client = client
+
+    const agents = await new CloudStore().loadAgents()
+    expect(agents.map((a: Agent) => a.id)).toEqual(['claude-1', 'claude-2'])
+
+    const select = calls.find((c) => c.table === 'agents' && c.method === 'select')
+    expect(select?.args[0]).toContain('app_agent_id')
+  })
+
+  it('saveAgents rebuilds the app id → uuid binding from what the upsert returned', async () => {
+    const { client, inserts } = makeClient(
+      {
+        memberships: membershipsOk,
+        agents: { data: [], error: null },
+        activity_events: { error: null },
+      },
+      {},
+      // What the database answers: the app id already had a row, and this is its
+      // uuid. Nothing else in the process knows it — the store never loaded.
+      { agents: { data: [{ id: 'uuid-1', app_agent_id: 'claude-1' }], error: null } },
+    )
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.saveAgents([{ id: 'claude-1', name: 'Agent A', repositories: [] } as Agent])
+    await store.appendHistory({
+      agentId: 'claude-1', agentName: 'Agent A', action: 'started', repositories: [], timestamp: 1000,
+    })
+
+    // The event attaches to the row the database resolved. Before this, a store
+    // that had not hydrated attributed the event to a uuid it had invented.
+    expect(inserts.activity_events[0]).toMatchObject({ agent_id: 'uuid-1' })
+  })
+
+  it('saveAgents sends one row per app id, whatever the caller passed', async () => {
+    const { client, upserts } = makeClient({
+      memberships: membershipsOk,
+      agents: { data: [], error: null },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.saveAgents([
+      { id: 'claude-1', name: 'Stale', repositories: [] } as Agent,
+      { id: 'claude-1', name: 'Fresh', repositories: [] } as Agent,
+    ])
+
+    // Postgres rejects a whole ON CONFLICT statement that would hit the same
+    // conflict target twice (21000), so one duplicated cache entry would fail the
+    // save of every OTHER agent too. The later entry wins — it is the more recent
+    // state of the same agent.
+    const rows = upserts.agents[0] as Array<Record<string, unknown>>
+    expect(rows).toHaveLength(1)
+    expect(rows[0].name).toBe('Fresh')
+  })
+
+  it('a hydration in flight never hands out an empty id map', async () => {
+    // The single-process half of the duplication: loadAgents used to clear the id
+    // map BEFORE awaiting its links query, so everything running inside that
+    // window — a save, an event — saw an EMPTY map and concluded the agents were
+    // new. The map is now built locally and swapped in after the awaits, so a
+    // reader gets the previous hydration's answer or this one's, never nothing.
+    //
+    // The links query is a gate: `opened` fires the moment CloudStore awaits it —
+    // i.e. once the hydration is past the point where it used to wipe the map —
+    // and it stays parked until `release`. Without that handshake the test would
+    // race the two await chains and pass either way.
+    let release: (() => void) | undefined
+    let opened: (() => void) | undefined
+    const settled = new Promise<QueryResult>((resolve) => {
+      release = () => resolve({ data: [], error: null })
+    })
+    const awaited = new Promise<void>((resolve) => { opened = resolve })
+    const links: PromiseLike<QueryResult> = {
+      then: (onFulfilled, onRejected) => {
+        opened?.()
+        return settled.then(onFulfilled, onRejected)
+      },
+    }
+
+    const results: Record<string, PendingResult> = {
+      memberships: membershipsOk,
+      agents: { data: [agentRow('uuid-1', 'claude-1', UID)], error: null },
+      agent_repositories: { data: [], error: null },
+      activity_events: { error: null },
+    }
+    const { client, upserts, inserts } = makeClient(
+      results,
+      {},
+      { agents: { data: [{ id: 'uuid-1', app_agent_id: 'claude-1' }], error: null } },
+    )
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.loadAgents()
+
+    // A second hydration (an org switch, a reconnect), parked on its links query.
+    results.agent_repositories = links
+    const rehydrating = store.loadAgents()
+    await awaited
+
+    // Written inside the window. Events are not queued behind the agent writes —
+    // they must not be, they are on the hot path — so this is exactly the read
+    // that used to come back empty and record an unattributable event.
+    await store.appendHistory({
+      agentId: 'claude-1', agentName: 'Agent A', action: 'started', repositories: [], timestamp: 1000,
+    })
+
+    // And a save from the same window: config/agents.ts fires them and forgets.
+    const saving = store.saveAgents([{ id: 'claude-1', name: 'Agent A', repositories: [] } as Agent])
+    release?.()
+    await Promise.all([rehydrating, saving])
+
+    expect(inserts.activity_events[0]).toMatchObject({ agent_id: 'uuid-1' })
+
+    const rows = upserts.agents[0] as Array<Record<string, unknown>>
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).not.toHaveProperty('id')
   })
 
   // ── columns vs jsonb ──────────────────────────────────────────────────────
@@ -536,11 +722,15 @@ describe('agents', () => {
   })
 
   it('saveAgents links the agent to the repositories it resolved, tolerating a link already there', async () => {
-    const { client, calls, upserts } = makeClient({
-      memberships: membershipsOk,
-      agents: { data: [], error: null },
-      agent_repositories: { data: [], error: null },
-    })
+    const { client, calls, upserts } = makeClient(
+      {
+        memberships: membershipsOk,
+        agents: { data: [], error: null },
+        agent_repositories: { data: [], error: null },
+      },
+      {},
+      { agents: { data: [{ id: 'uuid-1', app_agent_id: 'claude-1' }], error: null } },
+    )
     h.state.client = client
 
     await new CloudStore().saveAgents([
@@ -549,6 +739,9 @@ describe('agents', () => {
 
     const rows = upserts.agent_repositories[0] as Array<Record<string, unknown>>
     expect(rows.map((r) => r.repo_id)).toEqual(['r1', 'r2'])
+    // The uuid the agents upsert returned — the link table keys on the row id,
+    // which the client no longer knows until the database answers.
+    expect(rows.map((r) => r.agent_id)).toEqual(['uuid-1', 'uuid-1'])
     // (agent_id, repo_id) is the primary key, so re-creating a link that exists
     // must be a no-op and not a "failed to save your agents" the user cannot act
     // on. ignoreDuplicates and not a merge: the table grants no UPDATE.
@@ -557,11 +750,15 @@ describe('agents', () => {
   })
 
   it('saveAgents serializes concurrent writes instead of diffing the links twice', async () => {
-    const { client, calls } = makeClient({
-      memberships: membershipsOk,
-      agents: { data: [], error: null },
-      agent_repositories: { data: [], error: null },
-    })
+    const { client, calls } = makeClient(
+      {
+        memberships: membershipsOk,
+        agents: { data: [], error: null },
+        agent_repositories: { data: [], error: null },
+      },
+      {},
+      { agents: { data: [{ id: 'uuid-1', app_agent_id: 'claude-1' }], error: null } },
+    )
     h.state.client = client
 
     const store = new CloudStore()

--- a/desktop/src/main/store/CloudStore.ts
+++ b/desktop/src/main/store/CloudStore.ts
@@ -25,6 +25,10 @@ interface ConfigRow {
 
 interface AgentRow {
   id: string
+  // The app's own agent id ("claude-…"), and the key every write arbitrates on
+  // since 20260814090000. Null on a row no desktop wrote, and on every archived
+  // row — hence the jsonb fallback in fromAgentRow.
+  app_agent_id: string | null
   // DERIVED from the agent's repositories, and null for an agent on personal repos
   // only (or on none yet) — see migration 20260727160000. Selected but never read:
   // the client is not allowed an opinion on it.
@@ -230,7 +234,11 @@ interface CloudContext {
 
 export class CloudStore implements Store {
   private activeOrgId: string | undefined
-  /** app agent id ("claude-…") → agents.id (uuid). Rebuilt on every loadAgents. */
+  /**
+   * app agent id ("claude-…") → agents.id (uuid). Rebuilt on every loadAgents and
+   * refreshed from what each agent upsert returns — never invented here, which is
+   * what used to duplicate rows (see migration 20260814090000).
+   */
   private agentIdMap = new Map<string, string>()
   /** app agent id → digest of its last-synced repository ids (see syncRepoLinks). */
   private agentRepoKey = new Map<string, string>()
@@ -261,13 +269,22 @@ export class CloudStore implements Store {
    *
    * A chain, not a lock: the writes must also stay in the order they were made,
    * since an archive following a save means something different than the reverse.
+   *
+   * loadAgents rides it too, despite the name: it is a read-then-replace of those
+   * same caches, so it belongs in the same order as the writes (see loadAgents).
    */
   private queueAgentWrite<T>(task: () => Promise<T>): Promise<T> {
     const run = this.agentWrites.then(task, task)
     // The chain waits on outcomes, not successes: one failed write must not
     // reject every later one. The caller still gets the real rejection — it
     // awaits `run`, not the swallowed copy the chain holds.
-    this.agentWrites = run.catch(() => {})
+    //
+    // The fulfilment value is dropped as deliberately as the rejection. loadAgents
+    // rides this chain too and returns the whole roster, and a bare `.catch()`
+    // passes that value through — the tail would then hold every hydrated Agent
+    // alive until the next write replaced it, on a store that lives as long as the
+    // process and outlives a sign-out.
+    this.agentWrites = run.then(() => {}, () => {})
     return run
   }
 
@@ -723,8 +740,16 @@ export class CloudStore implements Store {
    * The backend derives it from agent_repositories (see the derive_agent_org
    * trigger), so sending one here would fight the trigger — and on an upsert an
    * omitted column is left untouched, which is exactly what we want.
+   *
+   * `id` is absent for the same reason, and it matters more: the row's uuid is
+   * the database's to mint. Left out, an update keeps the value the row already
+   * has and an insert takes the column's `gen_random_uuid()` default — so no
+   * client can name an identity, and the only key it asserts is `app_agent_id`,
+   * which the unique index arbitrates on (20260814090000). The app id also stays
+   * in the jsonb: rows written before that migration carry it only there, and
+   * readers that predate the column still look for it.
    */
-  private toAgentRow(agent: Agent, id: string, uid: string): Record<string, unknown> {
+  private toAgentRow(agent: Agent, uid: string): Record<string, unknown> {
     // The five fields that HAVE a column are peeled off the metadata rather than
     // copied into it. They used to be written twice — once in the column, once
     // inside the jsonb — while fromAgentRow read only the jsonb, which made every
@@ -734,7 +759,7 @@ export class CloudStore implements Store {
     // admin_list_user_agents already read the columns).
     const { ticketId, description, branchName, baseBranch, status, ...rest } = agent.metadata ?? {}
     return {
-      id,
+      app_agent_id: agent.id,
       owner_id: uid,
       name: agent.name,
       ticket_id: ticketId ?? null,
@@ -744,9 +769,10 @@ export class CloudStore implements Store {
       status: status ?? null,
       repositories: agent.repositories ?? [],
       // What is left has no column of its own: title, fullStackTaskId,
-      // relatedWorktrees, repositoryMetadata, usage — plus __app, the app-side
-      // identity (its local id, creation stamp and pane) that has nowhere else to
-      // live because the row's own id is a uuid the app never sees.
+      // relatedWorktrees, repositoryMetadata, usage — plus __app, which carries
+      // tsCreate and splitPane, neither of which has anywhere else to live. Its
+      // `id` is the one field now duplicated, and only for compatibility: a build
+      // older than 20260814090000 reads the app id from here and nowhere else.
       metadata: { ...rest, __app: { id: agent.id, tsCreate: agent.tsCreate, splitPane: agent.splitPane } },
     }
   }
@@ -757,7 +783,12 @@ export class CloudStore implements Store {
     delete rest.__app
 
     return {
-      id: app?.id ?? row.id,
+      // Column first, jsonb second, uuid last. The jsonb still answers for rows an
+      // older installed build writes — it sends `id` with onConflict 'id' and
+      // leaves the column null — so both levels stay until no such build is in the
+      // field, at which point toAgentRow can stop mirroring the id and this rung
+      // can go. The uuid is the last resort for a row no desktop ever wrote.
+      id: row.app_agent_id ?? app?.id ?? row.id,
       name: row.name,
       repositories: Array.isArray(row.repositories) ? row.repositories : [],
       repositoryIds: [],
@@ -795,32 +826,56 @@ export class CloudStore implements Store {
    * Archived agents are excluded too: they are closed work kept only for the
    * history they are attached to. Without this filter, restoreAgents() would
    * spawn a PTY for every agent ever closed.
+   *
+   * Queued behind the pending agent writes (see queueAgentWrite), like the two
+   * writers: hydrating is a read-then-replace of the very caches saveAgents and
+   * archiveAgent read and update, and interleaving the two is how a save came to
+   * see a half-built map. The cost is real — a hydration now waits for the
+   * writes in flight — and accepted: those writes are single round-trips, and
+   * hydration happens on launch and on org switches, not on the hot path. No
+   * deadlock either: loadAgents has exactly one caller (config/agents.ts), and
+   * nothing on the write chain calls it.
    */
   async loadAgents(): Promise<Agent[]> {
+    return this.queueAgentWrite(() => this.readAgentRows())
+  }
+
+  private async readAgentRows(): Promise<Agent[]> {
     const ctx = await this.context()
     if (!ctx) return []
 
     const { data, error } = await ctx.client
       .from('agents')
-      .select('id, org_id, owner_id, name, ticket_id, description, branch_name, base_branch, status, repositories, metadata, updated_at')
+      .select('id, app_agent_id, org_id, owner_id, name, ticket_id, description, branch_name, base_branch, status, repositories, metadata, updated_at')
       .eq('owner_id', ctx.uid)
       .is('archived_at', null)
 
     if (error || !data) return []
 
-    this.agentIdMap.clear()
-    this.agentRepoKey.clear()
     const rows = data as AgentRow[]
     const linksByAgent = await this.fetchRepoLinks(ctx, rows.map((r) => r.id))
+
+    // Built locally, published at the end. These used to be cleared here, before
+    // the fetchRepoLinks await — so anything reading them in that window (a
+    // write's uuid lookup, an event's agent_id) saw an EMPTY map and concluded
+    // the agents were new. Replacing the maps in one synchronous step means a
+    // reader sees either the previous hydration's answer or this one's, never a
+    // half-filled map. The early returns above leave both intact on purpose: a
+    // failed read is not evidence that the roster is gone.
+    const idMap = new Map<string, string>()
+    const repoKey = new Map<string, string>()
 
     const agents: Agent[] = []
     for (const raw of rows) {
       const agent = this.fromAgentRow(raw)
       agent.repositoryIds = linksByAgent.get(raw.id) ?? []
-      this.agentIdMap.set(agent.id, raw.id)
-      this.agentRepoKey.set(agent.id, agent.repositoryIds.join(','))
+      idMap.set(agent.id, raw.id)
+      repoKey.set(agent.id, agent.repositoryIds.join(','))
       agents.push(agent)
     }
+
+    this.agentIdMap = idMap
+    this.agentRepoKey = repoKey
     return agents
   }
 
@@ -862,6 +917,13 @@ export class CloudStore implements Store {
     )
     if (changed.length === 0) return
 
+    // The assertion holds because of what ran immediately before: writeAgentRows
+    // upserted a row for every one of these app ids and refreshed the map from the
+    // response, which PostgREST returns in full — ON CONFLICT DO UPDATE touches
+    // every row, and agents_select admits them all on `owner_id = auth.uid()`,
+    // which is the owner they were just written with. A guard here would be a
+    // branch nothing can take; if the invariant ever did break, the missing
+    // agent_id fails the insert loudly rather than writing anything wrong.
     const uuidByAppId = new Map(changed.map((a) => [a.id, this.agentIdMap.get(a.id)!]))
     const existing = await this.fetchRepoLinks(ctx, [...uuidByAppId.values()])
 
@@ -938,18 +1000,37 @@ export class CloudStore implements Store {
     const ctx = await this.context()
     if (!ctx) return
 
-    const rows = agents.map((a) => {
-      const uuid = this.agentIdMap.get(a.id) ?? randomUUID()
-      this.agentIdMap.set(a.id, uuid)
-      return this.toAgentRow(a, uuid, ctx.uid)
-    })
+    // One row per app id. `(owner_id, app_agent_id)` is what the upsert arbitrates
+    // on, and Postgres refuses a statement that would hit the same conflict target
+    // twice — 21000, "ON CONFLICT DO UPDATE command cannot affect row a second
+    // time" — which would fail the WHOLE roster over one duplicated cache entry.
+    // The later entry wins: it is the more recent state of the same agent.
+    const byAppId = new Map(agents.map((a) => [a.id, a]))
+    const unique = [...byAppId.values()]
+    const rows = unique.map((a) => this.toAgentRow(a, ctx.uid))
     if (rows.length === 0) return
 
-    const { error } = await ctx.client.from('agents').upsert(rows, { onConflict: 'id' })
+    // The database resolves identity, and says so: an app id it already knows
+    // returns the uuid of the row that holds it, a new one returns the uuid the
+    // column default just minted. Reading the binding back from the response is
+    // what replaced `agentIdMap.get(a.id) ?? randomUUID()` — a local cache miss
+    // used to mint a SECOND identity for an agent that already had one, which is
+    // the duplication migration 20260814090000 exists to end.
+    const { data, error } = await ctx.client
+      .from('agents')
+      .upsert(rows, { onConflict: 'owner_id,app_agent_id' })
+      .select('id, app_agent_id')
     if (error) throw new Error(`saveAgents failed: ${error.message}`)
 
+    for (const row of (data ?? []) as { id: string; app_agent_id: string | null }[]) {
+      if (row.app_agent_id) this.agentIdMap.set(row.app_agent_id, row.id)
+    }
+
     // After the upsert: the link rows reference agents that must already exist.
-    await this.syncRepoLinks(ctx, agents)
+    // The deduplicated list, for the same reason the upsert got it — a repeated app
+    // id would otherwise have its links diffed twice against one uuid, so the stale
+    // entry issues a delete the fresh entry immediately undoes.
+    await this.syncRepoLinks(ctx, unique)
   }
 
   /**
@@ -977,18 +1058,25 @@ export class CloudStore implements Store {
 
     // Scoped by owner, not by org: an agent on a personal repo has no org, and
     // ownership is the real permission boundary anyway.
+    //
+    // app_agent_id is released in the same statement as archived_at, and that is
+    // the whole reason a closed agent cannot be resurrected. App ids are
+    // `claude-${Date.now()}`, so a later agent may carry the same one; with the
+    // id still on the archived row, its upsert would conflict onto it and — since
+    // toAgentRow never sets archived_at — bring back a row the user closed, live
+    // in the database yet filtered out of every read. Null is also what keeps the
+    // unique index total-index-safe: any number of archived rows may share an app
+    // id, because null keys are distinct (see 20260814090000).
     const { error } = await ctx.client
       .from('agents')
-      .update({ archived_at: new Date().toISOString() })
+      .update({ archived_at: new Date().toISOString(), app_agent_id: null })
       .eq('owner_id', ctx.uid)
       .eq('id', uuid)
       .is('archived_at', null)
     if (error) throw new Error(`archiveAgent failed: ${error.message}`)
 
-    // Drop the app id → uuid binding so a future agent reusing this app id
-    // (ids are `claude-${Date.now()}`) mints a fresh row instead of upserting
-    // onto the archived one — which, since toAgentRow never sets archived_at,
-    // would resurrect it as an invisible agent.
+    // The local binding goes too: nothing in this process should keep pointing an
+    // app id at a row that no longer answers to it.
     this.agentIdMap.delete(appId)
     this.agentRepoKey.delete(appId)
   }

--- a/desktop/src/main/store/outbox.ts
+++ b/desktop/src/main/store/outbox.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
-import * as os from 'os'
 import * as path from 'path'
 import { randomUUID } from 'crypto'
+import { CONFIG_DIR } from '../config/paths'
 import type { HistoryEntry, SkillInvocationInput, SkillRunEndInput, UsageEventInput } from '../../types'
 import { getStore } from './Store'
 
@@ -40,7 +40,8 @@ import { getStore } from './Store'
  * produced it.
  */
 
-const OUTBOX_FILE = path.join(os.homedir(), '.config', 'magic-slash', 'outbox.ndjson')
+// Per-instance (CONFIG_DIR): two apps draining one queue replay each other's events.
+const OUTBOX_FILE = path.join(CONFIG_DIR, 'outbox.ndjson')
 
 /**
  * How many events the queue keeps. At roughly 200 bytes an entry this caps the file

--- a/desktop/src/main/usage/skill-spool.test.ts
+++ b/desktop/src/main/usage/skill-spool.test.ts
@@ -52,11 +52,16 @@ afterAll(() => fs.rmSync(TMP_HOME, { recursive: true, force: true }))
 const claimFiles = () =>
   fs.readdirSync(CONFIG_DIR).filter((f) => f.startsWith('pending-skills.ndjson.claiming.'))
 
-/** Write an abandoned claim, aged so the drain will or will not adopt it. */
-function abandonedClaim(records: object[], ageMs: number): string {
-  const file = path.join(CONFIG_DIR, `pending-skills.ndjson.claiming.9999.${Date.now()}`)
+/**
+ * Write a claim last stamped `sinceLastBeatMs` ago.
+ *
+ * A drain in progress stamps the files it owns every 15s, so the time since the last
+ * stamp — not the file's age — is what says whether anyone still owns it.
+ */
+function claimLastBeat(records: object[], sinceLastBeatMs: number): string {
+  const file = path.join(CONFIG_DIR, `pending-skills.ndjson.claiming.4242.${Date.now()}.0`)
   fs.writeFileSync(file, records.map((r) => JSON.stringify(r)).join('\n') + '\n')
-  const when = new Date(Date.now() - ageMs)
+  const when = new Date(Date.now() - sinceLastBeatMs)
   fs.utimesSync(file, when, when)
   return file
 }
@@ -124,7 +129,7 @@ describe('drainSkillSpool', () => {
     // more, but an upgrade must still pick up whatever one of them left behind — and
     // ahead of the fresh spool, so the older runs are recorded first.
     fs.writeFileSync(DRAINING_FILE, JSON.stringify(start('magic-done')) + '\n')
-    const old = new Date(Date.now() - 120_000)
+    const old = new Date(Date.now() - 20 * 60_000)
     fs.utimesSync(DRAINING_FILE, old, old)
     spool(start('magic-commit'))
 
@@ -324,22 +329,50 @@ describe('claiming the spool', () => {
     expect(recorded().map((r) => r.skill)).toEqual(['magic-commit', 'magic-pr'])
   })
 
-  it('adopts a claim abandoned by a process that died mid-drain', async () => {
-    abandonedClaim([start('magic-review')], 120_000)
+  it('adopts a claim that stopped beating', async () => {
+    // Four missed beats: the process that owned this is gone, and nothing else will ever
+    // come back for its runs.
+    claimLastBeat([start('magic-review')], 90_000)
 
     expect(await drainSkillSpool()).toBe(1)
     expect(recorded().map((r) => r.skill)).toEqual(['magic-review'])
     expect(claimFiles()).toEqual([])
   })
 
-  it('leaves a claim another drain is still working on alone', async () => {
-    // Fresh mtime means a live claim in another app. Adopting it would record the same
-    // runs twice — the one failure mode worse than adopting late.
-    const live = abandonedClaim([start('magic-review')], 0)
+  it('leaves a beating claim alone however old the file is', async () => {
+    // The case an age-only cutoff gets wrong. This claim was opened an hour ago and its
+    // drain is still going — a big backlog is minutes of network round-trips. It beat a
+    // moment ago, so it has an owner, and stealing it would record its runs twice.
+    const live = claimLastBeat([start('magic-review')], 1_000)
 
     expect(await drainSkillSpool()).toBe(0)
     expect(recorded()).toEqual([])
     expect(fs.existsSync(live)).toBe(true)
+  })
+
+  it('keeps its own claims beating while it drains', async () => {
+    // Without this the guarantee above is empty: a slow drain that never stamped its
+    // files would go stale under itself and be adopted by the other build mid-flight.
+    vi.useFakeTimers()
+    try {
+      spool(start('magic-commit'))
+
+      let before = 0
+      let after = 0
+      vi.mocked(recordSkillInvocation).mockImplementationOnce(async () => {
+        const claimed = path.join(CONFIG_DIR, claimFiles()[0])
+        before = fs.statSync(claimed).mtimeMs
+        // Long enough for the interval to fire, while this drain is still going.
+        await vi.advanceTimersByTimeAsync(16_000)
+        after = fs.statSync(claimed).mtimeMs
+      })
+
+      await drainSkillSpool()
+
+      expect(after).toBeGreaterThan(before)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/desktop/src/main/usage/skill-spool.test.ts
+++ b/desktop/src/main/usage/skill-spool.test.ts
@@ -119,14 +119,29 @@ describe('drainSkillSpool', () => {
     expect(recorded().map((r) => r.skill)).toEqual(['magic-commit', 'magic-pr'])
   })
 
-  it('retries a batch the app died in the middle of', async () => {
-    // A leftover .draining file is a drain that never finished. Its records are not
-    // stranded — retrying is safe because recordSkillInvocation owns the outbox.
+  it('retries a batch an older build died in the middle of', async () => {
+    // `.draining` is the shared working file older builds used. Nothing writes it any
+    // more, but an upgrade must still pick up whatever one of them left behind — and
+    // ahead of the fresh spool, so the older runs are recorded first.
     fs.writeFileSync(DRAINING_FILE, JSON.stringify(start('magic-done')) + '\n')
+    const old = new Date(Date.now() - 120_000)
+    fs.utimesSync(DRAINING_FILE, old, old)
     spool(start('magic-commit'))
 
     expect(await drainSkillSpool()).toBe(2)
     expect(recorded().map((r) => r.skill)).toEqual(['magic-done', 'magic-commit'])
+    expect(fs.existsSync(DRAINING_FILE)).toBe(false)
+  })
+
+  it('leaves a .draining an older build may still be writing alone', async () => {
+    // During an upgrade the previous build can be running right now, mid-drain. Its
+    // working file is only safe to adopt once it has gone untouched — taking it early
+    // would record the same runs twice.
+    fs.writeFileSync(DRAINING_FILE, JSON.stringify(start('magic-done')) + '\n')
+
+    expect(await drainSkillSpool()).toBe(0)
+    expect(recorded()).toEqual([])
+    expect(fs.existsSync(DRAINING_FILE)).toBe(true)
   })
 
   it('skips a torn line rather than discarding the batch', async () => {

--- a/desktop/src/main/usage/skill-spool.test.ts
+++ b/desktop/src/main/usage/skill-spool.test.ts
@@ -48,9 +48,23 @@ const closed = () => vi.mocked(closeSkillRun).mock.calls.map((c) => c[0] as Skil
 beforeAll(() => fs.mkdirSync(CONFIG_DIR, { recursive: true }))
 afterAll(() => fs.rmSync(TMP_HOME, { recursive: true, force: true }))
 
+/** Every `.claiming.` file currently sitting in the config dir. */
+const claimFiles = () =>
+  fs.readdirSync(CONFIG_DIR).filter((f) => f.startsWith('pending-skills.ndjson.claiming.'))
+
+/** Write an abandoned claim, aged so the drain will or will not adopt it. */
+function abandonedClaim(records: object[], ageMs: number): string {
+  const file = path.join(CONFIG_DIR, `pending-skills.ndjson.claiming.9999.${Date.now()}`)
+  fs.writeFileSync(file, records.map((r) => JSON.stringify(r)).join('\n') + '\n')
+  const when = new Date(Date.now() - ageMs)
+  fs.utimesSync(file, when, when)
+  return file
+}
+
 beforeEach(() => {
   fs.rmSync(SPOOL_FILE, { force: true })
   fs.rmSync(DRAINING_FILE, { force: true })
+  for (const f of claimFiles()) fs.rmSync(path.join(CONFIG_DIR, f), { force: true })
   vi.mocked(recordSkillInvocation).mockClear()
   vi.mocked(recordSkillInvocation).mockImplementation(async () => {})
   vi.mocked(closeSkillRun).mockClear()
@@ -265,6 +279,52 @@ describe('a run seen by both hooks', () => {
     spool(start('magic-done'))
     await drainSkillSpool()
     expect(recorded()).toHaveLength(1)
+  })
+})
+
+describe('claiming the spool', () => {
+  it('leaves no working file behind once the drain is done', async () => {
+    spool(start('magic-commit'))
+
+    await drainSkillSpool()
+
+    // The rename target is short-lived by contract: anything still here after a clean
+    // drain would be adopted a minute later and counted twice.
+    expect(claimFiles()).toEqual([])
+  })
+
+  it('records the spool a hook recreates while the drain is running', async () => {
+    // What the rename buys: the hook writes to a fresh SPOOL_FILE, not to the one being
+    // drained, so the record is still there for the next tick instead of being deleted
+    // unread.
+    spool(start('magic-commit'))
+    vi.mocked(recordSkillInvocation).mockImplementationOnce(async () => {
+      spool(start('magic-pr'))
+    })
+
+    expect(await drainSkillSpool()).toBe(1)
+    expect(recorded().map((r) => r.skill)).toEqual(['magic-commit'])
+
+    expect(await drainSkillSpool()).toBe(1)
+    expect(recorded().map((r) => r.skill)).toEqual(['magic-commit', 'magic-pr'])
+  })
+
+  it('adopts a claim abandoned by a process that died mid-drain', async () => {
+    abandonedClaim([start('magic-review')], 120_000)
+
+    expect(await drainSkillSpool()).toBe(1)
+    expect(recorded().map((r) => r.skill)).toEqual(['magic-review'])
+    expect(claimFiles()).toEqual([])
+  })
+
+  it('leaves a claim another drain is still working on alone', async () => {
+    // Fresh mtime means a live claim in another app. Adopting it would record the same
+    // runs twice — the one failure mode worse than adopting late.
+    const live = abandonedClaim([start('magic-review')], 0)
+
+    expect(await drainSkillSpool()).toBe(0)
+    expect(recorded()).toEqual([])
+    expect(fs.existsSync(live)).toBe(true)
   })
 })
 

--- a/desktop/src/main/usage/skill-spool.ts
+++ b/desktop/src/main/usage/skill-spool.ts
@@ -51,14 +51,31 @@ const DRAINING_FILE = `${SPOOL_FILE}.draining`
 const CLAIMING_PREFIX = `${path.basename(SPOOL_FILE)}.claiming.`
 
 /**
- * How long a `.claiming.` file must sit untouched before another drain adopts it.
+ * How often a drain in progress stamps the files it owns.
  *
- * A live claim exists for the duration of a rename, a read and an append — microseconds,
- * with no await in between. Anything older than this is the debris of a process that died
- * mid-claim, and adopting it is the only way its records are ever seen again. Generous on
- * purpose: adopting a claim that is merely slow would double-count it.
+ * This is what makes an mtime mean "someone is working on this" rather than "this was
+ * created a while ago". Without it, age cannot tell a dead drain from a slow one — and a
+ * drain is legitimately slow, since it holds its files until the last record reaches the
+ * network.
  */
-const STALE_CLAIM_MS = 60_000
+const HEARTBEAT_MS = 15_000
+
+/**
+ * How long a claim must go unstamped before another drain adopts it.
+ *
+ * Four missed beats: long enough that a stalled event loop does not hand a live claim
+ * away, short enough that records are not stranded for long when a process is killed.
+ */
+const STALE_CLAIM_MS = 4 * HEARTBEAT_MS
+
+/**
+ * The same, for the shared `.draining` file older builds used.
+ *
+ * They do not beat, so their mtime says nothing about liveness and only a duration long
+ * enough to outlast a real drain is safe. This exists for the length of an upgrade and
+ * costs nothing afterwards, since nothing writes that file any more.
+ */
+const LEGACY_DRAINING_GRACE_MS = 10 * 60_000
 
 /** Refuse to parse a spool larger than this — it is runaway, not a backlog. */
 const MAX_SPOOL_BYTES = 8 * 1024 * 1024
@@ -223,15 +240,42 @@ function takeOver(file: string): string | null {
   }
 }
 
+/** Stamp the files a drain owns, so no one mistakes them for abandoned. */
+function beat(files: string[]): void {
+  const now = new Date()
+  for (const file of files) {
+    try {
+      fs.utimesSync(file, now, now)
+    } catch {
+      // Already gone, or unwritable. The drain still holds the records in memory; only
+      // the crash-recovery copy is affected, and there is nothing useful to do here.
+    }
+  }
+}
+
+/**
+ * May this abandoned-looking file be taken over?
+ *
+ * A drain holds its working files until its last record reaches the network, so a claim
+ * being old is not evidence that it was abandoned — deciding on age alone would let one
+ * build steal a live claim and record the same runs twice, the very duplication this
+ * module exists to prevent. What makes age meaningful is the heartbeat: a drain in
+ * progress stamps its files, so an unstamped one really has no owner left.
+ *
+ * The legacy `.draining` file predates the heartbeat and never gets stamped, so it falls
+ * back to a cutoff long enough to outlast any real drain by an older build.
+ */
+function isAdoptable(entry: string, mtimeMs: number): boolean {
+  const grace = entry.startsWith(CLAIMING_PREFIX) ? STALE_CLAIM_MS : LEGACY_DRAINING_GRACE_MS
+  return mtimeMs <= Date.now() - grace
+}
+
 /**
  * Take over the working files of drains that died, oldest first.
  *
  * Two kinds end up here: a `.claiming.` file whose process was killed after the rename,
  * and the `.draining` file an older build left behind. Both are adopted the same way —
  * by renaming them, so two apps sweeping at once cannot both win the same file.
- *
- * Only claims untouched for STALE_CLAIM_MS are taken: a live claim is milliseconds old,
- * and stealing one would record its runs twice. Late is the safer error here.
  */
 function adoptAbandoned(): string[] {
   let entries: string[]
@@ -241,7 +285,6 @@ function adoptAbandoned(): string[] {
     return [] // No config dir yet: there is nothing to adopt.
   }
 
-  const cutoff = Date.now() - STALE_CLAIM_MS
   const adopted: string[] = []
 
   for (const entry of entries.sort()) {
@@ -251,7 +294,7 @@ function adoptAbandoned(): string[] {
 
     const orphan = path.join(STABLE_CONFIG_DIR, entry)
     try {
-      if (fs.statSync(orphan).mtimeMs > cutoff) continue
+      if (!isAdoptable(entry, fs.statSync(orphan).mtimeMs)) continue
       const claimed = takeOver(orphan)
       if (!claimed) continue
       adopted.push(claimed)
@@ -325,28 +368,39 @@ export function drainSkillSpool(): Promise<number> {
       return 0
     }
 
-    for (const run of runs) {
-      // The hook writes an empty string when MAGIC_SLASH_TERMINAL_ID is unset.
-      const agentId = run.agentId || undefined
+    // Says "still working" for as long as this takes. Every record below is a network
+    // round-trip, so a real drain can outlast any fixed cutoff — the beat is what keeps
+    // another build from reading the silence as an abandoned claim and recording these
+    // runs a second time. unref'd so it can never hold the process open at quit.
+    const heartbeat = setInterval(() => beat(files), HEARTBEAT_MS)
+    heartbeat.unref?.()
 
-      // Sequential, not parallel: a run's close must be applied after its start, or
-      // close_skill_run finds no open run to attach to and the run stays abandoned.
-      // The file preserves that order; this loop must not undo it.
-      if (run.type === 'end') {
-        await closeSkillRun({
-          skill: run.skill,
-          agentId,
-          outcome: run.outcome!,
-          occurredAt: run.occurredAt!,
-        })
-      } else {
-        // Two hooks can see one typed command. Skipped BEFORE the write, not
-        // deduplicated after: the alternative is a row in the database that the
-        // rollups would count, and there is nothing downstream that could tell it
-        // apart from a real second run.
-        if (isDuplicateStart(run, run.occurredAt ?? Date.now())) continue
-        await recordSkillInvocation({ skill: run.skill, agentId, occurredAt: run.occurredAt })
+    try {
+      for (const run of runs) {
+        // The hook writes an empty string when MAGIC_SLASH_TERMINAL_ID is unset.
+        const agentId = run.agentId || undefined
+
+        // Sequential, not parallel: a run's close must be applied after its start, or
+        // close_skill_run finds no open run to attach to and the run stays abandoned.
+        // The file preserves that order; this loop must not undo it.
+        if (run.type === 'end') {
+          await closeSkillRun({
+            skill: run.skill,
+            agentId,
+            outcome: run.outcome!,
+            occurredAt: run.occurredAt!,
+          })
+        } else {
+          // Two hooks can see one typed command. Skipped BEFORE the write, not
+          // deduplicated after: the alternative is a row in the database that the
+          // rollups would count, and there is nothing downstream that could tell it
+          // apart from a real second run.
+          if (isDuplicateStart(run, run.occurredAt ?? Date.now())) continue
+          await recordSkillInvocation({ skill: run.skill, agentId, occurredAt: run.occurredAt })
+        }
       }
+    } finally {
+      clearInterval(heartbeat)
     }
 
     // Last, and only now: until every record has been handed over, these files are the

--- a/desktop/src/main/usage/skill-spool.ts
+++ b/desktop/src/main/usage/skill-spool.ts
@@ -31,16 +31,21 @@ import { closeSkillRun, recordSkillInvocation } from './skill-invocations'
  * picked up by the next drain. rename(2) is atomic within a filesystem, so no record is
  * ever visible in both files or in neither.
  *
- * The target is unique per claim rather than DRAINING_FILE itself. Two apps may drain at
- * once (the installed build and a dev one share this spool by design — see paths.ts) and
- * a fixed name would let the second rename land on top of the first one's claim, erasing
- * records it had claimed but not yet recorded.
+ * The target is unique per claim, and NO file is shared between drains. Two apps may
+ * drain at once — the installed build and a dev one share this spool by design, see
+ * paths.ts — so any file both could read is a file both could record, and one run would
+ * become two rows. Every file a drain touches is therefore one it renamed into its own
+ * name: the losers of that rename get ENOENT and drain nothing, which is the correct
+ * outcome. A drain that dies leaves its working file behind for adoptAbandoned.
  */
 
 // STABLE_CONFIG_DIR, never the dev-suffixed one: the producing hook lives in
 // ~/.claude/settings.json with this path baked in, shared by every build.
 const SPOOL_FILE = path.join(STABLE_CONFIG_DIR, 'pending-skills.ndjson')
-/** Where a drain moves the spool to work on it, out of the hook's way. */
+/**
+ * The shared working file older builds drained into. Kept only so an upgrade adopts
+ * whatever one of them left behind; nothing writes it any more.
+ */
 const DRAINING_FILE = `${SPOOL_FILE}.draining`
 /** Prefix of the short-lived file a drain renames the spool onto — see claim(). */
 const CLAIMING_PREFIX = `${path.basename(SPOOL_FILE)}.claiming.`
@@ -187,90 +192,113 @@ function parse(line: string): SpooledRun | null {
   }
 }
 
-/**
- * Fold abandoned `.claiming.` files back into DRAINING_FILE.
- *
- * The rename in claim() is atomic, but the copy that follows it is not instantaneous: a
- * process killed in between leaves a file nothing else knows to look at. Only claims
- * older than STALE_CLAIM_MS are adopted, so a drain running right now in another app is
- * never robbed of records it is about to write.
- */
-function adoptStaleClaims(): void {
-  let entries: string[]
-  try {
-    entries = fs.readdirSync(STABLE_CONFIG_DIR)
-  } catch {
-    return // No config dir yet: there is nothing to adopt.
-  }
+let claimCounter = 0
 
-  const cutoff = Date.now() - STALE_CLAIM_MS
-  for (const entry of entries) {
-    if (!entry.startsWith(CLAIMING_PREFIX)) continue
-    const orphan = path.join(STABLE_CONFIG_DIR, entry)
-    try {
-      if (fs.statSync(orphan).mtimeMs > cutoff) continue
-      fs.appendFileSync(DRAINING_FILE, fs.readFileSync(orphan, 'utf-8'), {
-        encoding: 'utf-8',
-        mode: 0o600,
-      })
-      fs.rmSync(orphan, { force: true })
-      console.warn(`[skill-spool] Adopted an abandoned claim: ${entry}`)
-    } catch (error) {
-      console.error('[skill-spool] Failed to adopt an abandoned claim:', error)
+/** A working-file name no other drain can be using, in this process or another. */
+function newClaimPath(): string {
+  return `${SPOOL_FILE}.claiming.${process.pid}.${Date.now()}.${claimCounter++}`
+}
+
+/**
+ * Take ownership of `file` by renaming it to a private working path.
+ *
+ * rename(2) is atomic and fails if the source is gone, so of any number of processes
+ * racing for the same file exactly one wins — the losers get ENOENT and simply have
+ * nothing to drain. Returns the path now owned, or null if someone else took it first.
+ */
+function takeOver(file: string): string | null {
+  try {
+    if (!fs.existsSync(file)) return null
+    if (fs.statSync(file).size > MAX_SPOOL_BYTES) {
+      console.warn(`[skill-spool] ${file} is oversized, discarding it`)
+      fs.rmSync(file, { force: true })
+      return null
     }
+    const claimed = newClaimPath()
+    fs.renameSync(file, claimed)
+    return claimed
+  } catch (error) {
+    console.error('[skill-spool] Failed to claim the spool:', error)
+    return null
   }
 }
 
 /**
- * Claim the current spool, if any, by moving it aside. Returns the records it held.
+ * Take over the working files of drains that died, oldest first.
  *
- * A leftover `.draining` file means a previous drain died midway (the app was killed
- * between the rename and the last record). Its contents are prepended so those runs
- * are retried rather than stranded — a replay is harmless because recordSkillInvocation
- * mints an idempotence key per attempt and the outbox is what guards against loss,
- * not against a second attempt at a row that never landed.
+ * Two kinds end up here: a `.claiming.` file whose process was killed after the rename,
+ * and the `.draining` file an older build left behind. Both are adopted the same way —
+ * by renaming them, so two apps sweeping at once cannot both win the same file.
+ *
+ * Only claims untouched for STALE_CLAIM_MS are taken: a live claim is milliseconds old,
+ * and stealing one would record its runs twice. Late is the safer error here.
  */
-function claim(): SpooledRun[] {
-  const lines: string[] = []
+function adoptAbandoned(): string[] {
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(STABLE_CONFIG_DIR)
+  } catch {
+    return [] // No config dir yet: there is nothing to adopt.
+  }
 
-  adoptStaleClaims()
+  const cutoff = Date.now() - STALE_CLAIM_MS
+  const adopted: string[] = []
 
-  for (const file of [DRAINING_FILE, SPOOL_FILE]) {
+  for (const entry of entries.sort()) {
+    const isClaim = entry.startsWith(CLAIMING_PREFIX)
+    const isLegacyDraining = entry === path.basename(DRAINING_FILE)
+    if (!isClaim && !isLegacyDraining) continue
+
+    const orphan = path.join(STABLE_CONFIG_DIR, entry)
     try {
-      if (!fs.existsSync(file)) continue
-      if (fs.statSync(file).size > MAX_SPOOL_BYTES) {
-        console.warn(`[skill-spool] ${file} is oversized, discarding it`)
-        fs.rmSync(file, { force: true })
-        continue
-      }
-      if (file === SPOOL_FILE) {
-        // The claim itself, and the only atomic step that matters: after this rename
-        // the hook's appends recreate SPOOL_FILE and are drained next time, while
-        // nothing can still be written to what we just took. Reading first and deleting
-        // after would silently discard everything appended in between.
-        const claimed = `${SPOOL_FILE}.claiming.${process.pid}.${Date.now()}`
-        fs.renameSync(file, claimed)
-
-        // Copied to DRAINING_FILE before the working file goes away, so a crash between
-        // here and the last record leaves the runs somewhere a later drain will look.
-        // Appended rather than replacing it: a leftover from a previous crash is still
-        // pending and must not be overwritten.
-        const pending = fs.readFileSync(claimed, 'utf-8')
-        fs.appendFileSync(DRAINING_FILE, pending, { encoding: 'utf-8', mode: 0o600 })
-        fs.rmSync(claimed, { force: true })
-        lines.push(...pending.split('\n'))
-      } else {
-        lines.push(...fs.readFileSync(file, 'utf-8').split('\n'))
-      }
-    } catch (error) {
-      console.error('[skill-spool] Failed to claim the spool:', error)
+      if (fs.statSync(orphan).mtimeMs > cutoff) continue
+      const claimed = takeOver(orphan)
+      if (!claimed) continue
+      adopted.push(claimed)
+      console.warn(`[skill-spool] Adopted an abandoned claim: ${entry}`)
+    } catch {
+      // Gone between readdir and stat — another drain got there first. Nothing to do.
     }
   }
 
-  return lines
+  return adopted
+}
+
+/**
+ * Claim everything there is to drain. Returns the records and the files holding them.
+ *
+ * Every file this returns is owned by this drain alone: it was renamed into a private
+ * path, so no hook can still append to it and no other app can read it. That is the
+ * whole design — there is no shared mutable file left. A drain that dies leaves its
+ * working files behind, and adoptAbandoned hands them to a later one rather than
+ * letting the runs strand.
+ *
+ * The caller deletes the files once every record has been handed over, not before: they
+ * are the only copy while the drain is in flight.
+ */
+function claim(): { runs: SpooledRun[]; files: string[] } {
+  // Abandoned work first, so older runs are recorded before newer ones — closeSkillRun
+  // needs a run's start to land before its end.
+  const files = adoptAbandoned()
+
+  const fresh = takeOver(SPOOL_FILE)
+  if (fresh) files.push(fresh)
+
+  const lines: string[] = []
+  for (const file of files) {
+    try {
+      lines.push(...fs.readFileSync(file, 'utf-8').split('\n'))
+    } catch (error) {
+      console.error('[skill-spool] Failed to read a claimed file:', error)
+    }
+  }
+
+  const runs = lines
     .filter((line) => line.trim() !== '')
     .map(parse)
     .filter((run): run is SpooledRun => run !== null)
+
+  return { runs, files }
 }
 
 let draining: Promise<number> | null = null
@@ -290,8 +318,12 @@ export function drainSkillSpool(): Promise<number> {
   if (draining) return draining
 
   draining = (async () => {
-    const runs = claim()
-    if (runs.length === 0) return 0
+    const { runs, files } = claim()
+    if (runs.length === 0) {
+      // Empty, but the files are ours and nothing else will ever look at them.
+      for (const file of files) fs.rmSync(file, { force: true })
+      return 0
+    }
 
     for (const run of runs) {
       // The hook writes an empty string when MAGIC_SLASH_TERMINAL_ID is unset.
@@ -317,7 +349,9 @@ export function drainSkillSpool(): Promise<number> {
       }
     }
 
-    fs.rmSync(DRAINING_FILE, { force: true })
+    // Last, and only now: until every record has been handed over, these files are the
+    // only copy of the runs they hold.
+    for (const file of files) fs.rmSync(file, { force: true })
     console.log(`[skill-spool] Recorded ${runs.length} spooled skill run(s)`)
     return runs.length
   })()

--- a/desktop/src/main/usage/skill-spool.ts
+++ b/desktop/src/main/usage/skill-spool.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs'
-import * as os from 'os'
 import * as path from 'path'
+import { STABLE_CONFIG_DIR } from '../config/paths'
 import type { SkillRunOutcome } from '../../types'
 import { closeSkillRun, recordSkillInvocation } from './skill-invocations'
 
@@ -31,8 +31,9 @@ import { closeSkillRun, recordSkillInvocation } from './skill-invocations'
  * is ever visible in both files or in neither.
  */
 
-const CONFIG_DIR = path.join(os.homedir(), '.config', 'magic-slash')
-const SPOOL_FILE = path.join(CONFIG_DIR, 'pending-skills.ndjson')
+// STABLE_CONFIG_DIR, never the dev-suffixed one: the producing hook lives in
+// ~/.claude/settings.json with this path baked in, shared by every build.
+const SPOOL_FILE = path.join(STABLE_CONFIG_DIR, 'pending-skills.ndjson')
 /** Where a drain moves the spool to work on it, out of the hook's way. */
 const DRAINING_FILE = `${SPOOL_FILE}.draining`
 

--- a/desktop/src/main/usage/skill-spool.ts
+++ b/desktop/src/main/usage/skill-spool.ts
@@ -22,13 +22,19 @@ import { closeSkillRun, recordSkillInvocation } from './skill-invocations'
  * both belong. What it DOES own is telling one run seen twice from two runs — see
  * isDuplicateStart.
  *
- * WHY IT READS THE FILE BEFORE DELETING IT
+ * WHY IT RENAMES THE FILE BEFORE READING IT
  * ---------------------------------------------------------------------------
- * The hook appends concurrently, from any number of Claude Code sessions. Reading
- * then truncating would drop whatever landed in between, so the file is RENAMED to a
- * private working copy first: appends after the rename recreate the original and are
- * picked up by the next drain. rename(2) is atomic within a filesystem, so no record
- * is ever visible in both files or in neither.
+ * The hook appends concurrently, from any number of Claude Code sessions — and since
+ * every producer is a separate process, that is true of a single app instance too.
+ * Reading and then deleting would drop whatever landed in between, so the file is
+ * RENAMED out of the way first: appends after the rename recreate the original and are
+ * picked up by the next drain. rename(2) is atomic within a filesystem, so no record is
+ * ever visible in both files or in neither.
+ *
+ * The target is unique per claim rather than DRAINING_FILE itself. Two apps may drain at
+ * once (the installed build and a dev one share this spool by design — see paths.ts) and
+ * a fixed name would let the second rename land on top of the first one's claim, erasing
+ * records it had claimed but not yet recorded.
  */
 
 // STABLE_CONFIG_DIR, never the dev-suffixed one: the producing hook lives in
@@ -36,6 +42,18 @@ import { closeSkillRun, recordSkillInvocation } from './skill-invocations'
 const SPOOL_FILE = path.join(STABLE_CONFIG_DIR, 'pending-skills.ndjson')
 /** Where a drain moves the spool to work on it, out of the hook's way. */
 const DRAINING_FILE = `${SPOOL_FILE}.draining`
+/** Prefix of the short-lived file a drain renames the spool onto — see claim(). */
+const CLAIMING_PREFIX = `${path.basename(SPOOL_FILE)}.claiming.`
+
+/**
+ * How long a `.claiming.` file must sit untouched before another drain adopts it.
+ *
+ * A live claim exists for the duration of a rename, a read and an append — microseconds,
+ * with no await in between. Anything older than this is the debris of a process that died
+ * mid-claim, and adopting it is the only way its records are ever seen again. Generous on
+ * purpose: adopting a claim that is merely slow would double-count it.
+ */
+const STALE_CLAIM_MS = 60_000
 
 /** Refuse to parse a spool larger than this — it is runaway, not a backlog. */
 const MAX_SPOOL_BYTES = 8 * 1024 * 1024
@@ -170,6 +188,40 @@ function parse(line: string): SpooledRun | null {
 }
 
 /**
+ * Fold abandoned `.claiming.` files back into DRAINING_FILE.
+ *
+ * The rename in claim() is atomic, but the copy that follows it is not instantaneous: a
+ * process killed in between leaves a file nothing else knows to look at. Only claims
+ * older than STALE_CLAIM_MS are adopted, so a drain running right now in another app is
+ * never robbed of records it is about to write.
+ */
+function adoptStaleClaims(): void {
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(STABLE_CONFIG_DIR)
+  } catch {
+    return // No config dir yet: there is nothing to adopt.
+  }
+
+  const cutoff = Date.now() - STALE_CLAIM_MS
+  for (const entry of entries) {
+    if (!entry.startsWith(CLAIMING_PREFIX)) continue
+    const orphan = path.join(STABLE_CONFIG_DIR, entry)
+    try {
+      if (fs.statSync(orphan).mtimeMs > cutoff) continue
+      fs.appendFileSync(DRAINING_FILE, fs.readFileSync(orphan, 'utf-8'), {
+        encoding: 'utf-8',
+        mode: 0o600,
+      })
+      fs.rmSync(orphan, { force: true })
+      console.warn(`[skill-spool] Adopted an abandoned claim: ${entry}`)
+    } catch (error) {
+      console.error('[skill-spool] Failed to adopt an abandoned claim:', error)
+    }
+  }
+}
+
+/**
  * Claim the current spool, if any, by moving it aside. Returns the records it held.
  *
  * A leftover `.draining` file means a previous drain died midway (the app was killed
@@ -181,6 +233,8 @@ function parse(line: string): SpooledRun | null {
 function claim(): SpooledRun[] {
   const lines: string[] = []
 
+  adoptStaleClaims()
+
   for (const file of [DRAINING_FILE, SPOOL_FILE]) {
     try {
       if (!fs.existsSync(file)) continue
@@ -190,12 +244,20 @@ function claim(): SpooledRun[] {
         continue
       }
       if (file === SPOOL_FILE) {
-        // Atomic hand-off: concurrent hooks recreate SPOOL_FILE and are drained next
-        // time. Appended to DRAINING_FILE rather than replacing it, so a leftover
-        // from a previous crash is not overwritten.
-        const pending = fs.readFileSync(file, 'utf-8')
+        // The claim itself, and the only atomic step that matters: after this rename
+        // the hook's appends recreate SPOOL_FILE and are drained next time, while
+        // nothing can still be written to what we just took. Reading first and deleting
+        // after would silently discard everything appended in between.
+        const claimed = `${SPOOL_FILE}.claiming.${process.pid}.${Date.now()}`
+        fs.renameSync(file, claimed)
+
+        // Copied to DRAINING_FILE before the working file goes away, so a crash between
+        // here and the last record leaves the runs somewhere a later drain will look.
+        // Appended rather than replacing it: a leftover from a previous crash is still
+        // pending and must not be overwritten.
+        const pending = fs.readFileSync(claimed, 'utf-8')
         fs.appendFileSync(DRAINING_FILE, pending, { encoding: 'utf-8', mode: 0o600 })
-        fs.rmSync(file, { force: true })
+        fs.rmSync(claimed, { force: true })
         lines.push(...pending.split('\n'))
       } else {
         lines.push(...fs.readFileSync(file, 'utf-8').split('\n'))

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -208,7 +208,12 @@ the world when it ran.)
   `(org_id, owner_id) → memberships` FK leaves behind when a member is removed —
   so an ex-member's agents stay cleanable and adoptable. The desktop app mirrors
   this on read: `loadAgents()` (local terminal restoration) filters on
-  `owner_id`, and only `loadOrgAgents()` spans members.
+  `owner_id`, and only `loadOrgAgents()` spans members. An agent's identity is
+  `app_agent_id` — the desktop's own `claude-<epoch>` id, unique per owner and the
+  key every agent upsert conflicts on, so a second app instance cannot mint a
+  second row for one agent. Archiving releases it (the column goes null with
+  `archived_at`), which is what lets a reused app id start a new row instead of
+  resurrecting a closed one.
 - Both user-scoped tables added for settings reference `auth.users` with
   `ON DELETE CASCADE`, so `delete_account()` removes them with the user row — no
   change to that RPC was needed.

--- a/supabase/migrations/20260814090000_agents_app_agent_id.sql
+++ b/supabase/migrations/20260814090000_agents_app_agent_id.sql
@@ -1,0 +1,185 @@
+-- Migration: the app's own agent id becomes the agent's identity in the database
+--
+-- THE BUG
+-- ---------------------------------------------------------------------------
+-- The same agent appears several times in `agents`, and on the Team page as
+-- several people's worth of work. Every duplicate carries the same app-level id
+-- inside its metadata — `metadata->'__app'->>'id'`, the `claude-<epoch>` string
+-- the desktop mints when a terminal is created — under a different uuid primary
+-- key.
+--
+-- Nothing in the database said those rows were the same agent. The binding from
+-- an app id to a row uuid lived in ONE process's memory (CloudStore.agentIdMap),
+-- rebuilt on each hydration and consulted on each write:
+--
+--     const uuid = this.agentIdMap.get(a.id) ?? randomUUID()
+--     …upsert(rows, { onConflict: 'id' })
+--
+-- A cache miss therefore did not mean "this agent is new". It meant "this
+-- process has not looked yet" — and it minted a brand-new identity for an agent
+-- that already had one. Two ordinary situations produce the miss:
+--
+--   * two app instances (a second window, a relaunch before the first quit)
+--     write the same roster; each has its own map, and the one that never
+--     hydrated invents uuids for agents the other created;
+--   * a single instance, mid-hydration: loadAgents() cleared the map BEFORE
+--     awaiting its query, so any write landing inside that window re-minted the
+--     WHOLE roster.
+--
+-- Each invented uuid is a new row, and `on conflict (id)` cannot object: the key
+-- it arbitrates on is the one that was just made up.
+--
+-- THE FIX
+-- ---------------------------------------------------------------------------
+-- The app id descends into the database as a column, gets a unique index per
+-- owner, and becomes what the upsert arbitrates on. Identity stops being a
+-- process's recollection and becomes a constraint: whatever any client believes,
+-- a second row for an app id it already owns cannot be inserted. The client
+-- change is the natural consequence — it stops sending `id` at all, so the
+-- primary key keeps its value on update and its `gen_random_uuid()` default on
+-- insert, and the database is the only thing that ever mints one.
+--
+-- Why not make the app id the primary key outright: every event table references
+-- agents through a composite `(org_id, agent_id)` foreign key, the webapp and the
+-- Realtime feed key on the uuid, and `agent_repositories` has it in its own
+-- primary key. Repointing all of that would be a rewrite of the schema to fix a
+-- write path. The uuid stays the surrogate key; the app id becomes the NATURAL
+-- key beside it, which is the only thing the duplicates ever needed.
+--
+-- Why not a partial index on the active rows, which is what the invariant really
+-- is: PostgREST cannot express an index predicate in `on_conflict`, so an upsert
+-- could not infer it. The index is total, and the invariant "an archived row
+-- holds no app id" is maintained by the writers instead (see below).
+
+-- ---------------------------------------------------------------------------
+-- The column, backfilled from the jsonb it has been hiding in
+-- ---------------------------------------------------------------------------
+-- Text, not uuid: `claude-1754923118423` is a client-minted string and always
+-- has been. Nullable, because a row that is not the desktop's — an agent created
+-- by anything else, or by a test — has no app id, and null keys are distinct in
+-- a unique index, so any number of them coexist.
+alter table public.agents add column if not exists app_agent_id text;
+
+-- ARCHIVED ROWS ARE LEFT NULL, deliberately. App ids are `claude-${Date.now()}`
+-- and closing an agent does not retire its id: the desktop is free to reuse one,
+-- and a closed agent must not win the conflict arbitration against the live agent
+-- that reuses it — resurrecting a row the user closed, invisible because
+-- `archived_at` stays set. "Only a live agent holds an app id" is the invariant
+-- that makes the total index safe, and it starts here.
+update public.agents
+   set app_agent_id = metadata->'__app'->>'id'
+ where archived_at is null
+   and app_agent_id is null
+   and metadata->'__app'->>'id' is not null;
+
+-- ---------------------------------------------------------------------------
+-- Fold the duplicates the missing constraint let in
+-- ---------------------------------------------------------------------------
+-- The OLDEST row of each group is the keeper, because it is the one the history
+-- points at: the duplicates were minted later by processes that had lost the
+-- binding, so the events, the usage and the skill runs of the first sessions all
+-- reference the first row. Keeping the newest would mean moving the most data and
+-- archiving the row every existing reference agrees on.
+--
+-- The losers are archived, not deleted: whatever DID accumulate under them stays
+-- reachable through the keeper, and a soft delete is the same thing closing an
+-- agent does (20260727140000). Their app_agent_id is released in the same
+-- statement, per the invariant above.
+--
+-- Note what the repointing must move: the event tables' foreign key is composite,
+-- `(org_id, agent_id) → agents (org_id, id)`, and two duplicates of one agent can
+-- perfectly well have derived DIFFERENT organizations (the derivation reads their
+-- own repository links, and the duplicates rarely have the same ones). So both
+-- columns move together, to the keeper's pair — updating agent_id alone would
+-- point the row at an agent of another org and the constraint would reject it.
+do $$
+declare
+  dup   record;
+  loser record;
+  keep_org uuid;
+begin
+  for dup in
+    select owner_id,
+           app_agent_id,
+           -- created_at ties are broken by id so the choice is deterministic and
+           -- the run is repeatable.
+           (array_agg(id order by created_at, id))[1] as keep_id
+      from public.agents
+     where archived_at is null
+       and owner_id is not null
+       and app_agent_id is not null
+     group by owner_id, app_agent_id
+    having count(*) > 1
+  loop
+    for loser in
+      select id
+        from public.agents
+       where owner_id = dup.owner_id
+         and app_agent_id = dup.app_agent_id
+         and archived_at is null
+         and id <> dup.keep_id
+    loop
+      -- The repository links first: they are what the keeper's organization is
+      -- derived from, so moving them before the events means the events land on
+      -- an org that is already final. created_at travels with the row because
+      -- attachment order is what picks the org among several.
+      --
+      -- `on conflict do nothing` — the primary key is (agent_id, repo_id), and
+      -- two duplicates of one agent usually resolve to the SAME repositories, so
+      -- most of these links already exist on the keeper. What cannot be moved is
+      -- then deleted rather than left behind: the loser is being archived, and a
+      -- link would keep re-deriving an organization for a row nobody works in.
+      insert into public.agent_repositories (agent_id, repo_id, created_at)
+      select dup.keep_id, ar.repo_id, ar.created_at
+        from public.agent_repositories ar
+       where ar.agent_id = loser.id
+      on conflict do nothing;
+
+      delete from public.agent_repositories where agent_id = loser.id;
+
+      -- Read AFTER the links moved: the insert above fires derive_agent_org and
+      -- may have just given the keeper an organization it did not have.
+      select org_id into keep_org from public.agents where id = dup.keep_id;
+
+      update public.usage_events
+         set org_id = keep_org, agent_id = dup.keep_id
+       where agent_id = loser.id;
+
+      update public.activity_events
+         set org_id = keep_org, agent_id = dup.keep_id
+       where agent_id = loser.id;
+
+      update public.skill_invocations
+         set org_id = keep_org, agent_id = dup.keep_id
+       where agent_id = loser.id;
+
+      update public.agents
+         set archived_at = now(), app_agent_id = null
+       where id = loser.id;
+    end loop;
+  end loop;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- The constraint that makes the duplicate unrepresentable
+-- ---------------------------------------------------------------------------
+-- Per OWNER, not per organization: an agent belongs to its owner, and its org is
+-- derived from its repositories (20260727160000) — it can be null, it can change
+-- under the agent's feet, and it is emphatically not part of who the agent is.
+-- The owner is the scope the app writes in and the scope RLS enforces.
+--
+-- Total, not partial, because `on_conflict=owner_id,app_agent_id` in PostgREST
+-- infers the index from the column list alone and cannot carry a `where`. Rows
+-- outside the invariant are excluded by their nulls instead: archived rows hold
+-- no app id, and a row whose owner_id was nulled by the membership foreign key
+-- has no owner to be unique within.
+create unique index if not exists uq_agents_owner_app_agent_id
+  on public.agents (owner_id, app_agent_id);
+
+comment on column public.agents.app_agent_id is
+  'The desktop app''s own agent id (`claude-<epoch>`) — the NATURAL key an upsert '
+  'arbitrates on, unique per owner. Null for a row no desktop created, and for '
+  'every archived row: closing an agent releases its app id so a later agent may '
+  'reuse it instead of resurrecting the closed one. Also mirrored in '
+  'metadata->''__app''->>''id'' for readers written before this column existed.';

--- a/supabase/tests/agents_app_agent_id.test.sql
+++ b/supabase/tests/agents_app_agent_id.test.sql
@@ -1,0 +1,269 @@
+-- pgTAP: the app's agent id is the agent's identity, and duplicates are refused.
+--
+-- Covers 20260814090000_agents_app_agent_id.sql: the `app_agent_id` column, the
+-- unique index over (owner_id, app_agent_id), and the one-shot dedup that folded
+-- the rows the missing constraint had let in.
+--
+-- No `set role authenticated` anywhere: nothing here is about RLS. What is under
+-- test is a constraint, which holds for every writer including the ones that
+-- bypass policies — that is the entire point of moving the identity out of a
+-- client's memory and into the schema.
+--
+-- The dedup half is a TRANSCRIPTION of the migration's do-block, deliberately.
+-- A data migration runs once, inside a transaction that is long gone, so the only
+-- way to assert on its behaviour is to rebuild the state it met and replay it.
+-- The index is dropped first — the duplicates it now forbids are exactly the ones
+-- the block existed to remove — and recreated at the end, which is itself the
+-- assertion that the dedup left the table indexable. Keep the two in step: a
+-- change to the migration's block belongs here too.
+
+begin;
+select plan(12);
+
+-- ---------------------------------------------------------------------------
+-- Seed. Two orgs, u1 in both, u2 in org A. Two repos owned by u1: one in org B,
+-- one personal — the pair the dedup needs to show that two duplicates of one agent
+-- can derive different organizations.
+-- ---------------------------------------------------------------------------
+insert into auth.users (instance_id, id, aud, role, email, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-000000000000', '11111111-1111-1111-1111-111111111111', 'authenticated', 'authenticated', 'u1@example.com', now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '22222222-2222-2222-2222-222222222222', 'authenticated', 'authenticated', 'u2@example.com', now(), now());
+
+insert into public.organizations (id, name, created_by)
+values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Org A', '11111111-1111-1111-1111-111111111111'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Org B', '11111111-1111-1111-1111-111111111111');
+
+insert into public.memberships (org_id, user_id, role)
+values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', 'admin'),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', 'user'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', 'admin');
+
+insert into public.repositories (id, owner_id, org_id, name)
+values
+  ('c0000000-0000-0000-0000-00000000000b', '11111111-1111-1111-1111-111111111111', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'repo-b'),
+  ('c0000000-0000-0000-0000-0000000000cc', '11111111-1111-1111-1111-111111111111', null,                                   'repo-perso');
+
+-- ---------------------------------------------------------------------------
+-- The constraint: one live row per (owner, app id)
+-- ---------------------------------------------------------------------------
+insert into public.agents (id, org_id, owner_id, name, app_agent_id)
+values ('a0000000-0000-0000-0000-000000000001', null, '11111111-1111-1111-1111-111111111111', 'Agent', 'claude-1');
+
+-- 1. The bug, made unrepresentable: a second process writing the same agent no
+--    longer creates a second row, whatever its own id map believes.
+select throws_ok(
+  $$insert into public.agents (id, org_id, owner_id, name, app_agent_id)
+    values ('a0000000-0000-0000-0000-000000000002', null, '11111111-1111-1111-1111-111111111111', 'Agent', 'claude-1')$$,
+  '23505',
+  null,
+  'a second live row for one app id is refused'
+);
+
+-- 2. The app id is scoped to its OWNER, not to the product: two people whose
+--    apps both minted `claude-1` in the same millisecond are unrelated agents.
+select lives_ok(
+  $$insert into public.agents (id, org_id, owner_id, name, app_agent_id)
+    values ('a0000000-0000-0000-0000-000000000003', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', 'Agent', 'claude-1')$$,
+  'another owner may hold the same app id'
+);
+
+-- 3. Closing an agent releases its app id (archiveAgent nulls both columns
+--    together), so the id becomes free again — app ids are `claude-${Date.now()}`
+--    and the desktop is entitled to reuse one.
+update public.agents
+   set archived_at = now(), app_agent_id = null
+ where id = 'a0000000-0000-0000-0000-000000000001';
+
+select lives_ok(
+  $$insert into public.agents (id, org_id, owner_id, name, app_agent_id)
+    values ('a0000000-0000-0000-0000-000000000004', null, '11111111-1111-1111-1111-111111111111', 'Agent again', 'claude-1')$$,
+  'an app id reused after archiving is accepted as a new row'
+);
+
+-- 4. …and it is a NEW row: the closed agent stays closed rather than being
+--    resurrected by the write that reused its id.
+select is(
+  (select count(*) from public.agents
+    where owner_id = '11111111-1111-1111-1111-111111111111' and archived_at is null and app_agent_id = 'claude-1'),
+  1::bigint,
+  'reusing an app id leaves exactly one live agent holding it'
+);
+
+-- 5. Any number of archived rows may have carried the same app id. This is why
+--    archiving nulls the column rather than relying on a partial index: the index
+--    has to be total (PostgREST cannot infer a predicate in on_conflict), and
+--    null keys are what keeps closed agents out of its way.
+update public.agents
+   set archived_at = now(), app_agent_id = null
+ where id = 'a0000000-0000-0000-0000-000000000004';
+
+select lives_ok(
+  $$insert into public.agents (id, org_id, owner_id, name, app_agent_id, archived_at)
+    values ('a0000000-0000-0000-0000-000000000005', null, '11111111-1111-1111-1111-111111111111', 'Third', null, now())$$,
+  'two closed agents that both carried one app id coexist'
+);
+
+-- ---------------------------------------------------------------------------
+-- The dedup: the oldest row wins, and it wins the history with it
+-- ---------------------------------------------------------------------------
+-- Rebuild what the migration met: three rows for one app id, the id living only
+-- in the jsonb, and the duplicates carrying DIFFERENT derived organizations —
+-- which is the ordinary case, since each duplicate resolved its own repository
+-- links.
+drop index public.uq_agents_owner_app_agent_id;
+
+insert into public.agents (id, org_id, owner_id, name, metadata, created_at)
+values
+  ('d0000000-0000-0000-0000-000000000001', null, '11111111-1111-1111-1111-111111111111', 'Keeper',
+   '{"__app": {"id": "claude-dup"}}'::jsonb, '2026-01-01 10:00:00+00'),
+  ('d0000000-0000-0000-0000-000000000002', null, '11111111-1111-1111-1111-111111111111', 'Loser 1',
+   '{"__app": {"id": "claude-dup"}}'::jsonb, '2026-01-02 10:00:00+00'),
+  ('d0000000-0000-0000-0000-000000000003', null, '11111111-1111-1111-1111-111111111111', 'Loser 2',
+   '{"__app": {"id": "claude-dup"}}'::jsonb, '2026-01-03 10:00:00+00');
+
+-- The keeper works on a personal repo (org null); the first loser on a team repo,
+-- which derives org B onto it. The events' composite FK is (org_id, agent_id), so
+-- repointing has to move both columns at once — moving agent_id alone would point
+-- the row at an agent of another organization.
+-- Explicit stamps, because attachment order is what decides the derived org and
+-- one statement's rows would otherwise share a single now().
+insert into public.agent_repositories (agent_id, repo_id, created_at)
+values
+  ('d0000000-0000-0000-0000-000000000001', 'c0000000-0000-0000-0000-0000000000cc', '2026-01-01 11:00:00+00'),
+  ('d0000000-0000-0000-0000-000000000002', 'c0000000-0000-0000-0000-00000000000b', '2026-01-02 11:00:00+00');
+
+-- One event per row; org_id is stamped from the agent by trigger.
+insert into public.activity_events (id, org_id, user_id, agent_id, action)
+values
+  ('e0000000-0000-0000-0000-000000000001', null, '11111111-1111-1111-1111-111111111111',
+   'd0000000-0000-0000-0000-000000000001', 'agent_created'),
+  ('e0000000-0000-0000-0000-000000000002', null, '11111111-1111-1111-1111-111111111111',
+   'd0000000-0000-0000-0000-000000000002', 'pr_created');
+
+-- ── transcription of 20260814090000: backfill, then fold ────────────────────
+update public.agents
+   set app_agent_id = metadata->'__app'->>'id'
+ where archived_at is null
+   and app_agent_id is null
+   and metadata->'__app'->>'id' is not null;
+
+do $$
+declare
+  dup   record;
+  loser record;
+  keep_org uuid;
+begin
+  for dup in
+    select owner_id,
+           app_agent_id,
+           (array_agg(id order by created_at, id))[1] as keep_id
+      from public.agents
+     where archived_at is null
+       and owner_id is not null
+       and app_agent_id is not null
+     group by owner_id, app_agent_id
+    having count(*) > 1
+  loop
+    for loser in
+      select id
+        from public.agents
+       where owner_id = dup.owner_id
+         and app_agent_id = dup.app_agent_id
+         and archived_at is null
+         and id <> dup.keep_id
+    loop
+      insert into public.agent_repositories (agent_id, repo_id, created_at)
+      select dup.keep_id, ar.repo_id, ar.created_at
+        from public.agent_repositories ar
+       where ar.agent_id = loser.id
+      on conflict do nothing;
+
+      delete from public.agent_repositories where agent_id = loser.id;
+
+      select org_id into keep_org from public.agents where id = dup.keep_id;
+
+      update public.usage_events
+         set org_id = keep_org, agent_id = dup.keep_id
+       where agent_id = loser.id;
+
+      update public.activity_events
+         set org_id = keep_org, agent_id = dup.keep_id
+       where agent_id = loser.id;
+
+      update public.skill_invocations
+         set org_id = keep_org, agent_id = dup.keep_id
+       where agent_id = loser.id;
+
+      update public.agents
+         set archived_at = now(), app_agent_id = null
+       where id = loser.id;
+    end loop;
+  end loop;
+end;
+$$;
+
+-- 6. The oldest row survives — it is the one the history already points at.
+select is(
+  (select id from public.agents
+    where owner_id = '11111111-1111-1111-1111-111111111111'
+      and app_agent_id = 'claude-dup' and archived_at is null),
+  'd0000000-0000-0000-0000-000000000001'::uuid,
+  'the oldest row of a duplicate group is the one kept, and it holds the app id'
+);
+
+-- 7. The younger ones are archived, not deleted: whatever accumulated under them
+--    stays readable, and their app id is released so it cannot collide again.
+select is(
+  (select count(*) from public.agents
+    where id in ('d0000000-0000-0000-0000-000000000002', 'd0000000-0000-0000-0000-000000000003')
+      and archived_at is not null and app_agent_id is null),
+  2::bigint,
+  'every loser is archived with its app id released'
+);
+
+-- 8. The keeper's own events were never touched.
+select is(
+  (select agent_id from public.activity_events where id = 'e0000000-0000-0000-0000-000000000001'),
+  'd0000000-0000-0000-0000-000000000001'::uuid,
+  'the keeper keeps the events it already owned'
+);
+
+-- 9. The loser's event followed it — agent AND org together. The keeper inherited
+--    the team repo along the way, so its derived org is now B and the composite
+--    FK is satisfied by a pair that exists.
+select results_eq(
+  $sql$ select agent_id, org_id from public.activity_events
+         where id = 'e0000000-0000-0000-0000-000000000002' $sql$,
+  $sql$ values ('d0000000-0000-0000-0000-000000000001'::uuid, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid) $sql$,
+  'a loser''s event is repointed at the keeper with the keeper''s organization'
+);
+
+-- 10. The links merged rather than being dropped: the work the duplicate did on a
+--     repository is work the surviving agent did.
+select results_eq(
+  $sql$ select repo_id from public.agent_repositories
+         where agent_id = 'd0000000-0000-0000-0000-000000000001' order by created_at $sql$,
+  $sql$ values ('c0000000-0000-0000-0000-0000000000cc'::uuid), ('c0000000-0000-0000-0000-00000000000b'::uuid) $sql$,
+  'the losers'' repository links move to the keeper, in attachment order'
+);
+
+-- 11. …and none is left on an archived row, where it would keep re-deriving an
+--     organization for an agent nobody works in.
+select is(
+  (select count(*) from public.agent_repositories
+    where agent_id in ('d0000000-0000-0000-0000-000000000002', 'd0000000-0000-0000-0000-000000000003')),
+  0::bigint,
+  'no repository link is left pointing at an archived duplicate'
+);
+
+-- 12. The whole point of the fold: the table can now carry the constraint.
+select lives_ok(
+  $$create unique index uq_agents_owner_app_agent_id on public.agents (owner_id, app_agent_id)$$,
+  'the deduplicated table accepts the unique index'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Description

Agents were duplicating in the `agents` table: the same app-level id (`metadata->'__app'->>'id'`) ended up on several rows with different uuid PKs. The desktop UI hid it — `normalizeAgents()` dedupes by app id — so it only showed on the web app and in the database.

The row uuid was the client's to invent: `agentIdMap.get(a.id) ?? randomUUID()`, upserted `onConflict: 'id'`. Nothing in the schema tied a row to its app id, so any process with a cold map minted a second identity for an agent that already had one. Launching the dev build alongside the installed app is the reliable way to trigger it — a fresh process, an empty map, and `restoreAgents()` re-saving the whole roster.

This makes the app id the identity **in the database**, so a cold cache now self-heals instead of duplicating.

## Related Issue

Fixes #179

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **`app_agent_id` becomes the identity** (`20260814090000_agents_app_agent_id.sql`): new column backfilled from the jsonb for live rows only, a total `unique (owner_id, app_agent_id)` index, and a dedup that keeps the oldest row of each group, repoints `usage_events` / `activity_events` / `skill_invocations` (`org_id` and `agent_id` together — the FK is composite) and `agent_repositories`, then archives the losers with a null app id.
- **The client no longer sends `id`**: `toAgentRow()` omits it, so an update keeps the row's uuid and an insert takes `gen_random_uuid()`. The upsert arbitrates on `onConflict: 'owner_id,app_agent_id'` and `agentIdMap` is rebuilt from its `.select()` response instead of from a locally minted uuid.
- **`archiveAgent()` releases the app id** in the same statement as `archived_at` — that is what keeps a total unique index viable (PostgREST cannot infer a partial index in `on_conflict`) and stops a reused `claude-${Date.now()}` id resurrecting a closed row.
- **The `loadAgents()` race is closed**: the id→uuid maps are built locally and published in one synchronous step after the awaits, and the read rides `queueAgentWrite()` so hydration is ordered against writes.
- **The dev build no longer shares singletons with the installed app**: `requestSingleInstanceLock()` plus a `-dev` `userData` and config dir under `VITE_DEV_SERVER_URL`. New `config/paths.ts` splits `CONFIG_DIR` (per-instance: session, port, outbox, command history) from `STABLE_CONFIG_DIR` (anything whose path is baked into `~/.claude/settings.json` — statusline, skill spool, `Read()` permission, `profile.md`).
- **`stopStatusServer()` no longer deletes a port file it never published**, so the instance that loses the lock cannot clobber the winner's.
- Tests: 5 new `CloudStore` cases (id-less upsert, column-over-jsonb read precedence, map rebuilt from the response, in-batch duplicate collapsing, and a deterministic interleaving test that parks the links query to prove the map is never empty mid-hydration), new `paths.test.ts`, and a 12-assertion pgTAP file.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

`npm test` 957/957, `tsc --noEmit` clean, `npm run lint` 0 errors (3 pre-existing warnings in `RepoPage.tsx`, untouched here). The migration was replayed end-to-end on a throwaway Postgres 17 container over seeded pre-migration duplicates, and re-running it is a no-op. The desktop app itself was **not** launched — see step 1 below.

### Test Steps

1. Run `npm run desktop:install`, then `npm run desktop`. The app must start normally and land in `~/.config/magic-slash-dev` (expect a re-login in dev — that is the intended isolation, not a regression).
2. Apply the migration (`supabase db push`) on a database that already has duplicates, then run `select owner_id, app_agent_id, count(*) from agents where archived_at is null group by 1, 2 having count(*) > 1;` — it must return zero rows, and the surviving row of each former duplicate group must be the oldest one, still carrying its `usage_events` / `activity_events` / `skill_invocations`.
3. With the installed **Magic Slash.app** running, launch `npm run desktop`. Both must run side by side, and the agent roster must appear exactly once on the web dashboard — previously the whole roster showed up twice.
4. Launch the **same** build a second time. The existing window must take focus (restored if minimized) instead of a second process starting.
5. Close an agent in the app, then create a new one. The closed row must stay archived — it must not come back as a live agent — and `select count(*) from agents where archived_at is not null and app_agent_id is not null;` must return 0.
6. Quit the dev build while the installed app is running, then confirm `~/.config/magic-slash/port` still exists and the installed app's Claude hooks keep reporting into it.

## Screenshots

N/A — no UI surface changed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

**Deploy order matters: migration first, app release second.** In between, an N-1 desktop still upserts on `id` and leaves `app_agent_id` null — and since null keys are distinct, the unique index will not catch it, so it can still create a duplicate that the new build only reconciles through the jsonb fallback in `fromAgentRow()`. An N-1 build running *after* the app release will instead take a visible `23505` (`saveAgents failed` toast plus a rehydrate) rather than silently duplicating.

Two known limits, deliberate and worth a reviewer's opinion:

- The invariant "an archived row holds no app id" is enforced by client code only. `CloudStore.archiveAgent` is the sole agent archiver in the system, but a `check (archived_at is null or app_agent_id is null)` would make it structural.
- Cross-**client** resurrection is still theoretically possible: a stale fire-and-forget `saveAgents` from another machine can re-insert an agent closed elsewhere. The instance lock removes the common trigger, not the scenario.

The pgTAP file's dedup assertions are a transcription of the migration's do-block rather than an execution of it (a one-shot data migration offers no other handle); the file documents that the two must be kept in step. Note `supabase/tests/*.test.sql` is not wired into CI.