### PR TITLE
[#186] Persist the model ID and context window size on usage_events

### DIFF
--- a/desktop/src/main/hooks/status-server.test.ts
+++ b/desktop/src/main/hooks/status-server.test.ts
@@ -38,6 +38,7 @@ describe('parseStatusLinePayload', () => {
     const usage = parseStatusLinePayload(fullPayload)
     expect(usage.costUsd).toBe(0.4237)
     expect(usage.model).toBe('Opus 4.8')
+    expect(usage.modelId).toBe('claude-opus-4-8')
     expect(usage.durationMs).toBe(754321)
     expect(usage.linesAdded).toBe(120)
     expect(usage.linesRemoved).toBe(45)
@@ -89,12 +90,13 @@ describe('parseStatusLinePayload', () => {
 
   it('ignores fields with the wrong type', () => {
     const payload = JSON.stringify({
-      model: { display_name: 42 },
+      model: { id: 7, display_name: 42 },
       cost: { total_cost_usd: 'nope' },
       context_window: { used_percentage: null },
     })
     const usage = parseStatusLinePayload(payload)
     expect(usage.model).toBeUndefined()
+    expect(usage.modelId).toBeUndefined()
     expect(usage.costUsd).toBeUndefined()
     expect(usage.contextPercent).toBeUndefined()
   })

--- a/desktop/src/main/hooks/status-server.ts
+++ b/desktop/src/main/hooks/status-server.ts
@@ -203,6 +203,7 @@ export function parseStatusLinePayload(body: string): TerminalUsage {
     contextTokens,
     contextWindowSize,
     model: typeof data?.model?.display_name === 'string' ? data.model.display_name : undefined,
+    modelId: typeof data?.model?.id === 'string' ? data.model.id : undefined,
     durationMs: typeof cost.total_duration_ms === 'number' ? cost.total_duration_ms : undefined,
     linesAdded: typeof cost.total_lines_added === 'number' ? cost.total_lines_added : undefined,
     linesRemoved: typeof cost.total_lines_removed === 'number' ? cost.total_lines_removed : undefined,

--- a/desktop/src/main/ipc/terminal-handlers.test.ts
+++ b/desktop/src/main/ipc/terminal-handlers.test.ts
@@ -109,7 +109,15 @@ describe('session-end usage flush (terminal:kill)', () => {
       id,
       name: 'Agent',
       metadata: {
-        usage: { model: 'Claude Opus', costUsd: 1.23, linesAdded: 10, linesRemoved: 4, durationMs: 5000 },
+        usage: {
+          model: 'Claude Opus',
+          modelId: 'claude-opus-4-8',
+          contextWindowSize: 200000,
+          costUsd: 1.23,
+          linesAdded: 10,
+          linesRemoved: 4,
+          durationMs: 5000,
+        },
       },
       repositories: [],
     })
@@ -121,6 +129,8 @@ describe('session-end usage flush (terminal:kill)', () => {
       expect.objectContaining({
         agentId: id,
         model: 'Claude Opus',
+        modelId: 'claude-opus-4-8',
+        contextWindowSize: 200000,
         costUsd: 1.23,
         linesAdded: 10,
         linesRemoved: 4,
@@ -131,6 +141,47 @@ describe('session-end usage flush (terminal:kill)', () => {
     // Flush must happen BEFORE archiveAgent so the store can still resolve the uuid.
     expect(recordUsageSnapshot.mock.invocationCallOrder[0]).toBeLessThan(
       archiveAgent.mock.invocationCallOrder[0],
+    )
+  })
+
+  it('keeps every model seen mid-session, in order of first appearance', async () => {
+    const id = 'claude-kill-switch'
+    term.getTerminal.mockReturnValue({
+      id,
+      name: 'Agent',
+      // The gauge holds the LAST model; the set is what says the attribution is approximate.
+      metadata: { usage: { model: 'Sonnet 4.8', modelId: 'claude-sonnet-4-8', costUsd: 2 } },
+      modelIds: new Set(['claude-opus-4-8', 'claude-sonnet-4-8']),
+      repositories: [],
+    })
+
+    await invoke('terminal:kill', { id })
+
+    // An ARRAY, not the Set: the payload is JSON.stringify'd into the outbox on a
+    // failed write, and a Set would serialise to {}. Unsorted — first→last order is the point.
+    expect(recordUsageSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: 'claude-sonnet-4-8',
+        modelIds: ['claude-opus-4-8', 'claude-sonnet-4-8'],
+      }),
+    )
+  })
+
+  it('sends no model ids when the statusLine never reported one', async () => {
+    const id = 'claude-kill-no-model'
+    term.getTerminal.mockReturnValue({
+      id,
+      name: 'Agent',
+      metadata: { usage: { costUsd: 1 } },
+      repositories: [],
+    })
+
+    await invoke('terminal:kill', { id })
+
+    // Undefined, never [] — it lands as NULL, which is what array_length(model_ids, 1)
+    // already returns for an empty array.
+    expect(recordUsageSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ modelIds: undefined }),
     )
   })
 

--- a/desktop/src/main/ipc/terminal-handlers.ts
+++ b/desktop/src/main/ipc/terminal-handlers.ts
@@ -134,12 +134,22 @@ const NOTIFICATION_COOLDOWN = 30000 // 30 seconds between notifications per term
  */
 function flushUsageSnapshot(id: string): void {
   if (usageFlushed.has(id)) return
-  const usage = getTerminal(id)?.metadata?.usage
+  const terminal = getTerminal(id)
+  const usage = terminal?.metadata?.usage
   if (!usage) return
   usageFlushed.add(id)
+  // Materialise the model-id set as an array HERE: on a failed write the payload
+  // goes to the on-disk outbox as JSON, and JSON.stringify(new Set()) is `{}` —
+  // an offline session would replay an empty object into a text[] column. Null
+  // rather than [] when nothing was seen, to match array_length(model_ids, 1),
+  // which is NULL for an empty array anyway.
+  const modelIds = terminal?.modelIds?.size ? Array.from(terminal.modelIds) : undefined
   void recordUsageSnapshot({
     agentId: id,
     model: usage.model,
+    modelId: usage.modelId,
+    contextWindowSize: usage.contextWindowSize,
+    modelIds,
     costUsd: usage.costUsd,
     linesAdded: usage.linesAdded,
     linesRemoved: usage.linesRemoved,

--- a/desktop/src/main/pty/terminal-manager.ts
+++ b/desktop/src/main/pty/terminal-manager.ts
@@ -164,6 +164,12 @@ export interface Terminal {
    *  passed at launch. A session nobody has said anything to holds nothing worth
    *  keeping, which is what makes a silent relaunch safe. */
   hasUserInput?: boolean
+  /** Every model.id the statusLine has reported for this session, in order of
+   *  first appearance (a Set iterates in insertion order). Lives on the terminal
+   *  rather than in a module map so it survives a respawn and dies with the
+   *  object — more than one entry means a /model switch happened mid-session and
+   *  the end-of-session snapshot describes only the last model. */
+  modelIds?: Set<string>
   /** Replaces the running Claude Code with a fresh one in a given directory.
    *  Only set for agents (launchClaude), not for plain shells. */
   respawn?: (cwd: string, notice?: string) => void
@@ -722,6 +728,12 @@ export function updateTerminalUsageFromHook(terminalId: string, usage: TerminalU
   const terminal = terminals.get(terminalId)
   if (!terminal) return
   terminal.metadata = { ...terminal.metadata, usage }
+
+  // Accumulated outside metadata.usage, which is wholly replaced above — see Terminal.modelIds.
+  if (usage.modelId) {
+    if (!terminal.modelIds) terminal.modelIds = new Set()
+    terminal.modelIds.add(usage.modelId)
+  }
 }
 
 // Update terminal repositories from hook callback

--- a/desktop/src/main/store/CloudStore.test.ts
+++ b/desktop/src/main/store/CloudStore.test.ts
@@ -191,6 +191,9 @@ describe('appendUsage', () => {
     await store.appendUsage({
       agentId: 'claude-1',
       model: 'Claude Opus',
+      modelId: 'claude-opus-4-8',
+      contextWindowSize: 200000,
+      modelIds: ['claude-sonnet-4-8', 'claude-opus-4-8'],
       costUsd: 1.23,
       linesAdded: 10,
       linesRemoved: 4,
@@ -209,6 +212,11 @@ describe('appendUsage', () => {
       user_id: UID,
       agent_id: null,
       model: 'Claude Opus',
+      model_id: 'claude-opus-4-8',
+      // A model capacity, not a counter — unlike tokens, which stays null.
+      context_window_size: 200000,
+      // Two ids = a /model switch, so the columns above describe the last one only.
+      model_ids: ['claude-sonnet-4-8', 'claude-opus-4-8'],
       cost_usd: 1.23,
       tokens: null,
       lines_added: 10,
@@ -267,6 +275,10 @@ describe('appendUsage', () => {
     const row = inserts.usage_events[0] as Record<string, unknown>
     expect(row).toMatchObject({
       model: null,
+      // Also the shape of an outbox entry queued before these columns existed.
+      model_id: null,
+      context_window_size: null,
+      model_ids: null,
       cost_usd: null,
       tokens: null,
       lines_added: null,

--- a/desktop/src/main/store/CloudStore.ts
+++ b/desktop/src/main/store/CloudStore.ts
@@ -1401,7 +1401,9 @@ export class CloudStore implements Store {
    * the agents.id uuid via agentIdMap, and attributes the org exactly like
    * appendHistory (see eventOrgId). tokens is left null on purpose:
    * TerminalUsage.contextTokens is a point-in-time context gauge, not a cumulative
-   * session-token count, so it must not be mapped into this row.
+   * session-token count, so it must not be mapped into this row. context_window_size
+   * IS written: it is a capacity of the model, not a counter, so it says nothing
+   * false about the session.
    */
   async appendUsage(event: UsageEventInput): Promise<void> {
     const ctx = await this.eventContext()
@@ -1414,6 +1416,9 @@ export class CloudStore implements Store {
       user_id: ctx.uid,
       agent_id: agentUuid,
       model: event.model ?? null,
+      model_id: event.modelId ?? null,
+      context_window_size: event.contextWindowSize ?? null,
+      model_ids: event.modelIds ?? null,
       cost_usd: event.costUsd ?? null,
       tokens: null,
       lines_added: event.linesAdded ?? null,

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -117,6 +117,7 @@ export interface TerminalUsage {
   contextTokens?: number     // tokens currently occupying the context window
   contextWindowSize?: number // context_window.context_window_size
   model?: string             // model.display_name
+  modelId?: string           // model.id
   durationMs?: number        // cost.total_duration_ms
   linesAdded?: number        // cost.total_lines_added
   linesRemoved?: number      // cost.total_lines_removed
@@ -633,7 +634,16 @@ export interface OrgAgentChange {
 export interface UsageEventInput {
   /** app agent id ("claude-…"), mapped to the agents.id uuid by the store. */
   agentId: string
+  /** model.display_name at session end — a label, not something to group on. */
   model?: string
+  /** model.id at session end (e.g. "claude-opus-4-8"), the stable identity. */
+  modelId?: string
+  /** Context window of that model, in tokens — a capacity, not a counter, which is
+   *  why it is recorded while `tokens` stays null (see appendUsage). */
+  contextWindowSize?: number
+  /** Every model.id seen during the session, in order of first appearance. More
+   *  than one means a /model switch, so the fields above describe the last one only. */
+  modelIds?: string[]
   costUsd?: number
   linesAdded?: number
   linesRemoved?: number

--- a/supabase/migrations/20260815100000_usage_events_model_columns.sql
+++ b/supabase/migrations/20260815100000_usage_events_model_columns.sql
@@ -1,0 +1,38 @@
+-- Migration: usage_events model identity and context window
+--
+-- The session snapshot only kept the model's display name ("Opus 4.8"), which is
+-- a label that Anthropic can reword between releases and that nothing can be
+-- grouped on reliably. model_id stores the stable id from the statusLine payload
+-- (model.id, e.g. claude-opus-4-8) next to it; model stays the display name,
+-- unchanged, because that is what the UI shows.
+--
+-- context_window_size was already parsed by the client and then thrown away.
+-- It is persisted here even though tokens stays null on purpose: tokens would be
+-- a cumulative session counter, and all the client has is a point-in-time context
+-- gauge that must not be passed off as one. context_window_size is not a counter
+-- at all — it is a capacity of the model that was in use, a constant for a given
+-- model, so recording it says nothing false about the session.
+--
+-- model_ids is the ordered set of every model.id seen during the session, in
+-- order of first appearance. A /model mid-session makes the single-model columns
+-- an approximation, and the row has to be able to say so itself:
+-- array_length(model_ids, 1) > 1 marks a snapshot whose cost cannot be attributed
+-- to one model. NULL means no model id was ever reported (an older client, or a
+-- session that never got a statusLine).
+
+alter table public.usage_events
+  add column if not exists model_id text,
+  add column if not exists context_window_size integer,
+  add column if not exists model_ids text[];
+
+comment on column public.usage_events.model is
+  'Display name of the model in use at SESSION END (e.g. "Opus 4.8"), not the model of the whole session — see model_ids.';
+
+comment on column public.usage_events.model_id is
+  'Stable id of the model in use at SESSION END (statusLine model.id, e.g. "claude-opus-4-8"). Group on this, not on model.';
+
+comment on column public.usage_events.context_window_size is
+  'Context window of the model in use at SESSION END, in tokens. A model capacity, not a cumulative counter — which is why it is recorded while tokens stays null.';
+
+comment on column public.usage_events.model_ids is
+  'Every model.id seen during the session, ordered by first appearance. array_length(model_ids, 1) > 1 = a /model switch mid-session, so model/model_id/context_window_size describe only the last one.';


### PR DESCRIPTION
## Description

At session end, `flushUsageSnapshot()` appends one `usage_events` row from the in-memory usage gauge. What it stored was too lossy to build on: the row carried `model.display_name` (`"Opus 4.8"`) rather than the stable API id, and `context_window_size` — parsed from the statusLine payload and rendered live by `UsageCard` — was thrown away entirely.

This adds `model_id text` and `context_window_size integer` to `usage_events` in a new migration, and wires them through the parser, the type layer and the store write. It also settles the third problem from the issue: a `/model` switch mid-session used to attribute the whole session to whichever model happened to be active last. A `Set` carried on the `Terminal` object now accumulates every `model.id` seen, and the flush writes it to a new `model_ids text[]` column in order of first appearance, so `array_length(model_ids, 1) > 1` identifies the sessions whose attribution is unreliable.

The `model` column is untouched and still holds the display name. This is a write-path change only: `loadOrgUsageStats` and `UsageEventRow` were deliberately left alone, so nothing consumes the new columns yet.

## Related Issue

Closes #186

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **New migration** `supabase/migrations/20260815100000_usage_events_model_columns.sql` — adds `model_id text`, `context_window_size integer` and `model_ids text[]` in a single `alter table`, with a `comment on column` for each. The comments state explicitly that `model` / `model_id` / `context_window_size` are the gauge state **at session end**, not "the session's model", and document why `context_window_size` is persisted while `tokens` stays null (a model capacity is a constant; a context gauge is not a session total). No RLS or index changes — the existing policies are row-level.
- **`desktop/src/main/hooks/status-server.ts`** — `parseStatusLinePayload` now reads `model.id`, which was already present in the payload and simply ignored. Same defensive `typeof` guard as its neighbour.
- **`desktop/src/types.ts`** — `TerminalUsage` gains `modelId`; `UsageEventInput` gains `modelId`, `contextWindowSize` and `modelIds`.
- **`desktop/src/main/pty/terminal-manager.ts`** — `Terminal` gains a `modelIds: Set<string>`, fed by `updateTerminalUsageFromHook`. It lives on the terminal object rather than in a module-level map, so it survives `respawnInCwd` and is collected with the terminal — no manual cleanup, no leak. The IPC contract and the `metadata.usage` shape are unchanged.
- **`desktop/src/main/ipc/terminal-handlers.ts`** — `flushUsageSnapshot` materialises the `Set` with `Array.from` **before** calling `recordUsageSnapshot`, and passes `undefined` rather than `[]` when no model id was ever seen.
- **`desktop/src/main/store/CloudStore.ts`** — `appendUsage` writes the three new columns. `tokens: null` and its rationale are untouched.
- **Tests** — extended `status-server.test.ts` (happy path + wrong-type `model.id`), `terminal-handlers.test.ts` (a two-model ordered case and a no-model-id case) and `CloudStore.test.ts` (populated row + all-null row, which doubles as the replay case for outbox entries written before this change).

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

Automated: `npx vitest run` → 73 files / 1070 tests pass. `npx tsc --noEmit` in `desktop/` → clean. `npm run lint` → 0 errors (3 pre-existing `no-explicit-any` warnings in `RepoPage.tsx`, untouched here).

The end-to-end run below has **not** been performed yet — it needs the migration applied to a real database and a live agent session, so it is left to the reviewer.

### Test Steps

Setup: apply the migration to a local Supabase instance (`npx supabase db push`) and run the desktop app (`npm run desktop`). No env vars, seed data or extra services beyond the usual desktop setup are required.

1. Confirm the schema landed: `select column_name, data_type from information_schema.columns where table_name = 'usage_events' and column_name in ('model_id', 'context_window_size', 'model_ids');` → three rows, typed `text`, `integer` and `ARRAY`.
2. Open an agent in the desktop app and let it run a few turns so the statusLine posts to `/usage`. The sidebar usage card should show the context window exactly as before — this change must not alter anything the UI renders.
3. Run `/model` mid-session to switch to a different model, let at least one more turn go by, then close the terminal to trigger the end-of-session flush.
4. Inspect the row: `select model, model_id, context_window_size, model_ids, tokens from usage_events order by occurred_at desc limit 1;` → `model` is the last model's display name, `model_id` its API id, `context_window_size` is populated (200000 or 1000000), `model_ids` contains **both** ids in the order they were used, and `tokens` is still `null`.
5. Exercise the degraded path: disconnect the network before closing a terminal, then check `~/.config/magic-slash/outbox.ndjson` — the queued entry must carry `model_ids` as a JSON **array**, not `{}`. Reconnect and confirm the replay inserts the row. (A `Set` reaching `JSON.stringify` would serialise to `{}` and replay an empty object into a `text[]` column; this is why the conversion happens at the flush boundary.)
6. Run a session on a single model and confirm `model_ids` holds exactly one id; run one where the statusLine never reports an id and confirm the column is `NULL` rather than `{}` — `array_length('{}', 1)` is already `NULL`, so the two would be indistinguishable to any query.

## Screenshots

N/A — no UI change. The sidebar usage card is deliberately untouched.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

Three things worth a reviewer's attention:

- **The read path is not fixed by this PR.** `loadOrgUsageStats` still selects and groups on `model`, so the issue's stated motivation — a display-name rename silently creating a second bucket — is only addressed at the write layer. A follow-up is needed for the problem to actually go away; extending the read path here would have forced `UsageStatRow`, `cloud/org.ts` and `daily-digest.ts` to change for data nothing consumes yet.
- **The accumulation itself is untested.** `updateTerminalUsageFromHook` is where ordering and deduplication actually happen, but the flush test constructs the `Set` by hand. There is no `terminal-manager.test.ts` in the repo — the folder's convention is to test extracted pure helpers — so this follows local practice, but a future refactor swapping the `Set` for an array `.push`, or sorting it, would not fail any test.
- **`array_length(model_ids, 1) > 1` evaluates to `NULL` on the `NULL` rows** (older clients, or sessions with no statusLine), so a naive `where not (...)` in an analytics query would silently drop them rather than include them. Harmless for the `> 1` predicate documented on the column, worth knowing for whoever writes that query.

CHANGELOG is left unchecked on purpose: the file has no `Unreleased` section and its entries are grouped under a released version heading, so adding one here would invent a pattern the repo does not currently use. Happy to add an entry if the release process expects it per-PR.

`supabase/README.md:84` still describes `usage_events` as "(cost, tokens, lines, timing)". That omission pre-dates this PR — the `model` column was already missing from it — so it was left out of scope rather than folded in.
