### PR TITLE
fix(desktop): report and retry a failed agent archive

### DIFF
--- a/desktop/src/main/config/agents.test.ts
+++ b/desktop/src/main/config/agents.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { Agent } from '../../types'
 import type { Store } from '../store/Store'
 import { setStore, NOOP_STORE } from '../store/Store'
+
+// The archive spool is a real file in the real config dir (its own behaviour lives in
+// store/pending-archives.test.ts). Mocked here so a test can say "this close has not
+// been confirmed yet" without writing to the developer's disk.
+const spool = vi.hoisted(() => ({ pending: [] as string[] }))
+
+vi.mock('../store/pending-archives', () => ({
+  pendingArchiveIds: () => spool.pending,
+}))
+
 import {
   createDefaultMetadata,
   mergeMetadata,
@@ -38,6 +48,10 @@ async function seed(initial: unknown[] = []): Promise<void> {
   setStore(fakeStore(initial))
   await hydrateAgents()
 }
+
+beforeEach(() => {
+  spool.pending = []
+})
 
 // --- Pure function tests (no store needed) ---
 
@@ -229,6 +243,32 @@ describe('archiveAgent', () => {
     archiveAgent('nope')
     expect(readAgents()).toHaveLength(1)
     expect(archivedAgents).toEqual([])
+  })
+
+  it('never hydrates back an agent whose archive has not been confirmed', async () => {
+    // The store filters on `archived_at is null`, so a close whose stamp never
+    // landed comes back in the roster — and comes back all the way: restoreAgents()
+    // gives it a PTY and the next writeAgents() re-upserts it. Filtering here, on
+    // the cache every one of those reads, is what covers them at once.
+    spool.pending = ['a1']
+    await seed([
+      { id: 'a1', name: 'Closed offline', repositories: [], tsCreate: 100 },
+      { id: 'a2', name: 'Agent 2', repositories: [], tsCreate: 200 },
+    ])
+
+    expect(readAgents().map(a => a.id)).toEqual(['a2'])
+  })
+
+  it('hydrates the agent again once its archive is settled', async () => {
+    // The filter is not a tombstone: an entry leaves the spool as soon as its write
+    // is resolved one way or the other, so it can never hide an agent for good.
+    spool.pending = ['a1']
+    await seed([{ id: 'a1', name: 'Agent 1', repositories: [], tsCreate: 100 }])
+    expect(readAgents()).toEqual([])
+
+    spool.pending = []
+    await hydrateAgents()
+    expect(readAgents().map(a => a.id)).toEqual(['a1'])
   })
 })
 

--- a/desktop/src/main/config/agents.ts
+++ b/desktop/src/main/config/agents.ts
@@ -3,6 +3,7 @@ import { filterValidRepositories, readConfig } from './config'
 import { expandPath } from './validation'
 import { resolveRepoIds } from '../../repoMatch'
 import { getStore, reportWriteError } from '../store/Store'
+import { pendingArchiveIds } from '../store/pending-archives'
 
 /**
  * The configured repositories these paths belong to, as `repositories` table
@@ -79,10 +80,24 @@ function normalizeAgents(raw: unknown): Agent[] {
 
 let agentsCache: Agent[] = []
 
-/** Load agents from the store into the cache. Call after auth is established. */
+/**
+ * Load agents from the store into the cache. Call after auth is established.
+ *
+ * Agents whose archive is still pending are dropped on the way in. The store's read
+ * filters on `archived_at is null`, so an agent the user closed while the stamp
+ * could not be written comes back in this list — and it comes back all the way:
+ * restoreAgents() spawns it a PTY, and the next writeAgents() re-upserts it. One
+ * filter here covers every one of those, because they all read this cache.
+ *
+ * Read AFTER the load, so a close made while the roster was in flight is honoured
+ * too. The ids leave the spool as soon as their write is settled (see
+ * pending-archives), which is why this cannot hide an agent indefinitely.
+ */
 export async function hydrateAgents(): Promise<Agent[]> {
   try {
-    agentsCache = normalizeAgents(await getStore().loadAgents())
+    const loaded = normalizeAgents(await getStore().loadAgents())
+    const pending = new Set(pendingArchiveIds())
+    agentsCache = loaded.filter((agent) => !pending.has(agent.id))
   } catch (error) {
     console.error('Error hydrating agents:', error)
     agentsCache = []

--- a/desktop/src/main/ipc/connectivity-handlers.ts
+++ b/desktop/src/main/ipc/connectivity-handlers.ts
@@ -3,6 +3,7 @@ import type { ConnectivityStatus, StoreWriteKind } from '../store/Store'
 import { getStore, setWriteErrorHandler } from '../store/Store'
 import { ensureHydrated, rehydrate, resetHydration } from '../store/hydrate'
 import { flushOutbox } from '../store/outbox'
+import { flushPendingArchives } from '../store/pending-archives'
 import { drainSkillSpool } from '../usage/skill-spool'
 import { migrateConfig } from '../config/migrate'
 import { applyRemoteSettingsRow, scheduleRemoteRefresh, setRemoteSyncEmitters } from '../config/remote-sync'
@@ -96,6 +97,13 @@ export function setupConnectivityHandlers(getMainWindow: () => BrowserWindow | n
 
     if (status === 'ok') {
       try {
+        // BEFORE hydrating, and awaited: a close whose stamp never landed is
+        // replayed here, so the roster this hydration reads already excludes it
+        // through the store's own `archived_at is null` filter. Flushing after
+        // would leave the agent in the cache — and restored, with a live PTY —
+        // until the next hydration. Never rejects; an entry it cannot deliver
+        // stays for the next tick.
+        await flushPendingArchives()
         await ensureHydrated()
         // migrateConfig only ever changes data on the first post-upgrade pass;
         // run it (and restoreAgents) once rather than on every 20s poll/focus.

--- a/desktop/src/main/store/CloudStore.test.ts
+++ b/desktop/src/main/store/CloudStore.test.ts
@@ -34,6 +34,29 @@ vi.mock('../cloud/realtime', () => ({
   mapOrgAgentRow: vi.fn(),
 }))
 
+// The archive spool is a real file in the real config dir; its own behaviour is
+// covered in pending-archives.test.ts. Here it is a recorder, so these tests can
+// assert WHAT the store spools and settles — the write-ahead entry, and whether an
+// outcome was treated as final — without touching the developer's disk.
+//
+// `writable` mirrors the real return value: whether the intent actually reached the
+// disk. It is what entitles the store to stay quiet about a write it could not make
+// now, so a test can revoke it and check the store stops being quiet.
+const spool = vi.hoisted(() => ({
+  enqueued: [] as { appId: string; uid: string }[],
+  resolved: [] as string[],
+  writable: true,
+}))
+
+vi.mock('./pending-archives', () => ({
+  enqueuePendingArchive: (entry: { appId: string; uid: string }) => {
+    if (!spool.writable) return false
+    spool.enqueued.push(entry)
+    return true
+  },
+  resolvePendingArchive: (appId: string) => { spool.resolved.push(appId) },
+}))
+
 import { CloudStore } from './CloudStore'
 
 // ── Supabase client fake ────────────────────────────────────────────────────
@@ -48,6 +71,22 @@ type QueryResult = { data?: unknown; error?: unknown }
 // A result may be a promise, which is how a test parks a query mid-chain and
 // interleaves another call with it (the builder adopts whatever it is given).
 type PendingResult = QueryResult | PromiseLike<QueryResult>
+/**
+ * The answers a table gives, in call order. An ARRAY is a queue consumed one query
+ * at a time, with the last element sticking; a bare value answers every query. The
+ * queue exists because one query on a table now legitimately follows another and
+ * must answer differently — archiveAgentRow updates, then reads the row back when
+ * the update matched nothing, and that control select is the only thing that tells
+ * an already-archived agent from a lost write.
+ */
+type TableResults = Record<string, PendingResult | PendingResult[]>
+
+/** The next result configured for `table`, consuming one step of a queue. */
+function take(source: TableResults, table: string): PendingResult | undefined {
+  const configured = source[table]
+  if (!Array.isArray(configured)) return configured
+  return configured.length > 1 ? configured.shift() : configured[0]
+}
 
 interface RecordedCall {
   table: string
@@ -56,7 +95,7 @@ interface RecordedCall {
 }
 
 function makeClient(
-  resultsByTable: Record<string, PendingResult>,
+  resultsByTable: TableResults,
   // Keyed by function name. Separate from the table map because an RPC is not a
   // table and shares no builder chain with one: `client.rpc()` resolves straight
   // to { data, error }.
@@ -73,7 +112,6 @@ function makeClient(
   const upserts: Record<string, unknown[]> = {}
 
   function builder(table: string) {
-    const result = resultsByTable[table] ?? { data: [], error: null }
     let upserted = false
     const record = (method: string, args: unknown[]) => calls.push({ table, method, args })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -103,8 +141,15 @@ function makeClient(
         return b
       },
       delete: (...args: unknown[]) => { record('delete', args); return b },
-      then: (resolve: (v: QueryResult) => unknown, reject?: (e: unknown) => unknown) =>
-        Promise.resolve(upserted ? resultsByUpsert[table] ?? result : result).then(resolve, reject),
+      then: (resolve: (v: QueryResult) => unknown, reject?: (e: unknown) => unknown) => {
+        // An update takes its answer from the table queue like any other query: what
+        // PostgREST returns for `update(...).select(...)` is the rows it MATCHED, and
+        // that is simply this table's next answer.
+        const result = (upserted ? resultsByUpsert[table] : undefined)
+          ?? take(resultsByTable, table)
+          ?? { data: [], error: null }
+        return Promise.resolve(result).then(resolve, reject)
+      },
     }
     return b
   }
@@ -127,6 +172,9 @@ beforeEach(() => {
   h.state.session = { user: { id: UID } }
   h.state.cloudEnabled = true
   h.state.client = null
+  spool.enqueued.length = 0
+  spool.resolved.length = 0
+  spool.writable = true
 })
 
 // ── appendUsage ─────────────────────────────────────────────────────────────
@@ -403,7 +451,7 @@ describe('agents', () => {
     expect(payload.app_agent_id).toBeNull()
 
     // Scoped by owner_id so closing an agent can never reach a teammate's row,
-    // and by `archived_at is null` so a second close is a no-op.
+    // and by `archived_at is null` so a second close matches nothing.
     const updateIndex = calls.findIndex((c) => c.table === 'agents' && c.method === 'update')
     expect(calls.slice(updateIndex).filter((c) => c.method === 'eq')).toEqual([
       { table: 'agents', method: 'eq', args: ['owner_id', UID] },
@@ -412,18 +460,302 @@ describe('agents', () => {
     expect(calls.slice(updateIndex)).toContainEqual({
       table: 'agents', method: 'is', args: ['archived_at', null],
     })
+    // The update asks for the rows it matched. Without this, PostgREST answers the
+    // same whether it stamped one row or none.
+    expect(calls.slice(updateIndex)).toContainEqual({
+      table: 'agents', method: 'select', args: ['id'],
+    })
+    // Confirmed by the database, so the write-ahead entry is settled.
+    expect(spool.resolved).toEqual(['claude-1'])
   })
 
-  it('archiveAgent is a no-op for an agent the store never loaded', async () => {
+  it('archiveAgent records the close on disk before the write, and keeps it there when the write fails', async () => {
+    // The entry has to exist BEFORE the round-trip: Electron does not await
+    // `before-quit`, so nothing can flush a close at quit time — surviving the
+    // process is the only way a close in flight is not lost. A failed write must
+    // leave it alone, or the retry has nothing to retry.
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      agents: [
+        { data: [agentRow('uuid-1', 'claude-1', UID)], error: null }, // loadAgents
+        { data: null, error: { message: 'offline' } }, // the archiving update
+      ],
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.loadAgents()
+    await expect(store.archiveAgent('claude-1')).rejects.toThrow('archiveAgent failed: offline')
+
+    expect(spool.enqueued).toEqual([{ appId: 'claude-1', uid: UID }])
+    expect(spool.resolved).toEqual([])
+  })
+
+  it('archiveAgent spools the close before the write chain even starts, not after it drains', async () => {
+    // "Write-ahead" has to mean ahead of the QUEUE, not merely ahead of the PATCH.
+    // Spooling from inside the queued task made the entry wait on whatever the
+    // agent-write chain was already holding — and that chain holds a network
+    // round-trip routinely, since writeAgents() fires on every metadata mutation and
+    // loadAgents rides it too. Quit in that window and nothing was ever written to
+    // disk: the close is gone, with no `before-quit` hook to catch it. So the
+    // invariant is about ORDER, and the assertion is made with the chain provably
+    // still blocked.
+    let releaseLoad: (() => void) | undefined
+    const parkedLoad = new Promise<QueryResult>((resolve) => {
+      releaseLoad = () => resolve({ data: [], error: null })
+    })
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      agents: [
+        parkedLoad, // a loadAgents that never comes back until this test says so
+        { data: [{ id: 'uuid-1' }], error: null }, // the archiving update, once unblocked
+      ],
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    const loading = store.loadAgents() // occupies the chain, parked mid-query
+    const archiving = store.archiveAgent('claude-1')
+
+    // Synchronously: not one microtask later, and above all not after `loading`.
+    expect(spool.enqueued).toEqual([{ appId: 'claude-1', uid: UID }])
+    // And still nothing settled — the write has not been attempted yet, let alone
+    // confirmed. Only the intent is durable at this point, which is the whole idea.
+    expect(spool.resolved).toEqual([])
+
+    releaseLoad?.()
+    await loading
+    await archiving
+    expect(spool.resolved).toEqual(['claude-1'])
+  })
+
+  it('archiveAgent still archives an agent the store never loaded, matching on the app id', async () => {
+    // This used to return early: the id→uuid binding is process-local, so an empty
+    // map describes a cold cache — a close before the first hydration, a replay
+    // after a restart — far more often than a nonexistent agent. Returning quietly
+    // there is exactly how a closed agent came back live on the next launch.
     const { client, calls } = makeClient({
       memberships: membershipsOk,
-      agents: { data: [], error: null },
+      // No loadAgents here, so the archiving update is the only query on the table.
+      agents: { data: [{ id: 'uuid-1' }], error: null },
     })
     h.state.client = client
 
     await new CloudStore().archiveAgent('claude-unknown')
 
-    expect(calls.filter((c) => c.table === 'agents')).toEqual([])
+    const updateIndex = calls.findIndex((c) => c.table === 'agents' && c.method === 'update')
+    expect(updateIndex).toBeGreaterThanOrEqual(0)
+    expect(calls.slice(updateIndex).filter((c) => c.method === 'eq')).toEqual([
+      { table: 'agents', method: 'eq', args: ['owner_id', UID] },
+      { table: 'agents', method: 'eq', args: ['app_agent_id', 'claude-unknown'] },
+    ])
+    expect(spool.resolved).toEqual(['claude-unknown'])
+  })
+
+  it('archiveAgent matches on the uuid when it knows it, so a legacy row with a null app id is still archived', async () => {
+    // An older installed build upserts `onConflict: 'id'` and leaves app_agent_id
+    // null, and migration 20260814090000 only backfilled the rows that existed
+    // then. Matching on the app id unconditionally would find 0 rows for those and
+    // report a failure for an archive that should have worked.
+    const legacy = { ...agentRow('uuid-2', 'claude-2', UID), app_agent_id: null }
+    const { client, calls } = makeClient({
+      memberships: membershipsOk,
+      agents: { data: [legacy], error: null },
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.loadAgents() // the id comes from the jsonb, and still binds to uuid-2
+    await store.archiveAgent('claude-2')
+
+    const updateIndex = calls.findIndex((c) => c.table === 'agents' && c.method === 'update')
+    expect(calls.slice(updateIndex).filter((c) => c.method === 'eq')).toEqual([
+      { table: 'agents', method: 'eq', args: ['owner_id', UID] },
+      { table: 'agents', method: 'eq', args: ['id', 'uuid-2'] },
+    ])
+    expect(spool.resolved).toEqual(['claude-2'])
+  })
+
+  it('archiveAgent treats a re-close of an already archived agent as done, not as a failure', async () => {
+    // The second close matches nothing — app_agent_id is already null and
+    // archived_at is already set — which is indistinguishable from a lost write
+    // until the row itself is read back. Toasting here would report a failure for
+    // the one case where the work is provably finished.
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      agents: [
+        { data: [agentRow('uuid-1', 'claude-1', UID)], error: null }, // loadAgents
+        { data: [], error: null }, // the update matches nothing
+        // The control select: the row is there, and it is stamped.
+        { data: { id: 'uuid-1', archived_at: '2026-08-14T09:00:00.000Z' }, error: null },
+      ],
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.loadAgents()
+    await expect(store.archiveAgent('claude-1')).resolves.toBeUndefined()
+
+    expect(spool.resolved).toEqual(['claude-1'])
+  })
+
+  it('archiveAgent recognises an already archived row on a cold map, which is the state every replay finds', async () => {
+    // THE case the spool exists for: the first PATCH committed and its response died
+    // with the process. flushPendingArchives() runs BEFORE ensureHydrated(), so the
+    // replay has no id→uuid binding at all — and the row it is looking for holds a
+    // null app_agent_id, so the update matches nothing. Asking for the row by uuid
+    // only, as this did, means never asking on the one path that needs it: the
+    // recovery would throw, toast, and report a failure for a close that worked.
+    const { client, calls } = makeClient({
+      memberships: membershipsOk,
+      agents: [
+        { data: [], error: null }, // the update matches nothing: the row is already stamped
+        // The control select, by the jsonb copy of the app id — the archive statement
+        // nulled the column but has never touched metadata.
+        { data: [{ archived_at: '2026-08-14T09:00:00.000Z' }], error: null },
+      ],
+    })
+    h.state.client = client
+
+    // No loadAgents: a freshly started process, exactly as the flush finds it.
+    await expect(new CloudStore().archiveAgent('claude-1')).resolves.toBeUndefined()
+
+    expect(calls).toContainEqual({
+      table: 'agents', method: 'eq', args: ['metadata->__app->>id', 'claude-1'],
+    })
+    expect(spool.resolved).toEqual(['claude-1'])
+  })
+
+  it('archiveAgent still reports a loss on a cold map when the row it finds is live', async () => {
+    // The jsonb lookup must not turn every miss into a success. A row carrying this
+    // app id in its metadata with a null column and no stamp is an agent an older
+    // build wrote and that is still running — the archive genuinely did not happen,
+    // and this is the one path that can say so.
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      agents: [
+        { data: [], error: null }, // the update matches nothing
+        { data: [{ archived_at: null }], error: null }, // the control select: still live
+      ],
+    })
+    h.state.client = client
+
+    await expect(new CloudStore().archiveAgent('claude-1')).rejects.toThrow('no agent row matched claude-1')
+
+    // Settled all the same: replaying this update would match exactly as many rows
+    // next time, and an entry that can never resolve would hide the id from every
+    // hydration for good.
+    expect(spool.resolved).toEqual(['claude-1'])
+  })
+
+  it('archiveAgent throws when the update matched nothing and the row is not archived', async () => {
+    // The failure this whole path exists to surface: the statement ran, changed
+    // nothing, and the agent is still live. config/agents.ts turns the rejection
+    // into a toast + a rehydrate, instead of the user meeting the agent again on
+    // the next launch.
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      agents: [
+        { data: [agentRow('uuid-1', 'claude-1', UID)], error: null }, // loadAgents
+        { data: [], error: null }, // the update matches nothing
+        // The control select: the row is there, and it is NOT stamped.
+        { data: { id: 'uuid-1', archived_at: null }, error: null },
+      ],
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.loadAgents()
+    await expect(store.archiveAgent('claude-1')).rejects.toThrow('no agent row matched claude-1')
+
+    // Dropped rather than retried: this update will match exactly as many rows next
+    // time, and an entry that can never resolve would hide the id from hydration
+    // for good.
+    expect(spool.resolved).toEqual(['claude-1'])
+  })
+
+  it('archiveAgent keeps the close spooled when the control select itself fails, and blames the probe', async () => {
+    // The probe answering `false` on ANY error made a transport failure
+    // indistinguishable from a live row — so a flaky backend took the genuine-miss
+    // path, deleted the durable entry and threw `no agent row matched`. That voided
+    // the retry guarantee exactly when it was needed, and misattributed the cause on
+    // the way out. "The row is live" is a verdict; "the probe could not run" is the
+    // absence of one, and only the first may settle the entry.
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      agents: [
+        { data: [agentRow('uuid-1', 'claude-1', UID)], error: null }, // loadAgents
+        { data: [], error: null }, // the update matches nothing
+        // The control select never gets an answer: the connection went away between
+        // the update and this read.
+        { data: null, error: { message: 'fetch failed' } },
+      ],
+    })
+    h.state.client = client
+
+    const store = new CloudStore()
+    await store.loadAgents()
+    await expect(store.archiveAgent('claude-1'))
+      .rejects.toThrow('archiveAgent failed: could not confirm whether claude-1 is already archived: fetch failed')
+
+    // Kept, so the connectivity gate replays the close once the backend answers.
+    expect(spool.resolved).toEqual([])
+  })
+
+  it('archiveAgent keeps the close spooled when the cold-map probe fails, which is the state every replay starts from', async () => {
+    // The same hole on the path the spool exists for. A replay runs before
+    // ensureHydrated(), so it has no uuid and probes through the jsonb — and it runs
+    // the instant connectivity flipped to 'ok', which is the likeliest moment for a
+    // read to fail. Dropping the entry there would burn the retry on its first
+    // attempt.
+    const { client } = makeClient({
+      memberships: membershipsOk,
+      agents: [
+        { data: [], error: null }, // the update matches nothing
+        { data: null, error: { message: 'upstream timeout' } }, // the jsonb probe fails
+      ],
+    })
+    h.state.client = client
+
+    // No loadAgents: a freshly started process, exactly as the flush finds it.
+    await expect(new CloudStore().archiveAgent('claude-1'))
+      .rejects.toThrow('could not confirm whether claude-1 is already archived: upstream timeout')
+
+    expect(spool.resolved).toEqual([])
+  })
+
+  it('archiveAgent keeps the close spooled and stays quiet when there is no session to write it with', async () => {
+    // Offline, signed out, or cloud disabled. The connectivity gate replays this on
+    // reconnect and hydration already hides the agent, so a deferred write is not a
+    // lost one — there is nothing here to report to the user.
+    const { client, from } = makeClient({ memberships: membershipsOk, agents: { data: [], error: null } })
+    h.state.client = null // getAuthedClient() → null → userContext() bails
+    void client
+
+    await expect(new CloudStore().archiveAgent('claude-1')).resolves.toBeUndefined()
+
+    expect(from).not.toHaveBeenCalled()
+    expect(spool.enqueued).toEqual([{ appId: 'claude-1', uid: UID }])
+    expect(spool.resolved).toEqual([])
+  })
+
+  it('archiveAgent reports the close instead of deferring quietly when the spool could not take it', async () => {
+    // Same no-session path as above, minus the one thing that made silence
+    // acceptable there. With a read-only or full config dir nothing was written, so
+    // there is no entry for the gate to replay and no pending id for hydration to
+    // hide behind: staying quiet would drop the close on the floor and let the agent
+    // come back with a fresh PTY at the next launch — the very bug this file fixes.
+    // The toast is the only trace left, so it has to fire.
+    const { client, from } = makeClient({ memberships: membershipsOk, agents: { data: [], error: null } })
+    h.state.client = null
+    spool.writable = false
+    void client
+
+    await expect(new CloudStore().archiveAgent('claude-1')).rejects.toThrow(/could not be spooled/)
+
+    expect(from).not.toHaveBeenCalled()
+    expect(spool.enqueued).toEqual([])
+    expect(spool.resolved).toEqual([])
   })
 
   it('an app id reused after archiving cannot land on the archived row', async () => {

--- a/desktop/src/main/store/CloudStore.ts
+++ b/desktop/src/main/store/CloudStore.ts
@@ -6,6 +6,7 @@ import { loadSession } from '../cloud/session-store'
 import { isCloudEnabled } from '../cloud/supabase-client'
 import { mapOrgAgentRow, type OrgAgentRow } from '../cloud/realtime'
 import type { ConnectivityStatus, Store } from './Store'
+import { enqueuePendingArchive, resolvePendingArchive } from './pending-archives'
 import {
   applySettingsRow,
   configToSettingsRow,
@@ -57,6 +58,49 @@ interface OrgActivityEventRow {
   ticket_id: string | null
   repositories: string[]
   occurred_at: string
+}
+
+/**
+ * The app id where archiving cannot erase it: inside the metadata jsonb.
+ *
+ * PostgREST's jsonb path syntax — `->` walks, `->>` takes the leaf as text, which is
+ * what makes it comparable to a `claude-…` string. The same path migration
+ * 20260814090000 backfilled `app_agent_id` from, and the same one fromAgentRow falls
+ * back to. Its column namesake is nulled by the archive statement itself, so this is
+ * the ONLY way to recognise a row that is already archived. See isAlreadyArchived.
+ */
+const APP_ID_IN_METADATA = 'metadata->__app->>id'
+
+/**
+ * How many rows the already-archived probe reads.
+ *
+ * More than one because an app id may legitimately repeat across ARCHIVED rows (see
+ * isAlreadyArchived), bounded because the answer is a yes/no and a user who cycled
+ * one id a hundred times has already been answered by the first few.
+ */
+const ARCHIVED_PROBE_LIMIT = 20
+
+/**
+ * What the already-archived probe could establish — three states, not a boolean.
+ *
+ * `live` and `unknown` used to be the same answer (`false`), and they have OPPOSITE
+ * consequences for the write-ahead entry. `live` is a verdict: the row exists and is
+ * not stamped, so this update will match exactly as many rows next time and the
+ * entry must go. `unknown` is the absence of a verdict — a dropped connection, an
+ * expired token, PostgREST answering 5xx — and dropping the entry there voids the
+ * retry guarantee at the precise moment the backend is flaky, which is the moment
+ * the spool exists for. It also blamed the wrong thing, reporting `no agent row
+ * matched` for a question that was never answered.
+ */
+type ArchiveProbe =
+  | { state: 'archived' }
+  | { state: 'live' }
+  | { state: 'unknown'; reason: string }
+
+/** The message of whatever PostgREST (or the transport) handed back. */
+function probeFailure(error: unknown): string {
+  const message = (error as { message?: unknown } | null)?.message
+  return typeof message === 'string' && message !== '' ? message : 'the query failed'
 }
 
 /**
@@ -1042,19 +1086,75 @@ export class CloudStore implements Store {
    * Queued behind the pending agent writes (see queueAgentWrite) so it cannot drop
    * the id→uuid binding from under a save that is still using it, and so a save
    * that was already in flight cannot re-upsert the row it just stamped archived.
+   *
+   * Write-ahead logged (see pending-archives): the close is on disk before this
+   * method even joins the queue, so it is replayed rather than lost when the write
+   * cannot be made now — and when it CAN be made and still matches nothing, that is
+   * reported instead of passing for success.
    */
   async archiveAgent(appId: string): Promise<void> {
-    return this.queueAgentWrite(() => this.archiveAgentRow(appId))
+    // Ahead of the QUEUE, not merely ahead of the PATCH — and synchronously, before
+    // this method's first await. Inside archiveAgentRow the enqueue would run only
+    // once the agent-write chain had drained, and that chain is routinely holding a
+    // network round-trip: writeAgents() fires on every metadata mutation and
+    // loadAgents rides the same chain. Quit in that window and nothing was ever
+    // spooled — which is failure mode 3 of the ticket, the close whose PATCH dies
+    // with the process, and there is deliberately no `before-quit` hook to catch it
+    // (Electron does not await that handler anyway).
+    //
+    // loadSession() rather than userContext(): the uid has to be read WITHOUT an
+    // await, since awaiting anything at all is what this line exists to avoid. It is
+    // the same synchronous read context()/userContext() do, so it yields the same
+    // uid they would. Empty when no session is loaded, which the spool tolerates by
+    // design — replaying such an entry is scoped by owner_id all the same (see the
+    // header of pending-archives).
+    //
+    // The answer matters: everything downstream that stays QUIET about an
+    // unfinished archive does so because this file holds the intent. If the spool
+    // could not be written, that justification is gone and silence becomes the
+    // original bug again.
+    const spooled = enqueuePendingArchive({ appId, uid: loadSession()?.user?.id ?? '' })
+
+    return this.queueAgentWrite(() => this.archiveAgentRow(appId, spooled))
   }
 
-  private async archiveAgentRow(appId: string): Promise<void> {
+  private async archiveAgentRow(appId: string, spooled = true): Promise<void> {
     // Read the uuid before any await: a concurrent write must not observe a
-    // half-updated map, and callers flush usage right before closing.
+    // half-updated map, and callers flush usage right before closing. It may
+    // legitimately be missing — the binding is process-local, so a cold map (a
+    // close before the first hydration, a replay after a restart) knows nothing.
+    // That is a reason to match the row differently, not a reason to give up: an
+    // archive that does not happen is an agent that comes back live on the next
+    // launch.
     const uuid = this.agentIdMap.get(appId)
-    if (!uuid) return
 
-    const ctx = await this.context()
-    if (!ctx) return
+    // The write-ahead entry is already on disk — archiveAgent() spooled it before
+    // queueing this task, which is the only placement that survives a quit while
+    // another agent write holds the chain. Nothing to record here; from here on the
+    // job is to SETTLE that entry, and to leave it alone whenever the outcome is
+    // still open.
+
+    // userContext, not context: this write never reads ctx.orgId — it is scoped by
+    // owner_id — so requiring a resolved membership only meant silently dropping
+    // the archives of anyone working on personal repositories alone.
+    const ctx = await this.userContext()
+    if (!ctx) {
+      // Offline, no session, or cloud disabled. The entry stays in the spool and
+      // hydration already hides the agent, so this is a DEFERRED write, not a lost
+      // one — nothing to report to the user, and nothing to throw at the caller.
+      //
+      // Unless the spool never took it. Then there is no entry to replay and no
+      // hydration filter hiding the agent: the close would vanish here in silence
+      // and the agent would come back with a fresh PTY at the next launch, which is
+      // precisely what deferring quietly is allowed to do only when the intent is
+      // durable. Report it instead — the toast is the only remaining trace.
+      if (!spooled) {
+        throw new Error(
+          `archiveAgent failed: ${appId} could not be written now and could not be spooled for retry`
+        )
+      }
+      return
+    }
 
     // Scoped by owner, not by org: an agent on a personal repo has no org, and
     // ownership is the real permission boundary anyway.
@@ -1067,18 +1167,139 @@ export class CloudStore implements Store {
     // in the database yet filtered out of every read. Null is also what keeps the
     // unique index total-index-safe: any number of archived rows may share an app
     // id, because null keys are distinct (see 20260814090000).
-    const { error } = await ctx.client
+    const patch = ctx.client
       .from('agents')
       .update({ archived_at: new Date().toISOString(), app_agent_id: null })
       .eq('owner_id', ctx.uid)
-      .eq('id', uuid)
-      .is('archived_at', null)
+
+    // The uuid when the map has it, the app id ONLY as the cold-map fallback —
+    // never the other way round. fromAgentRow reads the app id from the column,
+    // the jsonb, then the uuid precisely because an older installed build still
+    // upserts `onConflict: 'id'` and leaves the column null; migration
+    // 20260814090000 backfilled the rows that existed then, not the ones such a
+    // build writes afterwards. Matching on app_agent_id alone would find 0 rows
+    // for those and report an archive that in fact should have worked.
+    const scoped = uuid ? patch.eq('id', uuid) : patch.eq('app_agent_id', appId)
+
+    // `.select()` is what turns "the statement ran" into "a row changed". Without
+    // it PostgREST answers the same for 0 rows matched as for 1, so every way this
+    // write can miss its row — a stale binding, a filter that matches nothing —
+    // reported as a success.
+    const { data, error } = await scoped.is('archived_at', null).select('id')
     if (error) throw new Error(`archiveAgent failed: ${error.message}`)
 
+    if ((data ?? []).length > 0) {
+      this.settleArchive(appId, ctx.uid)
+      return
+    }
+
+    // Zero rows. Two very different situations look identical from here, and only
+    // the row itself can tell them apart: the agent was ALREADY archived (a second
+    // close matches nothing, since app_agent_id is null and archived_at is set), or
+    // the update never found its agent at all.
+    //
+    // Asked with or WITHOUT a uuid, which is the whole point of the write-ahead
+    // spool: flushPendingArchives() runs before ensureHydrated(), so the canonical
+    // replay — the first PATCH committed, its response was lost with the process —
+    // arrives here on a cold map. Skipping the question there would throw
+    // `no agent row matched` and toast a failure for an archive that provably
+    // succeeded, which is the exact failure this ticket removes.
+    const probe = await this.isAlreadyArchived(ctx, uuid, appId)
+
+    if (probe.state === 'archived') {
+      this.settleArchive(appId, ctx.uid)
+      return
+    }
+
+    if (probe.state === 'unknown') {
+      // The probe never got an answer, so nothing has been proved about this agent.
+      // KEEP the entry: this is a transient backend failure, and the connectivity
+      // gate will replay the close once the backend answers again — dropping it here
+      // would spend the retry guarantee on the one condition it was written for. The
+      // message names the probe, because `no agent row matched` would assert
+      // something this pass is in no position to assert.
+      throw new Error(`archiveAgent failed: could not confirm whether ${appId} is already archived: ${probe.reason}`)
+    }
+
+    // A genuine miss: the row is there and still live, or it is gone entirely. Drop
+    // the spool entry first: replaying this exact update would match exactly as many
+    // rows next time, and an entry that can never be resolved would hide the app id
+    // from every hydration forever. Then throw, so config/agents.ts reports the
+    // failure instead of the user discovering it when the agent reappears.
+    //
+    // `unmatched`, which is what stops this from eating an unattributed entry. A
+    // close recorded with no session is replayed under whoever signs in next; if that
+    // guess was wrong the update lands here, and deleting the entry would destroy the
+    // real owner's only durable record of it.
+    resolvePendingArchive(appId, ctx.uid, 'unmatched')
+    throw new Error(`archiveAgent failed: no agent row matched ${appId}`)
+  }
+
+  /** The archive landed: forget the pending entry and the now-meaningless bindings. */
+  private settleArchive(appId: string, uid: string): void {
+    resolvePendingArchive(appId, uid, 'landed')
     // The local binding goes too: nothing in this process should keep pointing an
     // app id at a row that no longer answers to it.
     this.agentIdMap.delete(appId)
     this.agentRepoKey.delete(appId)
+  }
+
+  /**
+   * Whether the row this archive targeted is already stamped — i.e. the update
+   * matched nothing because the work was done, not because it was lost.
+   *
+   * A plain read of the caller's own row: `agents_select` (migration
+   * 20260727160000) lets an owner read back their agents, personal null-org ones
+   * included, so no policy has to change for this. Never `archived` on a doubt —
+   * reporting a doubtful archive is the pessimistic direction, and the right one.
+   *
+   * But a read that FAILS answers `unknown`, not `live`: it establishes nothing, and
+   * treating it as a verdict would delete the durable entry over a dropped
+   * connection. A read that succeeds and finds nothing does answer `live` — a row
+   * that is not there will not be there next time either (see ArchiveProbe).
+   *
+   * Two ways in, because the archive itself destroys the obvious one. Archiving
+   * nulls `app_agent_id` in the same statement that stamps `archived_at`, so the
+   * column cannot find an already-archived row, and the uuid is only known while
+   * the process that hydrated the map is still alive. What survives BOTH is the
+   * copy in the jsonb: toAgentRow always writes `metadata.__app.id` (it is the
+   * rung fromAgentRow falls back to, and what migration 20260814090000 backfilled
+   * the column from), and no archive path ever touches metadata.
+   */
+  private async isAlreadyArchived(
+    ctx: { client: SupabaseClient; uid: string },
+    uuid: string | undefined,
+    appId: string,
+  ): Promise<ArchiveProbe> {
+    const scoped = ctx.client.from('agents').select('archived_at').eq('owner_id', ctx.uid)
+
+    // Warm map: the uuid is the primary key, so at most one row can answer.
+    if (uuid) {
+      const { data, error } = await scoped.eq('id', uuid).maybeSingle()
+      if (error) return { state: 'unknown', reason: probeFailure(error) }
+      const row = data as { archived_at?: string | null } | null
+      // No row is a verdict of its own: the agent this update targeted does not
+      // exist under this owner, and no amount of replaying will make it appear.
+      return row?.archived_at ? { state: 'archived' } : { state: 'live' }
+    }
+
+    // Cold map — a replay after a restart, or a close before the first hydration.
+    // NOT maybeSingle: several rows may legitimately carry this app id in their
+    // jsonb, because the invariant "only a LIVE agent holds an app id" is enforced
+    // on the column alone (20260814090000). Closing and reusing an id leaves one
+    // archived row per cycle, and the duplicates that migration folded are archived
+    // rows carrying it too.
+    const { data, error } = await scoped.eq(APP_ID_IN_METADATA, appId).limit(ARCHIVED_PROBE_LIMIT)
+    if (error) return { state: 'unknown', reason: probeFailure(error) }
+
+    const rows = (data ?? []) as { archived_at?: string | null }[]
+    // EVERY row, not merely one of them. The update above already proved no live row
+    // holds this id in the COLUMN; a live row that still matches here is one an older
+    // build wrote with a null column, and for it the archive genuinely did not
+    // happen. Answering `archived` on the strength of an unrelated archived namesake
+    // would swallow exactly the loss this path exists to report.
+    const archived = rows.length > 0 && rows.every((row) => Boolean(row.archived_at))
+    return archived ? { state: 'archived' } : { state: 'live' }
   }
 
   /**

--- a/desktop/src/main/store/Store.ts
+++ b/desktop/src/main/store/Store.ts
@@ -51,7 +51,15 @@ export interface Store {
    * Soft-delete ONE agent (the user closed it). Never a hard delete: the row is
    * kept so its activity, usage and skill-invocation events keep their agent
    * link — a deleted row would null those FKs and orphan the history.
-   * Idempotent, and a no-op for an agent the store never loaded.
+   *
+   * Idempotent: closing an already-closed agent succeeds and changes nothing. NOT a
+   * no-op for an agent the store never loaded, which it used to be — the id→uuid
+   * binding is process-local, so "never loaded" describes a cold cache far more
+   * often than a nonexistent agent, and returning quietly there is how a close came
+   * back as a live agent after the next launch. An implementation must either
+   * archive the row, defer the write durably, or reject — never report a write that
+   * matched nothing as done. (NOOP_STORE stays a no-op: it persists nothing at all,
+   * so it has nothing to lose.)
    */
   archiveAgent(appId: string): Promise<void>
 

--- a/desktop/src/main/store/pending-archives.test.ts
+++ b/desktop/src/main/store/pending-archives.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import type { Store } from './Store'
+import { setStore, NOOP_STORE } from './Store'
+
+// The spool resolves its file from os.homedir() at import time, so the mock has to be
+// hoisted above it and the path has to be computable without touching the filesystem.
+const h = vi.hoisted(() => ({
+  TMP_HOME: `${process.env.TMPDIR ?? '/tmp'}/magic-slash-pending-archives-test-${process.pid}`,
+  session: { user: { id: 'user-1' } } as { user: { id: string } } | null,
+}))
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>()
+  return { ...actual, default: { ...actual, homedir: () => h.TMP_HOME }, homedir: () => h.TMP_HOME }
+})
+
+// Who is signed in decides which entries may be replayed at all. Mocked rather than
+// stubbed through the store, and that also keeps the real session module — which
+// imports electron's safeStorage — out of this suite.
+vi.mock('../cloud/session-store', () => ({
+  loadSession: () => h.session,
+}))
+
+import {
+  enqueuePendingArchive,
+  flushPendingArchives,
+  pendingArchiveIds,
+  resolvePendingArchive,
+  resetPendingArchivesForTests,
+} from './pending-archives'
+
+const SPOOL_FILE = path.join(h.TMP_HOME, '.config', 'magic-slash', 'pending-archives.ndjson')
+const UID = 'user-1'
+
+let archived: string[]
+
+/**
+ * A store that behaves like CloudStore does: it settles the spool entry itself,
+ * whatever the outcome — the write landed, the row was already archived, or the
+ * update can never match. Only a transient failure (offline) throws with the entry
+ * left in place, which is the one case the flush must keep.
+ *
+ * `deferred` is the fourth, and the odd one: with no session to write with,
+ * archiveAgent returns quietly WITHOUT settling anything. Neither the return nor the
+ * absence of a throw says a thing about whether the close was delivered.
+ */
+function fakeStore(outcome: (appId: string) => 'ok' | 'gone' | 'offline' | 'deferred' = () => 'ok'): Store {
+  return {
+    ...NOOP_STORE,
+    archiveAgent: async (appId) => {
+      archived.push(appId)
+      const result = outcome(appId)
+      if (result === 'offline') throw new Error('offline')
+      if (result === 'deferred') return
+      resolvePendingArchive(appId, h.session?.user?.id ?? '', result === 'gone' ? 'unmatched' : 'landed')
+      if (result === 'gone') throw new Error(`archiveAgent failed: no agent row matched ${appId}`)
+    },
+  }
+}
+
+beforeAll(() => {
+  fs.mkdirSync(path.dirname(SPOOL_FILE), { recursive: true })
+})
+
+afterAll(() => {
+  fs.rmSync(h.TMP_HOME, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  fs.rmSync(SPOOL_FILE, { force: true })
+  resetPendingArchivesForTests()
+  h.session = { user: { id: UID } }
+  archived = []
+  setStore(fakeStore())
+})
+
+describe('enqueuePendingArchive', () => {
+  it('puts the close on disk, so it outlives the process that made it', () => {
+    // The whole point: Electron does not await `before-quit`, so a close in flight
+    // when the app dies can only be recovered from something already written.
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    expect(fs.existsSync(SPOOL_FILE)).toBe(true)
+    expect(JSON.parse(fs.readFileSync(SPOOL_FILE, 'utf-8').trim())).toEqual({ appId: 'claude-1', uid: UID })
+  })
+
+  it('keeps the spool private to the user', () => {
+    // It names the agents someone worked on. 0600, like the outbox and the port file.
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    expect(fs.statSync(SPOOL_FILE).mode & 0o777).toBe(0o600)
+  })
+
+  it('never records the same agent twice', () => {
+    // A retry, or a replay re-entering through the store, must leave ONE entry:
+    // resolving it once would otherwise leave a phantom that hides the agent from
+    // every later hydration.
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    enqueuePendingArchive({ appId: 'claude-2', uid: UID })
+
+    expect(pendingArchiveIds()).toEqual(['claude-1', 'claude-2'])
+  })
+
+  it('says whether the intent is actually durable, instead of swallowing the failure', () => {
+    // A read-only, full or inaccessible config dir. Answering nothing here would put
+    // the original bug back: every caller that stays quiet about an unfinished
+    // archive is entitled to do so ONLY because this file holds the intent, so one
+    // that is not told the file does not hold it defers into silence and loses the
+    // close for good.
+    // A real failure rather than a stubbed one: a directory sitting where the spool
+    // file belongs makes the append throw EISDIR, the same shape as the read-only
+    // and out-of-space cases. (fs is an ESM namespace here, so it cannot be spied.)
+    fs.mkdirSync(SPOOL_FILE, { recursive: true })
+    // Still never throws — the caller is the write path this exists to protect.
+    expect(enqueuePendingArchive({ appId: 'claude-1', uid: UID })).toBe(false)
+    expect(pendingArchiveIds()).toEqual([])
+
+    fs.rmdirSync(SPOOL_FILE)
+    expect(enqueuePendingArchive({ appId: 'claude-1', uid: UID })).toBe(true)
+    expect(pendingArchiveIds()).toEqual(['claude-1'])
+  })
+
+  it('reports an already-recorded close as durable, since it is', () => {
+    // The dedupe path must answer true, not false: the replay re-enters through the
+    // store on every pass, and a false there would make each one look unspoolable.
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    expect(enqueuePendingArchive({ appId: 'claude-1', uid: UID })).toBe(true)
+  })
+
+  it('does not let one account\'s close stand in for another\'s on a colliding app id', () => {
+    // App ids are `claude-${Date.now()}` and the spool outlives a sign-out, so two
+    // accounts on one machine can hold the same one. Deduplicating on the app id
+    // alone, the second close would match the first's entry and be reported durable
+    // without ever being written — then settled, or hidden from hydration, under an
+    // owner who cannot make its write. Both must exist independently.
+    enqueuePendingArchive({ appId: 'claude-1', uid: 'user-2' })
+    expect(enqueuePendingArchive({ appId: 'claude-1', uid: UID })).toBe(true)
+
+    const entries = fs.readFileSync(SPOOL_FILE, 'utf-8').trim().split('\n').map((l) => JSON.parse(l))
+    expect(entries).toEqual([
+      { appId: 'claude-1', uid: 'user-2' },
+      { appId: 'claude-1', uid: UID },
+    ])
+  })
+})
+
+describe('pendingArchiveIds', () => {
+  it('reports what has not been confirmed yet, so hydration can hide it', () => {
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    resetPendingArchivesForTests() // as after a restart: nothing cached, the file is all there is
+    expect(pendingArchiveIds()).toEqual(['claude-1'])
+  })
+
+  it('reports nothing once the archive is settled', () => {
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    resolvePendingArchive('claude-1', UID, 'landed')
+    expect(pendingArchiveIds()).toEqual([])
+  })
+
+  it('settles only the owner\'s own entry, leaving a colliding one for its owner', () => {
+    // Settlement scoped by owner, for the same reason the replay is: this account
+    // proved something about ITS row and nothing about anyone else's, which is still
+    // live and still needs archiving.
+    enqueuePendingArchive({ appId: 'claude-1', uid: 'user-2' })
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+
+    resolvePendingArchive('claude-1', UID, 'landed')
+
+    // Gone for this session…
+    expect(pendingArchiveIds()).toEqual([])
+    // …and still there for the account that owns it.
+    h.session = { user: { id: 'user-2' } }
+    expect(pendingArchiveIds()).toEqual(['claude-1'])
+  })
+
+  it('does not let a failed guess delete an unattributed close', () => {
+    // A close made with no session loaded has uid ''. It is replayed under whoever
+    // signs in next, because refusing to replay it would strand it forever — but that
+    // replay is a GUESS about ownership. When it turns out wrong the update matches
+    // nothing, and deleting the entry there would destroy the real owner's only
+    // durable record: their live row stays unarchived and their agent comes back with
+    // a fresh PTY. So an `unmatched` outcome may only remove an exact uid match.
+    enqueuePendingArchive({ appId: 'claude-1', uid: '' })
+
+    resolvePendingArchive('claude-1', UID, 'unmatched')
+    expect(fs.readFileSync(SPOOL_FILE, 'utf-8')).toContain('claude-1')
+
+    // A write that LANDED proves the guess was right, so it may claim the entry.
+    resolvePendingArchive('claude-1', UID, 'landed')
+    expect(pendingArchiveIds()).toEqual([])
+  })
+
+  it('hides an id from hydration only for the account that closed it', () => {
+    // The roster hydration filters is already owner_id-scoped, so another account's
+    // pending close must not hide a live agent this user never closed — the mirror
+    // image of the resurrection bug, and just as invisible.
+    enqueuePendingArchive({ appId: 'claude-1', uid: 'user-2' })
+    expect(pendingArchiveIds()).toEqual([])
+
+    h.session = { user: { id: 'user-2' } }
+    expect(pendingArchiveIds()).toEqual(['claude-1'])
+  })
+})
+
+describe('flushPendingArchives', () => {
+  it('replays every pending close through the store, oldest first', async () => {
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    enqueuePendingArchive({ appId: 'claude-2', uid: UID })
+
+    expect(await flushPendingArchives()).toBe(2)
+    expect(archived).toEqual(['claude-1', 'claude-2'])
+    expect(pendingArchiveIds()).toEqual([])
+  })
+
+  it('keeps a close whose replay failed for a transient reason', async () => {
+    // Offline is the ordinary case, and the reason the spool exists: the entry must
+    // survive the failed attempt or the retry has nothing to retry.
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    setStore(fakeStore(() => 'offline'))
+
+    expect(await flushPendingArchives()).toBe(0)
+    expect(pendingArchiveIds()).toEqual(['claude-1'])
+  })
+
+  it('skips a close made by another account instead of replaying it', async () => {
+    // The spool outlives a sign-out. Replaying someone else's close would send an
+    // update scoped by the WRONG owner_id — it matches nothing in the database and
+    // reads to this user as a failed write of an agent they never had.
+    enqueuePendingArchive({ appId: 'claude-other', uid: 'user-2' })
+    enqueuePendingArchive({ appId: 'claude-mine', uid: UID })
+
+    await flushPendingArchives()
+
+    expect(archived).toEqual(['claude-mine'])
+  })
+
+  it('keeps another account\'s close so its owner can still settle it', async () => {
+    // Skipping is not dropping. The other account's row is still LIVE server-side —
+    // this flush proved nothing about it, only that it is not ours to send. Delete
+    // the entry and the last durable record of that close is gone: when its owner
+    // signs back in on this machine, hydration loads the agent and restoreAgents()
+    // hands it a fresh PTY. That is the resurrection the spool exists to prevent,
+    // merely postponed to the next account switch.
+    enqueuePendingArchive({ appId: 'claude-other', uid: 'user-2' })
+
+    await flushPendingArchives()
+    expect(archived).toEqual([])
+    // Asserted on the file, not on pendingArchiveIds(): that one is owner-scoped, so
+    // it rightly says nothing about another account's entry. The durable record is
+    // what has to survive here.
+    expect(fs.readFileSync(SPOOL_FILE, 'utf-8')).toContain('claude-other')
+
+    // And the owner coming back settles it, which is why keeping it is bounded.
+    h.session = { user: { id: 'user-2' } }
+    await flushPendingArchives()
+    expect(archived).toEqual(['claude-other'])
+    expect(pendingArchiveIds()).toEqual([])
+  })
+
+  it('drops a close whose row can never be found rather than retrying it forever', async () => {
+    // The store settles what it proves unmatchable, so the next flush has nothing to
+    // send. An entry kept here would hide its app id from every hydration for good.
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    setStore(fakeStore(() => 'gone'))
+
+    await flushPendingArchives()
+    expect(pendingArchiveIds()).toEqual([])
+
+    archived = []
+    await flushPendingArchives()
+    expect(archived).toEqual([])
+  })
+
+  it('counts only the closes that actually left the spool, not the ones merely attempted', async () => {
+    // A deferred write returns without throwing and without settling — that is the
+    // deliberate no-session behaviour, and the entry rightly stays. Counting the
+    // attempt would have this report the whole backlog as settled on every 20s tick
+    // of a signed-out app, while nothing had been delivered at all.
+    enqueuePendingArchive({ appId: 'claude-deferred', uid: UID })
+    enqueuePendingArchive({ appId: 'claude-done', uid: UID })
+    setStore(fakeStore((appId) => (appId === 'claude-deferred' ? 'deferred' : 'ok')))
+
+    expect(await flushPendingArchives()).toBe(1)
+    // And the deferred one is still there for the next pass, which is the point.
+    expect(pendingArchiveIds()).toEqual(['claude-deferred'])
+  })
+
+  it('shares one run between concurrent callers', async () => {
+    // The connectivity gate polls every 20s and on focus; two overlapping passes
+    // would send every stamp twice.
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+
+    const [first, second] = await Promise.all([flushPendingArchives(), flushPendingArchives()])
+
+    expect([first, second]).toEqual([1, 1])
+    expect(archived).toEqual(['claude-1'])
+  })
+
+  it('is a no-op on an empty spool and does not create the file', async () => {
+    expect(await flushPendingArchives()).toBe(0)
+    expect(fs.existsSync(SPOOL_FILE)).toBe(false)
+  })
+
+  it('skips a torn line rather than discarding the whole backlog', async () => {
+    // A crash mid-append leaves half a line. The other closes are still good.
+    enqueuePendingArchive({ appId: 'claude-1', uid: UID })
+    fs.appendFileSync(SPOOL_FILE, '{"appId":"claude-t\n')
+    enqueuePendingArchive({ appId: 'claude-3', uid: UID })
+    resetPendingArchivesForTests()
+
+    await flushPendingArchives()
+
+    expect(archived).toEqual(['claude-1', 'claude-3'])
+  })
+})
+
+describe('overflow', () => {
+  it('stays bounded, dropping the oldest closes past the cap', () => {
+    // With cloud disabled the flush is never reached — the gate only flushes on a
+    // reachable AND authed backend — so nothing would ever remove an entry and this
+    // file would grow for the life of the install. Dropping is a real loss (that
+    // agent may come back), which is why the newest closes are the ones kept: they
+    // are the ones a user would notice reappearing.
+    for (let i = 0; i < 1200; i++) enqueuePendingArchive({ appId: `claude-${i}`, uid: UID })
+
+    const ids = pendingArchiveIds()
+    // Trimming on the first append past the cap would rewrite the file on every
+    // append after it, so the spool may overshoot by the 10% compaction slack and is
+    // trimmed in one pass. The bound is what matters.
+    expect(ids.length).toBeLessThanOrEqual(1100)
+    expect(ids).toContain('claude-1199')
+    expect(ids).not.toContain('claude-0')
+  })
+})

--- a/desktop/src/main/store/pending-archives.ts
+++ b/desktop/src/main/store/pending-archives.ts
@@ -1,0 +1,360 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { CONFIG_DIR } from '../config/paths'
+import { loadSession } from '../cloud/session-store'
+import { getStore } from './Store'
+
+/**
+ * A write-ahead spool for the ONE agent write that has no second chance: the
+ * archive stamp.
+ *
+ * WHY THIS EXISTS
+ * ---------------------------------------------------------------------------
+ * Archiving is a soft delete — `archived_at` is stamped, the row stays — and
+ * `readAgentRows()` filters on `.is('archived_at', null)` while `restoreAgents()`
+ * relaunches everything that filter returns. So a stamp that never lands is not a
+ * missing timestamp: it is a closed agent that comes back on the next launch with a
+ * freshly spawned PTY, in a roster the user already pruned. The write was
+ * fire-and-forget, and every ordinary reason a desktop app cannot reach its backend
+ * — a closed lid, a train tunnel, a token refreshed a second too late, the app being
+ * quit right after the close — deleted it with nothing reported.
+ *
+ * WRITE-AHEAD, NOT A RETRY QUEUE
+ * ---------------------------------------------------------------------------
+ * The entry is on disk BEFORE the PATCH is issued, which is what covers the case no
+ * `before-quit` hook can: Electron does not await that handler, so a flush there
+ * would be decorative — the process is gone before the round-trip returns. An entry
+ * that survives the process is replayed by the connectivity gate; one whose write
+ * did land is resolved by the writer itself, right after the response.
+ *
+ * That ordering makes a duplicate replay harmless rather than merely unlikely: the
+ * update matches on `archived_at is null`, so a second delivery of a stamp that
+ * already committed matches nothing, and archiveAgentRow recognises that case as an
+ * idempotent re-close instead of a loss (see CloudStore.archiveAgentRow).
+ *
+ * WHY EACH ENTRY CARRIES A uid
+ * ---------------------------------------------------------------------------
+ * The spool outlives a sign-out. Replaying another user's pending archive against
+ * the session that happens to be open would send an update scoped by the WRONG
+ * `owner_id` — harmless in the database (it matches nothing) but reported to the
+ * current user as a failed write of an agent they never closed. The uid lets those
+ * entries be SKIPPED — kept, not dropped: the row they refer to is still live, so
+ * discarding them would destroy the only durable record of a close that still has to
+ * happen, and the agent would be resurrected the moment its owner signs back in here.
+ * Their owner's next flush settles them. Empty when the app had no session at the
+ * moment of the close, which is not evidence of a foreign entry — those are replayed,
+ * and the `owner_id` filter is what keeps that safe.
+ */
+
+// Per-instance (CONFIG_DIR), like the outbox and the session: two apps sharing this
+// file would replay each other's archives, and the dev build's agents are not the
+// installed build's.
+const SPOOL_FILE = path.join(CONFIG_DIR, 'pending-archives.ndjson')
+
+/**
+ * How many pending archives the spool keeps.
+ *
+ * Small on purpose — one entry per agent the user closed while offline, which is a
+ * handful, not a stream. It still needs a bound: with cloud disabled the flush is
+ * never reached at all (connectivity-handlers only flushes on 'ok', i.e. reachable
+ * AND authed), so nothing would ever remove an entry and the file would grow for the
+ * life of the install.
+ */
+const MAX_ENTRIES = 1000
+
+/**
+ * Compaction slack. Trimming to MAX_ENTRIES on the very first append past the cap
+ * would rewrite the whole file on every subsequent append; letting it overshoot by
+ * 10% makes the rewrite amortised instead.
+ */
+const COMPACT_AT = Math.floor(MAX_ENTRIES * 1.1)
+
+/** Refuse to parse a file larger than this — it is corrupt, not a backlog. */
+const MAX_FILE_BYTES = 8 * 1024 * 1024
+
+/** One archive that has not been confirmed by the backend yet. */
+export interface PendingArchive {
+  /** The app's own agent id (`claude-…`), the key everything else here matches on. */
+  appId: string
+  /** Who was signed in when the agent was closed. '' when nobody was. See the header. */
+  uid: string
+}
+
+/** In-memory line count, so an append does not have to read the file to know the size. */
+let cachedCount: number | null = null
+
+// The four functions below (read, write, compact, and the cap constants above) are
+// the same NDJSON mechanics as store/outbox.ts, deliberately kept as a second copy:
+// the two spools differ in policy, not in file handling. Fix one, look at the other.
+function readEntries(): PendingArchive[] {
+  try {
+    if (!fs.existsSync(SPOOL_FILE)) return []
+    if (fs.statSync(SPOOL_FILE).size > MAX_FILE_BYTES) {
+      // Not recoverable by parsing: something else wrote here, or a partial write
+      // ran away. Start clean rather than spend memory proving it is garbage.
+      fs.rmSync(SPOOL_FILE, { force: true })
+      return []
+    }
+    return fs
+      .readFileSync(SPOOL_FILE, 'utf-8')
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .flatMap((line) => {
+        // One torn line (a crash mid-append) must not discard the rest of the file.
+        try {
+          const entry = JSON.parse(line) as PendingArchive
+          if (typeof entry?.appId !== 'string' || entry.appId === '') return []
+          return [{ appId: entry.appId, uid: typeof entry.uid === 'string' ? entry.uid : '' }]
+        } catch {
+          return []
+        }
+      })
+  } catch (error) {
+    console.error('[pending-archives] Unreadable spool, starting empty:', error)
+    return []
+  }
+}
+
+/** Replace the file contents atomically, so a crash mid-write cannot truncate it. */
+function writeEntries(entries: PendingArchive[]): void {
+  try {
+    fs.mkdirSync(path.dirname(SPOOL_FILE), { recursive: true })
+    const tmp = `${SPOOL_FILE}.tmp`
+    const body = entries.map((e) => JSON.stringify(e)).join('\n')
+    fs.writeFileSync(tmp, body === '' ? '' : `${body}\n`, { encoding: 'utf-8', mode: 0o600 })
+    fs.renameSync(tmp, SPOOL_FILE)
+    cachedCount = entries.length
+  } catch (error) {
+    console.error('[pending-archives] Failed to rewrite the spool:', error)
+    cachedCount = null
+  }
+}
+
+/**
+ * Drop the OLDEST entries past the cap.
+ *
+ * A dropped entry is an agent that may come back, so this is a real loss and not a
+ * trim — but the newest closes are the ones a user would notice reappearing, and an
+ * unbounded file is a worse failure than a stale one.
+ */
+function compactIfNeeded(): void {
+  if ((cachedCount ?? 0) < COMPACT_AT) return
+  const entries = readEntries()
+  if (entries.length < COMPACT_AT) {
+    cachedCount = entries.length
+    return
+  }
+  const kept = entries.slice(entries.length - MAX_ENTRIES)
+  console.warn(`[pending-archives] Spool full, dropped ${entries.length - kept.length} oldest archive(s)`)
+  writeEntries(kept)
+}
+
+/**
+ * Record ONE archive as pending, BEFORE its write goes out.
+ *
+ * Deduplicated on (app id, uid): closing the same agent twice must leave ONE entry,
+ * or resolving it once would leave a phantom behind that hides the agent from every
+ * later hydration.
+ *
+ * The uid is half of that identity, not decoration. App ids are `claude-${Date.now()}`
+ * and the spool outlives a sign-out, so two accounts on one installation can hold the
+ * same id. Keyed on the app id alone, the second account's close would match the
+ * first's entry, be reported durable without ever being recorded, and then be settled
+ * — or hidden from hydration — under the wrong owner. Both accounts get their own
+ * entry, and each is settled only by the owner who can actually make its write.
+ *
+ * That is not an edge case but the normal path of a replay: flushPendingArchives()
+ * goes back through CloudStore.archiveAgent, which records its write-ahead entry
+ * before anything else, so every replayed entry re-enqueues itself. The dedupe makes
+ * that a no-op — which is why the flush needs no guard of its own.
+ *
+ * Never throws. The caller is a write path whose failure mode this exists to fix —
+ * making it fail differently would be no improvement.
+ *
+ * Returns whether the intent is now DURABLE: `true` when the entry is on disk (or
+ * was already there), `false` when the write could not be made — a read-only, full
+ * or inaccessible config dir. Swallowing that and answering nothing would be the
+ * original bug wearing a new hat: the caller's whole right to stay quiet on a
+ * deferred write rests on this file holding the intent, so a caller that is not told
+ * the file does NOT hold it would defer into silence and lose the close for good.
+ */
+export function enqueuePendingArchive(entry: PendingArchive): boolean {
+  try {
+    // A known-empty spool has nothing to deduplicate against, so the ordinary close
+    // — every close made while the backend is reachable — touches the disk once, to
+    // append. Only a spool that already holds something pays the read.
+    const entries = cachedCount === 0 ? [] : readEntries()
+    // Already recorded — by an earlier close of the same agent, or by the replay
+    // that re-enters through the store. The intent is durable either way. Matched on
+    // BOTH fields: another account's entry for a colliding app id is not this
+    // close's, and treating it as one would answer "durable" for something never
+    // written.
+    if (entries.some((e) => e.appId === entry.appId && e.uid === entry.uid)) return true
+    fs.mkdirSync(path.dirname(SPOOL_FILE), { recursive: true })
+    fs.appendFileSync(SPOOL_FILE, `${JSON.stringify(entry)}\n`, { encoding: 'utf-8', mode: 0o600 })
+    cachedCount = entries.length + 1
+    compactIfNeeded()
+    return true
+  } catch (error) {
+    console.error('[pending-archives] Failed to record a pending archive:', error)
+    return false
+  }
+}
+
+/**
+ * Why removing an entry takes an OUTCOME and not just an owner.
+ *
+ * Entries recorded with no session carry `uid: ''` — the app was signed out at the
+ * moment of the close, so who owned the agent is genuinely unknown. They are replayed
+ * under whatever session appears next, because refusing to replay them at all would
+ * strand them forever. But that replay is a GUESS about ownership, and the two ways it
+ * can end are not symmetric:
+ *
+ * - `landed` — the update matched a row under this owner, or the probe found it already
+ *   archived. That is proof the guess was right, so the unattributed entry may be
+ *   claimed and removed.
+ * - `unmatched` — nothing matched for this owner. That proves the opposite: the entry
+ *   was someone else's. Removing it here would delete the only durable record of a
+ *   close that still has to happen, and its owner's live agent would come back with a
+ *   fresh PTY — the resurrection this whole file exists to prevent, reached through the
+ *   very code meant to stop it.
+ *
+ * So an `unmatched` outcome only ever removes an entry whose uid matches EXACTLY.
+ */
+export type ArchiveOutcome = 'landed' | 'unmatched'
+
+/**
+ * Forget ONE pending archive — its outcome is settled.
+ *
+ * Called both when the stamp landed and when it provably never will for THIS owner
+ * (the row is gone, or was already archived): an entry that cannot succeed must not
+ * be retried forever, and must not keep hiding an app id from hydration.
+ *
+ * "Belongs to another account" is deliberately NOT such a case — that says nothing
+ * about the row, which is still live and still needs archiving by whoever owns it.
+ * The replay loop skips those entries instead of resolving them.
+ *
+ * Hence the `uid`: settling is scoped to the owner who actually made the write, so a
+ * colliding app id belonging to someone else survives. See `ArchiveOutcome` for why
+ * an unattributed entry follows the outcome rather than the owner.
+ */
+export function resolvePendingArchive(appId: string, uid: string, outcome: ArchiveOutcome): void {
+  try {
+    const entries = readEntries()
+    const kept = entries.filter(
+      (e) => !(e.appId === appId && (e.uid === uid || (outcome === 'landed' && e.uid === '')))
+    )
+    if (kept.length === entries.length) return
+    writeEntries(kept)
+  } catch (error) {
+    console.error('[pending-archives] Failed to resolve a pending archive:', error)
+  }
+}
+
+/**
+ * The app ids whose archive has not been confirmed yet, FOR THE CURRENT SESSION.
+ *
+ * Scoped by owner for the same reason resolution is: the roster this hides ids from
+ * is already `owner_id`-scoped, so another account's pending close says nothing about
+ * what this one may see. Left unscoped, a colliding app id would hide a live agent
+ * this user never closed — the mirror image of the resurrection bug, and just as
+ * invisible. Entries with no uid are included: they were made by this installation
+ * with no session loaded, and the replay treats them as the current session's too.
+ *
+ * Synchronous, because its one caller (hydrateAgents) has to decide what to put in
+ * the cache in the same step it fills it. A known-empty spool costs no disk access.
+ */
+export function pendingArchiveIds(): string[] {
+  if (cachedCount === 0) return []
+  const entries = readEntries()
+  cachedCount = entries.length
+  const uid = loadSession()?.user?.id ?? ''
+  return entries.filter((e) => e.uid === '' || uid === '' || e.uid === uid).map((e) => e.appId)
+}
+
+let flushing: Promise<number> | null = null
+
+/**
+ * Replay every pending archive, oldest first. Returns how many entries left the spool.
+ *
+ * The entries are NOT removed here: each replay goes back through the store, which
+ * owns the distinction between "landed", "already archived" and "will never match" —
+ * and resolves the entry itself in all three cases. This loop only removes what it
+ * refuses to send at all.
+ *
+ * Stops at the FIRST failure, like the outbox: the failure is almost always "the
+ * backend is unreachable", and walking the whole spool to learn that once per entry
+ * would hammer a network that is already down. An entry the store dropped on its way
+ * out still stops this pass, and that costs one gate tick — the next flush starts
+ * after it, since it is no longer in the file.
+ *
+ * Concurrent calls share one run: the connectivity gate polls every 20 seconds and on
+ * focus, and two overlapping passes would send every stamp twice.
+ */
+export function flushPendingArchives(): Promise<number> {
+  if (flushing) return flushing
+  if (cachedCount === 0) return Promise.resolve(0)
+
+  flushing = (async () => {
+    const entries = readEntries()
+    cachedCount = entries.length
+    if (entries.length === 0) return 0
+
+    const uid = loadSession()?.user?.id ?? ''
+
+    for (const entry of entries) {
+      // Another account's close. Not ours to replay: the update would be scoped by
+      // the current owner_id, match nothing, and be reported to this user as a
+      // failed write of an agent they never had.
+      //
+      // SKIPPED, not resolved. Dropping it would destroy the only durable record
+      // that this close ever happened: the row is still live server-side, so once
+      // its owner signs back in on this machine, hydration would load the agent and
+      // restoreAgents() would hand it a fresh PTY — the exact resurrection this
+      // spool exists to prevent, just deferred until the next account switch. The
+      // entry costs one line and is bounded by MAX_ENTRIES; the owner's next flush
+      // settles it. Only an outcome that is PROVEN (landed, already archived, or
+      // unmatchable for this owner) may resolve an entry, and "belongs to someone
+      // else" proves nothing about the row.
+      if (entry.uid !== '' && uid !== '' && entry.uid !== uid) continue
+
+      try {
+        await getStore().archiveAgent(entry.appId)
+      } catch (error) {
+        // Whether this entry survives is the store's call, not this loop's: it has
+        // already settled the ones it proved unmatchable. All that is decided here
+        // is that the rest of the backlog waits for the next tick.
+        console.error('[pending-archives] Replay failed, stopping this pass:', error)
+        break
+      }
+    }
+
+    // What settled is what LEFT the spool, and the file is the only thing that knows
+    // which entries those are. Counting the replays that came back without throwing
+    // would be counting something else: with no session to write with, archiveAgent
+    // DEFERS — it keeps the entry and stays quiet, deliberately — so a signed-out app
+    // would report its whole backlog as settled on every gate tick while nothing at
+    // all had been delivered. A rewrite that itself failed leaves its entry in place
+    // and is likewise not counted, which is the truth about it.
+    const remaining = new Set(readEntries().map((e) => e.appId))
+    const settled = entries.filter((e) => !remaining.has(e.appId)).length
+
+    if (settled > 0) console.log(`[pending-archives] Settled ${settled} pending archive(s)`)
+    return settled
+  })()
+    .catch((error) => {
+      console.error('[pending-archives] Flush failed:', error)
+      return 0
+    })
+    .finally(() => {
+      flushing = null
+    })
+
+  return flushing
+}
+
+/** Test seam: forget the cached count so a fresh temp file is read from disk. */
+export function resetPendingArchivesForTests(): void {
+  cachedCount = null
+  flushing = null
+}


### PR DESCRIPTION
## Description

Archiving an agent is a soft delete: `terminal:kill` stamps `archived_at` on the row and drops the agent from the in-memory cache. The stamp was written fire-and-forget, and three paths lost it with nothing reported — so the agent came back at the next launch with a freshly spawned PTY, and **an archive that did not land was indistinguishable from one that did**.

This makes the failure visible and the write durable:

- **Visible** — `archiveAgentRow` no longer returns silently on `!uuid` or `!ctx`, and `.select('id')` turns "0 rows matched" from a silent success into a reported failure, so `reportWriteError('agents', …)` actually fires.
- **Durable** — a write-ahead NDJSON spool records the intent to archive *before* the PATCH and resolves it only after a confirmed row count. It is replayed from the connectivity `ok` gate, so a close that died with the process is retried rather than lost.

Follow-up to #180 / #179 / #181, which removed the reproducible symptom but not the silent-loss window.

## Related Issue

Fixes #184

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **New `desktop/src/main/store/pending-archives.ts`** — a write-ahead NDJSON spool in `CONFIG_DIR`, modelled on the sibling `store/outbox.ts`: atomic tmp-then-rename at `0600`, per-line parse tolerance, a `MAX_ENTRIES` cap with compaction, and a single-flight flush. Entries carry `{ appId, uid }` so a close spooled under one account is never replayed against another.
- **`CloudStore.archiveAgent`** enqueues the spool entry *before* `queueAgentWrite`, so the intent hits disk synchronously at close time no matter what the agent-write chain is holding.
- **`CloudStore.archiveAgentRow`** — dropped `if (!uuid) return`; swapped `context()` for `userContext()` (the org was never read, so requiring it was a gratuitous silent failure); added `.select('id')` and a row-count check. `!ctx` now leaves the entry spooled and returns without a toast: a deferred write is not a lost one.
- **New `isAlreadyArchived` probe** returns three states. It looks the row up by uuid when the map is warm and by `metadata->__app->>id` when it is cold — the only identifier that survives the archive statement nulling `app_agent_id`, and therefore the only one a post-restart replay can use. A probe that *errors* keeps the spool entry for retry instead of destroying it.
- **`config/agents.ts`** — `hydrateAgents()` filters out app ids still pending, so an unconfirmed close cannot come back through `restoreAgents()` with a new PTY.
- **`ipc/connectivity-handlers.ts`** — the replay runs before `ensureHydrated()`, so hydration's `.is('archived_at', null)` filter naturally excludes what was just archived.
- **`store/Store.ts`** — the `archiveAgent` doc contract no longer claims a no-op for an unloaded agent; that was the silent-loss contract itself. Signature unchanged.

### Deliberate deviations from the issue's proposed fix

- **No `await` of the agent-write chain in `before-quit`.** Electron does not await that handler (`index.ts:780`; the only `preventDefault()` is the tray branch), so the existing `await stopStatusServer()` is already decorative and one more await would buy nothing. Write-ahead logging covers what a quit hook cannot.
- **uuid first, `app_agent_id` as the fallback**, rather than filtering on `app_agent_id` unconditionally. `fromAgentRow` reads `row.app_agent_id ?? app?.id ?? row.id`, an older installed build still upserts `onConflict: 'id'` leaving the column null, and migration `20260814090000` only backfilled rows existing at the time. An unconditional match would report a false failure on those rows.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

Full vitest suite passes: **73 files / 1073 tests**, including ~20 new ones. Every regression test was sanity-checked by reinstating the old behaviour and confirming it fails.

### Test Steps

Prerequisites: Node 20 (`.nvmrc`), a signed-in desktop build. Note the config dir is `~/.config/magic-slash-dev/` for a dev build and `~/.config/magic-slash/` for a packaged one.

1. Run `npx vitest run` from the repo root — expect 73 files / 1073 tests green.
2. **The issue's exact scenario.** Start the desktop app, open an agent, close it, and quit the app *immediately*. Relaunch: the agent must **not** reappear with a new terminal, and `pending-archives.ndjson` must be empty once the first connectivity check succeeds.
3. **Deferred write.** Disconnect the network, then close an agent. Expect **no** error toast, and one line in `pending-archives.ndjson`. Reconnect: within one connectivity poll the line disappears and the row is stamped (`archived_at` set, `app_agent_id` null).
4. **Idempotent re-close.** Close the same agent twice. The second close must produce no toast — it matches 0 rows legitimately and the probe recognises it as already archived.
5. **Reported loss.** Sign out so the id map is cold, then close an agent whose row does not exist. Expect a "write failed" toast rather than silence, and no lingering spool entry.

## Screenshots

N/A — no UI surface changed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

Two boxes are deliberately left unchecked:

- **CHANGELOG.md** was not touched — flagging it in case this repo expects an entry per fix.
- **`tsc --noEmit` was not run.** `desktop/node_modules` is not installed in this worktree, so the whole tree errors on missing `@types/node`/`electron` before checking anything. ESLint's TS parser is clean on the changed files, but **CI is the first real typecheck of this diff**.

Known limitations, all pre-existing or out of scope:

- The fix does not clean rows already left unarchived — as the issue notes, those need one more close after this ships.
- The hydration filter has no expiry: an entry the gate can never flush (cloud disabled) hides that agent from the local roster while its row stays unarchived server-side.
- `pending-archives.ts` duplicates ~100 lines of NDJSON mechanics from `outbox.ts`. Extraction was considered and deferred — `outbox.ts` is untouched here, so a shared helper would have exactly one caller. Two latent bugs live in **both** copies: `writeEntries` leaves a stale `.tmp` if `renameSync` throws, and the oversize branch of `readEntries` deletes the file without resetting `cachedCount`.
