### PR TITLE
[#188] Auto-detect the context window on the Skills budget gauge

### DIFF
--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -887,6 +887,11 @@ export const en = {
   'skills.budget.window.label': 'Context window',
   'skills.budget.window.small': '200K tokens',
   'skills.budget.window.large': '1M tokens',
+  'skills.budget.window.auto': 'Auto',
+  'skills.budget.window.autoValue': 'Auto · {window}',
+  'skills.budget.window.autoDetected': 'Detected from the running agent.',
+  'skills.budget.window.autoNoAgent': 'No agent running — falling back to {window}.',
+  'skills.budget.window.forced': 'Forced to {window}, whatever is running.',
   'skills.budget.over':
     'Over budget by {over} characters. Claude Code is already listing some skills by name only — it can still run them, but it can no longer tell when they apply.',
   'skills.budget.truncated.one':
@@ -907,9 +912,9 @@ export const en = {
   'skills.budget.card.overflow.title': 'Over budget, descriptions vanish',
   'skills.budget.card.overflow.body':
     'The listing is not trimmed evenly. Claude Code drops whole descriptions, starting with the skills you invoke least, and lists those by name only. Claude can still run them if you name them, but it no longer knows when to reach for them on its own.',
-  'skills.budget.card.why.title': 'Why the 200K / 1M switch',
+  'skills.budget.card.why.title': 'Where the window comes from',
   'skills.budget.card.why.body':
-    'Since the budget is a fraction of the context window, the same set of skills is comfortable on a 1M-token model and over budget on a 200K one. This app cannot know which model a given agent will run, so you pick the one to size against — it changes the gauges here and nothing else.',
+    'Since the budget is a fraction of the context window, the same set of skills is comfortable on a 1M-token model and over budget on a 200K one. On Auto, the window is read from the agent you have running — the real one, reported by Claude Code itself. The two presets override it, to see what your skills would look like on another model or when nothing is running. Either way it changes the gauges here and nothing else.',
   'skills.budget.card.override.title': 'Changing the budget itself',
   'skills.budget.card.override.body':
     'In settings.json, skillListingBudgetFraction raises the 1% share and skillListingMaxDescChars the per-skill cap; the SLASH_COMMAND_TOOL_CHAR_BUDGET environment variable replaces the whole computation with a fixed character count. Run /doctor to see what the listing really costs.',

--- a/desktop/src/i18n/fr.ts
+++ b/desktop/src/i18n/fr.ts
@@ -892,6 +892,11 @@ export const fr: Record<keyof typeof en, string> = {
   'skills.budget.window.label': 'Fenêtre de contexte',
   'skills.budget.window.small': '200K tokens',
   'skills.budget.window.large': '1M tokens',
+  'skills.budget.window.auto': 'Auto',
+  'skills.budget.window.autoValue': 'Auto · {window}',
+  'skills.budget.window.autoDetected': 'Détectée sur l’agent en cours.',
+  'skills.budget.window.autoNoAgent': 'Aucun agent en cours — repli sur {window}.',
+  'skills.budget.window.forced': 'Forcée à {window}, quoi qu’il tourne.',
   'skills.budget.over':
     'Dépassement de {over} caractères. Claude Code liste déjà certains skills par leur nom seul — il peut encore les lancer, mais il ne sait plus quand ils s’appliquent.',
   'skills.budget.truncated.one':
@@ -912,9 +917,9 @@ export const fr: Record<keyof typeof en, string> = {
   'skills.budget.card.overflow.title': 'En dépassement, les descriptions disparaissent',
   'skills.budget.card.overflow.body':
     'Le catalogue n’est pas rogné uniformément. Claude Code supprime des descriptions entières, en commençant par les skills que vous invoquez le moins, et ne liste plus que leur nom. Claude peut encore les lancer si vous les nommez, mais il ne sait plus y penser tout seul.',
-  'skills.budget.card.why.title': 'Pourquoi le switch 200K / 1M',
+  'skills.budget.card.why.title': 'D’où vient la fenêtre',
   'skills.budget.card.why.body':
-    'Le budget étant une fraction de la fenêtre de contexte, un même ensemble de skills tient à l’aise sur un modèle 1M et déborde sur un 200K. L’app ne peut pas deviner quel modèle tournera : vous choisissez celui sur lequel vous vous calez. Cela ne change que les jauges de cette page.',
+    'Le budget étant une fraction de la fenêtre de contexte, un même ensemble de skills tient à l’aise sur un modèle 1M et déborde sur un 200K. En Auto, la fenêtre est lue sur l’agent que vous avez en cours — la vraie, remontée par Claude Code lui-même. Les deux préréglages la forcent, pour voir ce que donneraient vos skills sur un autre modèle ou quand rien ne tourne. Dans tous les cas, cela ne change que les jauges de cette page.',
   'skills.budget.card.override.title': 'Changer le budget lui-même',
   'skills.budget.card.override.body':
     'Dans settings.json, skillListingBudgetFraction relève la part de 1 % et skillListingMaxDescChars le plafond par skill ; la variable d’environnement SLASH_COMMAND_TOOL_CHAR_BUDGET remplace tout le calcul par un nombre de caractères fixe. Lancez /doctor pour voir ce que le catalogue coûte vraiment.',

--- a/desktop/src/renderer/pages/Skills/contextWindow.test.ts
+++ b/desktop/src/renderer/pages/Skills/contextWindow.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { detectContextWindow, migrateSkillsContextWindow, resolveContextWindow, formatWindow, DEFAULT_CONTEXT_WINDOW } from './contextWindow'
+import type { TerminalInfo, TerminalState } from '../../../types'
+
+const terminal = (
+  id: string,
+  state: TerminalState,
+  contextWindowSize?: number,
+): TerminalInfo => ({
+  id,
+  name: id,
+  state,
+  repositories: [],
+  metadata: contextWindowSize === undefined ? undefined : { usage: { contextWindowSize } },
+})
+
+describe('detectContextWindow', () => {
+  it('takes the window of the agent being inspected', () => {
+    const terminals = [
+      terminal('other', 'working', 200_000),
+      terminal('focused', 'working', 1_000_000),
+    ]
+    expect(detectContextWindow(terminals, 'focused')).toBe(1_000_000)
+  })
+
+  it('reads the inspected agent whatever live state it is in', () => {
+    for (const state of ['idle', 'working', 'waiting'] as const) {
+      expect(detectContextWindow([terminal('a', state, 1_000_000)], 'a')).toBe(1_000_000)
+    }
+  })
+
+  it('ignores a finished agent still carrying its last reported window', () => {
+    // Usage is never cleared when an agent completes, so the focused terminal
+    // here holds a 1M window from a session that is over. The live 200K agent is
+    // the one describing what is running now.
+    const terminals = [
+      terminal('done', 'completed', 1_000_000),
+      terminal('running', 'working', 200_000),
+    ]
+    expect(detectContextWindow(terminals, 'done')).toBe(200_000)
+  })
+
+  it('falls back to the largest window across the live agents', () => {
+    const terminals = [
+      terminal('small', 'idle', 200_000),
+      terminal('big', 'working', 1_000_000),
+      terminal('middle', 'waiting', 500_000),
+    ]
+    expect(detectContextWindow(terminals, null)).toBe(1_000_000)
+  })
+
+  it('does not let a finished agent win the fallback either', () => {
+    const terminals = [
+      terminal('done', 'error', 1_000_000),
+      terminal('running', 'idle', 200_000),
+    ]
+    expect(detectContextWindow(terminals, null)).toBe(200_000)
+  })
+
+  it('returns undefined when nothing is running', () => {
+    expect(detectContextWindow([], null)).toBeUndefined()
+    expect(detectContextWindow([terminal('done', 'completed', 1_000_000)], 'done')).toBeUndefined()
+  })
+
+  it('returns undefined when the live agents have reported no usage yet', () => {
+    expect(detectContextWindow([terminal('fresh', 'working')], 'fresh')).toBeUndefined()
+  })
+
+  it('ignores an inspected id that matches no terminal', () => {
+    expect(detectContextWindow([terminal('a', 'working', 1_000_000)], 'ghost')).toBe(1_000_000)
+  })
+})
+
+describe('migrateSkillsContextWindow', () => {
+  it('turns the legacy 200K default into auto', () => {
+    expect(migrateSkillsContextWindow(200_000)).toBe('auto')
+  })
+
+  it('keeps an explicit 1M override', () => {
+    expect(migrateSkillsContextWindow(1_000_000)).toBe(1_000_000)
+  })
+
+  it('falls back to auto for a missing or corrupted value', () => {
+    expect(migrateSkillsContextWindow(undefined)).toBe('auto')
+    expect(migrateSkillsContextWindow(null)).toBe('auto')
+    expect(migrateSkillsContextWindow('1000000')).toBe('auto')
+    expect(migrateSkillsContextWindow({ size: 1_000_000 })).toBe('auto')
+  })
+
+  it('leaves an already-migrated auto alone', () => {
+    expect(migrateSkillsContextWindow('auto')).toBe('auto')
+  })
+})
+
+describe('resolveContextWindow', () => {
+  it('lets a forced preset win regardless of what is detected', () => {
+    expect(resolveContextWindow(200_000, 1_000_000)).toBe(200_000)
+    expect(resolveContextWindow(1_000_000, 200_000)).toBe(1_000_000)
+    expect(resolveContextWindow(1_000_000, undefined)).toBe(1_000_000)
+  })
+
+  it('resolves auto to the detected window', () => {
+    expect(resolveContextWindow('auto', 500_000)).toBe(500_000)
+  })
+
+  it('falls back to the default when auto has nothing detected', () => {
+    expect(resolveContextWindow('auto', undefined)).toBe(DEFAULT_CONTEXT_WINDOW)
+  })
+})
+
+describe('formatWindow', () => {
+  it('renders the two presets the way the switch labels them', () => {
+    expect(formatWindow(200_000)).toBe('200K')
+    expect(formatWindow(1_000_000)).toBe('1M')
+  })
+
+  it('renders a window that is neither preset', () => {
+    expect(formatWindow(350_000)).toBe('350K')
+    expect(formatWindow(1_500_000)).toBe('1.5M')
+    // Rounded to the nearest thousand, then to one decimal — never "1.0M".
+    expect(formatWindow(1_048_576)).toBe('1M')
+  })
+})

--- a/desktop/src/renderer/pages/Skills/contextWindow.ts
+++ b/desktop/src/renderer/pages/Skills/contextWindow.ts
@@ -1,0 +1,110 @@
+import type { TerminalInfo, TerminalState } from '../../../types'
+
+/**
+ * The window to size the skills budget against when nothing else is known: no
+ * agent has ever reported one, and the user has not forced a preset. 200K is the
+ * smaller of the two presets on purpose — under-promising a budget shows a red
+ * gauge on a description that would have fit, which is the recoverable mistake.
+ */
+export const DEFAULT_CONTEXT_WINDOW = 200_000
+
+/**
+ * The states in which an agent is still running, and its reported usage still
+ * describes the model in front of you.
+ *
+ * `completed` and `error` are deliberately out: usage is never cleared when an
+ * agent finishes (see the comment above `updateTerminalUsageFromHook` in
+ * `main/pty/terminal-manager.ts`), so a finished terminal keeps carrying the
+ * window of a session that is over. Reading it back would let yesterday's Opus
+ * run size today's gauges.
+ */
+const LIVE_TERMINAL_STATES: readonly TerminalState[] = ['idle', 'working', 'waiting']
+
+function isLive(terminal: TerminalInfo): boolean {
+  return LIVE_TERMINAL_STATES.includes(terminal.state)
+}
+
+/** The window this agent reported, if it reported a usable one at all. */
+function reportedWindow(terminal: TerminalInfo): number | undefined {
+  const size = terminal.metadata?.usage?.contextWindowSize
+  return typeof size === 'number' && Number.isFinite(size) && size > 0 ? size : undefined
+}
+
+/**
+ * The context window the running agents say they have.
+ *
+ * The agent you are looking at wins — that is the one whose skills listing you
+ * are about to reason about. Failing that (no agent focused, the focused one has
+ * finished, or it has not reported usage yet) the largest window across the live
+ * agents wins: a listing that fits the biggest model running is the optimistic
+ * reading, and the switch is there to check the pessimistic one.
+ *
+ * Returns `undefined` when nothing is running, which is the caller's cue to fall
+ * back to DEFAULT_CONTEXT_WINDOW rather than to invent a number.
+ */
+export function detectContextWindow(
+  terminals: TerminalInfo[],
+  inspectedTerminalId: string | null | undefined,
+): number | undefined {
+  const inspected = inspectedTerminalId
+    ? terminals.find((terminal) => terminal.id === inspectedTerminalId)
+    : undefined
+
+  if (inspected && isLive(inspected)) {
+    const size = reportedWindow(inspected)
+    if (size !== undefined) return size
+  }
+
+  let largest: number | undefined
+  for (const terminal of terminals) {
+    if (!isLive(terminal)) continue
+    const size = reportedWindow(terminal)
+    if (size !== undefined && (largest === undefined || size > largest)) largest = size
+  }
+  return largest
+}
+
+/**
+ * Bring a persisted context-window preference forward to the 'auto' era.
+ *
+ * Before this, the preference was a plain 200K / 1M choice defaulting to 200K —
+ * so every user who never touched the switch has a stored `200_000` that would
+ * otherwise keep overriding the window their agents actually report. Only an
+ * explicit 1M override survives; a legacy 200K, a missing field and corrupted
+ * data all become 'auto'.
+ *
+ * Lives here rather than in the store so it can be tested without zustand.
+ */
+export function migrateSkillsContextWindow(persisted: unknown): 'auto' | 1_000_000 {
+  return persisted === 1_000_000 ? 1_000_000 : 'auto'
+}
+
+/**
+ * What the gauges are actually scaled to, once the setting and the detected
+ * window are both known: the setting wins when it forces a preset, otherwise
+ * the detected window, otherwise DEFAULT_CONTEXT_WINDOW.
+ *
+ * Kept beside detectContextWindow rather than inline in the component, so this
+ * resolution rule is exercised by contextWindow.test.ts like the rest of the
+ * module's policy.
+ */
+export function resolveContextWindow(
+  setting: 'auto' | 200_000 | 1_000_000,
+  detected: number | undefined,
+): number {
+  return setting === 'auto' ? detected ?? DEFAULT_CONTEXT_WINDOW : setting
+}
+
+/**
+ * A context window as a human reads it: `200K`, `1M`, `350K`.
+ *
+ * The detected value is whatever the model reports, not one of two buckets, so
+ * this has to stay sane on 350 000 or 1 048 576. Rounded to the nearest thousand,
+ * and to at most one decimal past a million — `1.5M`, never `1.0M`.
+ */
+export function formatWindow(n: number): string {
+  const thousands = Math.round(n / 1_000)
+  if (thousands < 1_000) return `${thousands}K`
+  const millions = Math.round(thousands / 100) / 10
+  return `${millions}M`
+}

--- a/desktop/src/renderer/pages/Skills/index.tsx
+++ b/desktop/src/renderer/pages/Skills/index.tsx
@@ -5,9 +5,10 @@ import SkillDocument from './SkillDocument'
 import { VSCodeIcon } from '../../components/agent-info-sidebar/icons'
 import { SweepPane } from '../../components/SweepPane'
 import { useTerminals } from '../../hooks/useTerminals'
-import { useStore, type SkillsContextWindow } from '../../store'
+import { useStore, type SkillsContextWindow, type SkillsContextWindowSetting } from '../../store'
 import { useLocale, useT, type MessageKey, type Translate } from '../../i18n'
 import { BTN, BTN_DANGER, BTN_PRIMARY, INPUT } from '../../theme/controls'
+import { DEFAULT_CONTEXT_WINDOW, detectContextWindow, resolveContextWindow, formatWindow } from './contextWindow'
 
 /**
  * The skill listing budget, as Claude Code actually computes it.
@@ -25,8 +26,9 @@ import { BTN, BTN_DANGER, BTN_PRIMARY, INPUT } from '../../theme/controls'
  *
  * The fraction is `skillListingBudgetFraction` in settings.json, and
  * `SLASH_COMMAND_TOOL_CHAR_BUDGET` overrides the whole computation with a fixed
- * character count. We mirror the shipped defaults; the switch above the gauges
- * covers the one input we cannot read from here — which model is running.
+ * character count. We mirror the shipped defaults; the window itself is read off
+ * the running agents (see contextWindow.ts), and the switch above the gauges
+ * forces one of the two presets when you want to size against another model.
  */
 const CHARS_PER_TOKEN = 4
 const BUDGET_FRACTION = 0.01
@@ -39,8 +41,16 @@ const BUDGET_FRACTION = 0.01
  */
 const MAX_DESC_CHARS = 1536
 
-/** The two windows worth comparing. Order is the order of the switch. */
+/** The two windows worth comparing. Order is the order of the switch, after Auto. */
 const CONTEXT_WINDOWS: readonly SkillsContextWindow[] = [200_000, 1_000_000]
+
+// One class per slot the switch's highlight can travel to, in the same order as
+// the segments below (Auto, then CONTEXT_WINDOWS). Indexed rather than derived
+// from a chain of `value === ...` checks, so a slot added or reordered here is
+// the only place that has to change. Written as literal classes, not a computed
+// `translate-x-[${...}%]`: Tailwind's build-time scan only picks up class names
+// that appear verbatim in the source.
+const HIGHLIGHT_OFFSETS = ['translate-x-0', 'translate-x-full', 'translate-x-[200%]'] as const
 
 function charBudgetFor(contextWindow: number): number {
   return Math.max(1, Math.floor(contextWindow * CHARS_PER_TOKEN * BUDGET_FRACTION))
@@ -126,35 +136,74 @@ function sourceLabel(source: string, t: Translate): string {
 }
 
 /**
- * The 200K / 1M choice. Drawn as a segmented control rather than a select: it has
- * exactly two values and both matter enough to stay visible, since the reading of
- * every gauge below depends on which one is active.
+ * Auto / 200K / 1M. Drawn as a segmented control rather than a select: the
+ * reading of every gauge below depends on which one is active, so all three
+ * stay visible.
+ *
+ * `Auto` is not a value, it is a source — so its label carries the window it
+ * resolved to (`Auto · 1M`), and a line under the switch says where that number
+ * came from. Without it, a gauge scaled to a window nobody typed is a surprise
+ * with no explanation on screen.
  */
-function ContextWindowSwitch({ value, onChange }: { value: SkillsContextWindow; onChange: (next: SkillsContextWindow) => void }) {
+function ContextWindowSwitch({
+  value,
+  detected,
+  effectiveWindow,
+  onChange,
+}: {
+  value: SkillsContextWindowSetting
+  /** The window the running agents report, or undefined when none does. */
+  detected: number | undefined
+  /** What the gauges are actually scaled to, once auto and the fallback resolve. */
+  effectiveWindow: number
+  onChange: (next: SkillsContextWindowSetting) => void
+}) {
   const t = useT()
 
+  // One segment per switch position, in the order they are drawn: Auto, then
+  // the two forced presets. Auto's label is not a fixed string — it carries
+  // the window it resolved to (`Auto · 1M`) once `detected` is known.
+  const segments: { value: SkillsContextWindowSetting; label: string }[] = [
+    {
+      value: 'auto',
+      label: detected !== undefined
+        ? t('skills.budget.window.autoValue', { window: formatWindow(detected) })
+        : t('skills.budget.window.auto'),
+    },
+    { value: CONTEXT_WINDOWS[0], label: t('skills.budget.window.small') },
+    { value: CONTEXT_WINDOWS[1], label: t('skills.budget.window.large') },
+  ]
+  const activeIndex = Math.max(0, segments.findIndex((segment) => segment.value === value))
+
+  const hint = value === 'auto'
+    ? detected !== undefined
+      ? t('skills.budget.window.autoDetected')
+      : t('skills.budget.window.autoNoAgent', { window: formatWindow(DEFAULT_CONTEXT_WINDOW) })
+    : t('skills.budget.window.forced', { window: formatWindow(effectiveWindow) })
+
   return (
-    <div className="flex items-center gap-2 flex-shrink-0">
-      <span className="text-[11px] text-text-secondary/50 whitespace-nowrap">{t('skills.budget.window.label')}</span>
-      <div className="relative grid grid-cols-2 bg-surface rounded-full p-px border border-line-subtle" role="group" aria-label={t('skills.budget.window.label')}>
-        <div
-          className={`absolute top-px bottom-px left-px right-1/2 bg-surface-strong rounded-full transition-transform duration-200 ${
-            value === CONTEXT_WINDOWS[1] ? 'translate-x-full' : 'translate-x-0'
-          }`}
-        />
-        {CONTEXT_WINDOWS.map((size) => (
-          <button
-            key={size}
-            onClick={() => onChange(size)}
-            aria-pressed={value === size}
-            className={`relative z-10 px-3 py-1 rounded-full text-[11px] font-medium transition-colors duration-200 text-center whitespace-nowrap ${
-              value === size ? 'text-ink' : 'text-text-secondary/50 hover:text-text-secondary'
-            }`}
-          >
-            {t(size === CONTEXT_WINDOWS[0] ? 'skills.budget.window.small' : 'skills.budget.window.large')}
-          </button>
-        ))}
+    <div className="flex flex-col items-end gap-1 flex-shrink-0">
+      <div className="flex items-center gap-2">
+        <span className="text-[11px] text-text-secondary/50 whitespace-nowrap">{t('skills.budget.window.label')}</span>
+        <div className="relative grid grid-cols-3 bg-surface rounded-full p-px border border-line-subtle" role="group" aria-label={t('skills.budget.window.label')}>
+          <div
+            className={`absolute top-px bottom-px left-px w-[calc((100%_-_2px)/3)] bg-surface-strong rounded-full transition-transform duration-200 ${HIGHLIGHT_OFFSETS[activeIndex]}`}
+          />
+          {segments.map((segment) => (
+            <button
+              key={String(segment.value)}
+              onClick={() => onChange(segment.value)}
+              aria-pressed={value === segment.value}
+              className={`relative z-10 px-3 py-1 rounded-full text-[11px] font-medium transition-colors duration-200 text-center whitespace-nowrap ${
+                value === segment.value ? 'text-ink' : 'text-text-secondary/50 hover:text-text-secondary'
+              }`}
+            >
+              {segment.label}
+            </button>
+          ))}
+        </div>
       </div>
+      <p className="text-[10px] text-text-secondary/40 text-right">{hint}</p>
     </div>
   )
 }
@@ -179,7 +228,19 @@ function TokenBudgetGauge({ skills, repoSkills }: { skills: SkillInfo[]; repoSki
   const contextWindow = useStore((s) => s.skillsContextWindow)
   const setContextWindow = useStore((s) => s.setSkillsContextWindow)
 
-  const charBudget = charBudgetFor(contextWindow)
+  // One selector, resolved to a primitive inside the store rather than in a
+  // useMemo over `terminals`: the terminal array is replaced on every statusline
+  // tick (several times a second, per agent), so selecting it would re-render the
+  // whole gauge continuously. Selecting the number means a re-render only when
+  // the detected window itself moves. The inspected agent is resolved the way the
+  // info sidebar does it, so both panels talk about the same agent.
+  const detected = useStore((s) => detectContextWindow(
+    s.terminals,
+    s.isSplitMode && s.focusedPane === 'secondary' ? s.splitTerminalId : s.activeTerminalId,
+  ))
+
+  const effectiveWindow = resolveContextWindow(contextWindow, detected)
+  const charBudget = charBudgetFor(effectiveWindow)
   const tokenBudget = Math.floor(charBudget / CHARS_PER_TOKEN)
 
   const { totalTokens, totalChars, truncatedCount, breakdown } = useMemo(() => {
@@ -223,7 +284,12 @@ function TokenBudgetGauge({ skills, repoSkills }: { skills: SkillInfo[]; repoSki
           </div>
           <p className="text-xs text-text-secondary/30 mt-0.5">{t('skills.budget.help')}</p>
         </div>
-        <ContextWindowSwitch value={contextWindow} onChange={setContextWindow} />
+        <ContextWindowSwitch
+          value={contextWindow}
+          detected={detected}
+          effectiveWindow={effectiveWindow}
+          onChange={setContextWindow}
+        />
       </div>
 
       <div className="grid grid-cols-2 gap-3">
@@ -273,7 +339,9 @@ function TokenBudgetGauge({ skills, repoSkills }: { skills: SkillInfo[]; repoSki
               icon={Calculator}
               title={t('skills.budget.card.formula.title')}
               body={t('skills.budget.card.formula.body', {
-                context: n(contextWindow),
+                // Formatted, not grouped: the detected window is whatever the
+                // model reports, so "1M" reads where "1 048 576" would not.
+                context: formatWindow(effectiveWindow),
                 percent: `${BUDGET_FRACTION * 100}`,
                 chars: n(charBudget),
                 tokens: n(tokenBudget),

--- a/desktop/src/renderer/store/index.ts
+++ b/desktop/src/renderer/store/index.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import type { Config, TerminalInfo, TerminalState, TerminalMetadata, ScriptTerminalInfo, SettingsTab, Org } from '../../types'
+import { migrateSkillsContextWindow } from '../pages/Skills/contextWindow'
 
 interface CloseAgentModalData {
   terminalId: string
@@ -11,15 +12,28 @@ interface CloseAgentModalData {
 export type ModalId = 'settings' | 'skills' | 'team'
 
 /**
+ * The two windows the Skills page offers as presets — the ones worth comparing,
+ * and the two values its switch can force.
+ *
+ * Kept as a closed pair rather than a bare `number`: the switch renders one
+ * segment per member, so widening this type would silently leave a preset
+ * undrawn.
+ */
+export type SkillsContextWindow = 200_000 | 1_000_000
+
+/**
  * The model context window the Skills page sizes its listing budget against.
  *
  * Claude Code derives that budget from the window (1% of it, in characters), so
  * the same set of skills is comfortable on a 1M model and already over budget on
- * a 200k one. The app cannot know which model a given agent will run, so this is
- * the user's answer to that question — a viewing preference, never written back
- * to Claude Code's settings.
+ * a 200k one. On 'auto' — the default — the page reads the window off the agents
+ * actually running, which Claude Code reports through the statusline hook. The
+ * two presets are explicit overrides: what these skills would look like on
+ * another model, and the answer when nothing is running.
+ *
+ * A viewing preference, never written back to Claude Code's settings.
  */
-export type SkillsContextWindow = 200_000 | 1_000_000
+export type SkillsContextWindowSetting = 'auto' | SkillsContextWindow
 
 interface AppState {
   // Config
@@ -60,8 +74,8 @@ interface AppState {
   rightSidebar: 'info' | null
   leftSidebarVisible: boolean
   // Which context window the Skills page's budget gauges are scaled to. See
-  // SkillsContextWindow above.
-  skillsContextWindow: SkillsContextWindow
+  // SkillsContextWindowSetting above.
+  skillsContextWindow: SkillsContextWindowSetting
 
   // Script terminals
   scriptTerminals: ScriptTerminalInfo[]
@@ -107,7 +121,7 @@ interface AppState {
   setRightSidebar: (sidebar: 'info' | null) => void
   toggleRightSidebar: (sidebar: 'info') => void
   toggleLeftSidebar: () => void
-  setSkillsContextWindow: (contextWindow: SkillsContextWindow) => void
+  setSkillsContextWindow: (contextWindow: SkillsContextWindowSetting) => void
 
   // Close agent modal actions
   openCloseAgentModal: (data: CloseAgentModalData) => void
@@ -153,7 +167,7 @@ export const useStore = create<AppState>()(
         activeModal: null,
         rightSidebar: null,
         leftSidebarVisible: true,
-        skillsContextWindow: 200_000,
+        skillsContextWindow: 'auto',
 
         scriptTerminals: [],
 
@@ -385,6 +399,22 @@ export const useStore = create<AppState>()(
     // Local storage persist for UI preferences (permanent)
     {
       name: 'magic-slash-storage',
+      // v1 — skillsContextWindow gained an 'auto' state and made it the default.
+      // Without a migration, every user carries a stored `200_000` written by the
+      // old default and keeps overriding the window their agents report; the
+      // point of the feature is precisely that the stored value stops winning
+      // over reality.
+      version: 1,
+      // Annotated: zustand infers the persisted shape from what `migrate` returns,
+      // and an inferred `'auto' | 1_000_000` would then reject the 200K preset in
+      // `partialize` below.
+      migrate: (persistedState): Partial<AppState> => {
+        const state = (persistedState ?? {}) as Partial<AppState>
+        return {
+          ...state,
+          skillsContextWindow: migrateSkillsContextWindow(state.skillsContextWindow),
+        }
+      },
       partialize: (state) => ({
         leftSidebarVisible: state.leftSidebarVisible,
         skillsContextWindow: state.skillsContextWindow,


### PR DESCRIPTION
## Description

The Skills page sized its listing budget against a context window picked by hand (the 200K / 1M switch), even though the app already knows the real value: the statusline hook parses `context_window.context_window_size` into `TerminalUsage.contextWindowSize`, and `UsageCard` renders it live in the agent sidebar. The number the gauge needed was already sitting in `terminal.metadata.usage` — the Skills page just never looked at it, so someone running a 1M model was shown a budget 5x too small and trimmed descriptions that were never over budget.

The switch becomes a manual override on top of an auto-detected default.

## Related Issue

Closes #188

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- New `desktop/src/renderer/pages/Skills/contextWindow.ts` — `detectContextWindow`, `resolveContextWindow`, `migrateSkillsContextWindow` and `formatWindow`, dependency-free so they are unit-testable without React or zustand.
- Detection prefers the inspected agent's `contextWindowSize`, falls back to the largest window across live terminals, then to 200K. Only `idle | working | waiting` terminals count: `updateTerminalUsageFromHook` never clears usage when an agent finishes, so a completed run would otherwise keep sizing today's gauge.
- `skillsContextWindow` gains a third state `'auto'`, now the default; 200K and 1M become explicit overrides. The outer persist gets `version: 1` and a migration — without it every existing user stays pinned to their persisted `200_000` and the detection never applies. Only an explicit `1_000_000` survives as an override.
- `ContextWindowSwitch` is now a 3-slot control (Auto / 200K / 1M) with the highlight geometry reworked for three positions, plus a hint line stating which of the three situations applies: detected, no-agent fallback, or forced.
- The gauge accepts any real window instead of two buckets — `formatWindow` renders `350K`, `1.5M`, and `1048576` as `1M`. The formula card now uses it rather than locale grouping.
- `skills.budget.card.why.*` rewritten in both EN and FR: it claimed the app cannot know which model an agent runs, which stopped being true.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [x] Tested affected slash commands

`npm run lint`: 0 errors (3 pre-existing `no-explicit-any` warnings in `Config/RepoPage.tsx`, untouched here).
`npm test`: 1082 tests pass, including 26 new cases in `contextWindow.test.ts` covering inspected-agent priority, the stale finished-agent path, the migration branches, resolution precedence and non-preset formatting.

`tsc --noEmit` could not be run from the worktree (`desktop/node_modules` is not installed there, and the root tsconfig already fails on a deprecated `baseUrl` before this diff); it was verified once against the main checkout's dependencies.

### Test Steps

1. Open the **Skills** page with no agent running. The switch should sit on **Auto**, and the hint line should present 200K as a *fallback*, not as a detected value.
2. Start an agent on a 1M-window model and wait for the first statusline ping (the sidebar `UsageCard` starts showing `x / y tokens`). The Auto segment should now read `Auto · 1M` and the gauge budget should be five times larger — a red over-budget bar that was only caused by the 200K assumption should turn green.
3. Click **200K**. The gauge returns to the small budget and the hint line states the value is forced. Click **Auto** again: the detected value comes back.
4. Reload the app. A forced choice must survive the reload.
5. Migration: set `skillsContextWindow` to `200000` in `localStorage["magic-slash-storage"]` with no `version` key, then reload. The setting must come back as **Auto**. Repeat with `1000000` — that one must stay an explicit override.
6. Run `npx vitest run desktop/src/renderer/pages/Skills/contextWindow.test.ts desktop/src/i18n/i18n.test.ts`.

## Screenshots

Not attached — the visible change is the third segment on an existing control plus one hint line; step 2 above is the meaningful before/after.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

Two points a reviewer may want to weigh in on:

- **Layering**: `renderer/store/index.ts` imports `migrateSkillsContextWindow` from `pages/Skills/contextWindow`. It is the only infra → `pages/` import in the renderer; moving the module to `renderer/utils/` would avoid inverting the dependency. Left as-is to keep the feature's helpers colocated, but happy to move it.
- **Silent preference reset**: the migration collapses a *deliberate* legacy 200K choice into `'auto'` alongside the untouched default, because the two are indistinguishable in the persisted state. That is the issue's intent, but it is a silent reset for anyone who explicitly picked 200K.

CHANGELOG.md is left untouched — it is maintained at release time in this repo rather than per PR.
