### PR TITLE
[#187] Surface per-model usage on the team dashboard

### DIFF
--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -851,6 +851,21 @@ export const en = {
     'No run recorded for this organization yet. Runs are attributed through the repositories of the agent that launches them, so work on a personal repository is not counted here.',
   'dashboard.skills.emptyPersonal':
     'No run recorded outside an organization yet. A run lands here when the agent that launched it works on personal repositories alone, and when it was started in a terminal the app did not open — one with no agent belongs to no organization.',
+  'dashboard.usage.section': 'Cost & usage',
+  'dashboard.usage.cost': 'Cost',
+  'dashboard.usage.sessions': 'Sessions',
+  'dashboard.usage.lines': 'Lines',
+  'dashboard.usage.duration': 'Time',
+  'dashboard.usage.byMember': 'By member',
+  'dashboard.usage.byModel': 'By model',
+  'dashboard.usage.unknownModel': 'Unknown model',
+  'dashboard.usage.empty': 'No usage to show here.',
+  // `{count}` is the row count actually returned, which IS the cap whenever this line
+  // shows — `loadOrgUsageStats` only sets `capped` when the read came back full. Derived
+  // rather than written out, so raising the limit cannot leave this sentence lying.
+  'dashboard.usage.capped':
+    'Only the {count} most recent sessions are read, so these totals are a floor rather than the whole picture.',
+  'dashboard.usage.failed': 'Usage could not be read.',
 
   // ── Team dashboard · hours spent inside the skills ────────────────────────
   'skillHours.hours': '{count}h',

--- a/desktop/src/i18n/fr.ts
+++ b/desktop/src/i18n/fr.ts
@@ -856,6 +856,18 @@ export const fr: Record<keyof typeof en, string> = {
     'Aucune exécution enregistrée pour cette organisation. Les exécutions sont rattachées via les dépôts de l’agent qui les lance : le travail sur un dépôt personnel n’est donc pas compté ici.',
   'dashboard.skills.emptyPersonal':
     'Aucune exécution enregistrée hors organisation. Une exécution arrive ici quand l’agent qui l’a lancée travaille uniquement sur des dépôts personnels, et quand elle a été démarrée dans un terminal que l’app n’a pas ouvert : sans agent, elle n’appartient à aucune organisation.',
+  'dashboard.usage.section': 'Coût et usage',
+  'dashboard.usage.cost': 'Coût',
+  'dashboard.usage.sessions': 'Sessions',
+  'dashboard.usage.lines': 'Lignes',
+  'dashboard.usage.duration': 'Temps',
+  'dashboard.usage.byMember': 'Par membre',
+  'dashboard.usage.byModel': 'Par modèle',
+  'dashboard.usage.unknownModel': 'Modèle inconnu',
+  'dashboard.usage.empty': 'Aucun usage à afficher ici.',
+  'dashboard.usage.capped':
+    'Seules les {count} sessions les plus récentes sont lues : ces totaux sont donc un plancher, pas le tableau complet.',
+  'dashboard.usage.failed': 'Impossible de lire l’usage.',
 
   // ── Tableau de bord d'équipe · heures passées sur les skills ──────────────
   'skillHours.hours': '{count}h',

--- a/desktop/src/renderer/pages/Dashboard/UsageSection.tsx
+++ b/desktop/src/renderer/pages/Dashboard/UsageSection.tsx
@@ -1,0 +1,247 @@
+import { Fragment, useEffect, useMemo, useState } from 'react'
+import { Coins } from 'lucide-react'
+import type { UsageStats } from '../../../types'
+import { useOrg } from '../../hooks/useOrg'
+import { useT, useLocale } from '../../i18n'
+import {
+  aggregateUsageByMember,
+  aggregateUsageByModel,
+  aggregateUsageTotals,
+  formatUsageDuration,
+  formatUsd,
+} from '../../utils/usageStats'
+
+/**
+ * What the organization's work COST, beside what it is doing.
+ *
+ * SCOPED TO THE ACTIVE ORGANIZATION, and it says so in its own heading: the read
+ * filters on `org_id`, so these are not the viewer's totals and not every org's — a
+ * figure this size with no name on it would be read as whichever of the three the
+ * reader expected. It deliberately does not follow the tab strip below, which is a
+ * view over the agents roster and has no say in which org the usage read answers about.
+ *
+ * THE TOTALS ARE A FLOOR whenever the read hits its row cap. A partial sum drawn as a
+ * whole number is a lie, so the cap is printed under the figures rather than left to the
+ * reader to suspect.
+ */
+export function UsageSection() {
+  const t = useT()
+  const locale = useLocale()
+  const { org, members } = useOrg()
+
+  // undefined = the read is in flight, null = it failed, a value = it landed. The
+  // three states draw differently on purpose: zeros held up while a read is running
+  // are a measurement the app does not have yet.
+  const [stats, setStats] = useState<UsageStats | null | undefined>(undefined)
+
+  useEffect(() => {
+    let cancelled = false
+    window.electronAPI.org
+      .getUsageStats()
+      .then((next) => {
+        if (!cancelled) setStats(next)
+      })
+      .catch(() => {
+        if (!cancelled) setStats(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // user_id → email, so a member row reads as a person rather than as a uuid.
+  // The same map `RepoSection` builds for the agent rows; it belongs on `useOrg`
+  // alongside the roster it derives from, which is the follow-up that would delete
+  // both copies.
+  const emailByMember = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const m of members) {
+      if (m.email) map.set(m.userId, m.email)
+    }
+    return map
+  }, [members])
+
+  // One memo for all four, keyed on the single read that feeds them: `rows` only ever
+  // changes when `stats` does, so splitting them apart would buy nothing but four
+  // dependency arrays.
+  const { rows, totals, byMember, byModel } = useMemo(() => {
+    const rows = stats?.rows ?? []
+    return {
+      rows,
+      totals: aggregateUsageTotals(rows),
+      byMember: aggregateUsageByMember(rows),
+      byModel: aggregateUsageByModel(rows),
+    }
+  }, [stats])
+
+  const loading = stats === undefined
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
+        <Coins className="w-4 h-4" />
+        <span>{t('dashboard.usage.section')}</span>
+        {/* The organization's own name, never translated and never a placeholder in a
+            sentence: it is what stops these totals reading as global ones. */}
+        {org && <span className="text-xs text-text-secondary/50 truncate">· {org.name}</span>}
+      </div>
+
+      {stats === null ? (
+        <p className="text-sm text-text-secondary/60">{t('dashboard.usage.failed')}</p>
+      ) : (
+        <>
+          <div className="rounded-xl bg-surface-subtle border border-line-field p-4">
+            {/* `aria-busy` while the read is in flight: the placeholders are decoration a
+                screen reader is not shown, so without it the labels would be announced
+                with nothing after them and no sign anything is coming. */}
+            <dl aria-busy={loading} className="grid gap-x-6 gap-y-4 sm:grid-cols-4">
+              <Stat label={t('dashboard.usage.cost')} loading={loading} placeholderClass="w-24" value={formatUsd(totals.costUsd, locale)} />
+              <Stat label={t('dashboard.usage.sessions')} loading={loading} placeholderClass="w-16" value={totals.sessions.toLocaleString(locale)} />
+              {/* Added and removed side by side rather than netted: a refactor that
+                  deletes as much as it writes is not the same work as one that writes
+                  nothing, and a single net figure cannot tell them apart. */}
+              <Stat
+                label={t('dashboard.usage.lines')}
+                loading={loading}
+                placeholderClass="w-28"
+                value={`+${totals.linesAdded.toLocaleString(locale)} / −${totals.linesRemoved.toLocaleString(locale)}`}
+              />
+              <Stat label={t('dashboard.usage.duration')} loading={loading} placeholderClass="w-20" value={formatUsageDuration(totals.durationMs, t)} />
+            </dl>
+          </div>
+
+          {/* Nothing below the figures until the read lands — the two splits and the
+              "nothing here" panel are both statements about rows that have arrived. */}
+          {!loading &&
+            (rows.length === 0 ? (
+              <div className="py-10 flex flex-col items-center justify-center text-text-secondary text-sm gap-2 bg-surface-subtle border border-line-subtle rounded-xl">
+                <Coins className="w-8 h-8 opacity-30" />
+                {/* Neutral on purpose. With no active organization the read resolves to no
+                    rows too, which is indistinguishable here from an organization that has
+                    genuinely recorded nothing — so this must not claim the team did no work. */}
+                <p>{t('dashboard.usage.empty')}</p>
+              </div>
+            ) : (
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Split
+                  title={t('dashboard.usage.byMember')}
+                  rows={byMember.map((m) => ({
+                    key: m.userId,
+                    // An empty key is a row whose owner the event never carried.
+                    label: m.userId ? emailByMember.get(m.userId) ?? m.userId : t('dashboard.unassigned'),
+                    sessions: m.sessions,
+                    costUsd: m.costUsd,
+                  }))}
+                />
+                <Split
+                  title={t('dashboard.usage.byModel')}
+                  rows={byModel.map((m) => ({
+                    // `''` for the missing-model bucket: no model survives the trim as an
+                    // empty string, so this cannot collide with a real name — including one
+                    // that happens to be "unknown".
+                    key: m.model ?? '',
+                    // The absent bucket is translated; a real model name never is.
+                    label: m.model ?? t('dashboard.usage.unknownModel'),
+                    sessions: m.sessions,
+                    costUsd: m.costUsd,
+                  }))}
+                />
+              </div>
+            ))}
+
+          {/* The count IS the cap: the read only reports itself capped when it came back
+              full, so this names the real limit instead of repeating it in the copy,
+              where raising the limit would leave the sentence lying. */}
+          {stats?.capped && (
+            <p className="text-xs text-text-secondary/50">
+              {t('dashboard.usage.capped', { count: rows.length.toLocaleString(locale) })}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
+ * One of the two breakdowns. Same three columns in both so they can be read as a pair:
+ * who or what on the left, how many sessions, how much they cost.
+ *
+ * Reads its own copy and locale rather than being handed them — both call sites would
+ * otherwise pass the same two labels, and every other row component on this page
+ * (`AgentRow`, `RepoCard`, `OwnerLabel`) already calls `useT()` for itself.
+ */
+function Split({
+  title,
+  rows,
+}: {
+  title: string
+  rows: { key: string; label: string; sessions: number; costUsd: number }[]
+}) {
+  const t = useT()
+  const locale = useLocale()
+
+  return (
+    <div className="rounded-xl bg-surface-subtle border border-line-field p-4">
+      <p className="text-[11px] uppercase tracking-wider text-text-secondary/50 mb-3">{title}</p>
+      <div className="grid grid-cols-[1fr_auto_auto] gap-x-4 gap-y-2 text-sm items-baseline">
+        {/* The label column's header is deliberately blank — the block's own title above
+            already names it — so the two figure headers start at column 2 rather than
+            an empty span standing in for one. */}
+        <span className="col-start-2 text-text-secondary/50 text-xs uppercase tracking-wider text-right">
+          {t('dashboard.usage.sessions')}
+        </span>
+        <span className="text-text-secondary/50 text-xs uppercase tracking-wider text-right">
+          {t('dashboard.usage.cost')}
+        </span>
+
+        {rows.map((row) => (
+          <Fragment key={row.key}>
+            <span className="text-text-secondary truncate" title={row.label}>{row.label}</span>
+            <span className="font-mono text-right">{row.sessions.toLocaleString(locale)}</span>
+            <span className="font-mono text-right text-ink">{formatUsd(row.costUsd, locale)}</span>
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * One headline figure: what it is above, how much below.
+ *
+ * The LABEL is never a placeholder — it is static copy, known before the read starts —
+ * so only the value waits. That is what makes the row settle in place instead of
+ * assembling itself.
+ *
+ * The same markup as `SkillHoursCard`'s own `Stat`, whose extra `suffix`/`title` props
+ * are already optional; the pair belongs in `parts.tsx` next to the other shared Team
+ * vocabulary, which is the follow-up that would leave one copy of this geometry.
+ */
+function Stat({
+  label,
+  value,
+  loading,
+  placeholderClass,
+}: {
+  label: string
+  value: string
+  loading: boolean
+  /** Width of the placeholder, chosen per column to approximate its real value. */
+  placeholderClass: string
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="truncate text-[11px] text-text-secondary">{label}</dt>
+      <dd className="mt-1">
+        {loading ? (
+          // Exactly the height of the value it stands in for, so nothing resizes when
+          // the number replaces it.
+          <span aria-hidden className={`block h-6 rounded-md bg-surface-strong animate-pulse ${placeholderClass}`} />
+        ) : (
+          <span className="block text-2xl font-semibold leading-none tracking-tight text-ink">{value}</span>
+        )}
+      </dd>
+    </div>
+  )
+}

--- a/desktop/src/renderer/pages/Dashboard/index.tsx
+++ b/desktop/src/renderer/pages/Dashboard/index.tsx
@@ -1,16 +1,18 @@
 import { RepoSection } from './RepoSection'
 import { SkillHoursBanner } from './SkillHoursBanner'
+import { UsageSection } from './UsageSection'
 
 /**
  * The Team page — "who is working on what", read from the org-wide agents
  * roster. One question, answered honestly: per repository shared with the
  * organization, how many agents are running and how many are on a PR.
  *
- * The hours above it are the one figure on this page that is NOT scoped by the tab
- * below: they are the viewer's own across every organization. Mounted here rather than
- * inside `RepoSection`, which owns the tabs — a card living above the strip it does not
- * answer to is the placement that says so, and it also means the hours do not wait on
- * the agents roster to draw. Same arrangement as the webapp's dashboard.
+ * The two blocks above it are the figures on this page that are NOT scoped by the tab
+ * below — the hours are the viewer's own across every organization, and the usage is the
+ * active organization's. Both are mounted here rather than inside `RepoSection`, which
+ * owns the tabs: a block living above the strip it does not answer to is the placement
+ * that says so, and it also means neither waits on the agents roster to draw. Same
+ * arrangement as the webapp's dashboard.
  */
 export function DashboardPage() {
   return (
@@ -18,6 +20,8 @@ export function DashboardPage() {
       {/* The title and the live indicator are rendered by the hosting modal. */}
       <div className="flex-1 overflow-auto p-6 flex flex-col gap-4">
         <SkillHoursBanner />
+        {/* What the active organization SPENT, above the roster of what it is doing. */}
+        <UsageSection />
         <RepoSection />
       </div>
     </div>

--- a/desktop/src/renderer/utils/usageStats.test.ts
+++ b/desktop/src/renderer/utils/usageStats.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import type { UsageStatRow } from '../../types'
-import { aggregateUsageTotals, aggregateUsageByMember, computeUsageHeatmap, formatUsd } from './usageStats'
+import type { Translate } from '../i18n'
+import {
+  aggregateUsageTotals,
+  aggregateUsageByMember,
+  aggregateUsageByModel,
+  computeUsageHeatmap,
+  formatUsageDuration,
+  formatUsd,
+} from './usageStats'
 
 function row(overrides: Partial<UsageStatRow> = {}): UsageStatRow {
   return {
@@ -52,6 +60,91 @@ describe('aggregateUsageByMember', () => {
   it('groups null owners under an empty-string key', () => {
     const result = aggregateUsageByMember([row({ userId: null, costUsd: 1 })])
     expect(result[0].userId).toBe('')
+  })
+})
+
+describe('aggregateUsageByModel', () => {
+  it('returns no buckets for no rows', () => {
+    expect(aggregateUsageByModel([])).toEqual([])
+  })
+
+  it('groups by model and sorts by cost descending', () => {
+    const result = aggregateUsageByModel([
+      row({ model: 'Claude Sonnet', costUsd: 1 }),
+      row({ model: 'Claude Opus', costUsd: 5 }),
+      row({ model: 'Claude Sonnet', costUsd: 2 }),
+    ])
+    expect(result).toHaveLength(2)
+    expect(result[0].model).toBe('Claude Opus')
+    expect(result[0].costUsd).toBe(5)
+    expect(result[1].model).toBe('Claude Sonnet')
+    expect(result[1].costUsd).toBe(3)
+    expect(result[1].sessions).toBe(2)
+  })
+
+  it('accumulates lines and duration alongside the cost', () => {
+    const result = aggregateUsageByModel([
+      row({ model: 'Claude Opus', costUsd: 1.5, linesAdded: 10, linesRemoved: 3, durationMs: 1000 }),
+      row({ model: 'Claude Opus', costUsd: 2.25, linesAdded: 4, linesRemoved: 1, durationMs: 2000 }),
+    ])
+    expect(result).toHaveLength(1)
+    // 1.5 and 2.25 are both exact in binary floating point, so their sum is too.
+    expect(result[0]).toEqual({
+      model: 'Claude Opus', costUsd: 3.75, sessions: 2, linesAdded: 14, linesRemoved: 4, durationMs: 3000,
+    })
+  })
+
+  it('buckets a null model under null rather than dropping the row', () => {
+    // Sessions recorded before the statusLine hook landed carry no model. Dropping
+    // them would make this split under-count the totals shown beside it.
+    const result = aggregateUsageByModel([row({ model: null, costUsd: 2 })])
+    expect(result).toEqual([{
+      model: null, costUsd: 2, sessions: 1, linesAdded: 5, linesRemoved: 2, durationMs: 60000,
+    }])
+  })
+
+  it('buckets an empty or whitespace-only model under null too', () => {
+    const result = aggregateUsageByModel([
+      row({ model: '', costUsd: 1 }),
+      row({ model: '   ', costUsd: 1 }),
+      row({ model: null, costUsd: 1 }),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].model).toBeNull()
+    expect(result[0].sessions).toBe(3)
+  })
+
+  it('keeps a model literally named "unknown" apart from the missing-model bucket', () => {
+    // The reason the bucket is `null` and not the string 'unknown': a real name must
+    // never be swallowed by the placeholder for an absent one.
+    const result = aggregateUsageByModel([
+      row({ model: 'unknown', costUsd: 3 }),
+      row({ model: null, costUsd: 1 }),
+    ])
+    expect(result.map((m) => m.model)).toEqual(['unknown', null])
+  })
+})
+
+describe('formatUsageDuration', () => {
+  // Echoes the catalogue's shape without pulling it in — what matters here is which
+  // key is picked and what is passed to it.
+  const t = ((key: string, params?: Record<string, string | number>) =>
+    `${key}:${JSON.stringify(params ?? {})}`) as unknown as Translate
+
+  it('drops to hours and minutes past an hour', () => {
+    expect(formatUsageDuration(3 * 3600_000 + 25 * 60_000, t)).toBe('duration.hoursMinutes:{"hours":3,"minutes":25}')
+  })
+
+  it('uses minutes and seconds under an hour', () => {
+    expect(formatUsageDuration(5 * 60_000 + 30_000, t)).toBe('duration.minutesSeconds:{"minutes":5,"seconds":30}')
+  })
+
+  it('falls back to seconds under a minute', () => {
+    expect(formatUsageDuration(42_000, t)).toBe('relative.seconds:{"count":42}')
+  })
+
+  it('reads zero as zero seconds rather than as no duration', () => {
+    expect(formatUsageDuration(0, t)).toBe('relative.seconds:{"count":0}')
   })
 })
 

--- a/desktop/src/renderer/utils/usageStats.ts
+++ b/desktop/src/renderer/utils/usageStats.ts
@@ -1,5 +1,6 @@
 import { localeOf } from '../../i18n'
 import { DEFAULT_LANGUAGE, type UsageStatRow } from '../../types'
+import type { Translate } from '../i18n'
 
 /**
  * Format a USD amount for display: `<$0.01` under a cent, rounded thousands, else
@@ -30,6 +31,25 @@ export interface MemberUsage {
   sessions: number
 }
 
+export interface ModelUsage {
+  /**
+   * `null` is the bucket for a row whose model could not be named — the same encoding
+   * `UsageStatRow.model` already uses for it, rather than a second one invented here.
+   *
+   * Deliberately NOT a sentinel string like `'unknown'`: a model really could be called
+   * that, and it would then be merged into the missing-model bucket and relabelled,
+   * silently and with nothing to catch it. (`aggregateUsageByMember` gets away with `''`
+   * for the same job only because no user id can ever be the empty string.) The view
+   * translates the null; this layer never does.
+   */
+  model: string | null
+  costUsd: number
+  sessions: number
+  linesAdded: number
+  linesRemoved: number
+  durationMs: number
+}
+
 /** Sum the headline totals across all usage rows. */
 export function aggregateUsageTotals(rows: UsageStatRow[]): UsageTotals {
   const totals: UsageTotals = { costUsd: 0, linesAdded: 0, linesRemoved: 0, durationMs: 0, sessions: rows.length }
@@ -53,6 +73,57 @@ export function aggregateUsageByMember(rows: UsageStatRow[]): MemberUsage[] {
     byUser.set(userId, entry)
   }
   return [...byUser.values()].sort((a, b) => b.costUsd - a.costUsd)
+}
+
+/**
+ * Per-model cost, sessions, lines and duration, sorted by cost descending.
+ *
+ * Rows with no model are BUCKETED under `null`, not dropped: sessions recorded before
+ * the statusLine hook started reporting one carry a null model, and silently leaving
+ * them out would make the per-model split add up to less than the totals beside it.
+ * An empty or whitespace-only name lands in the same bucket — a model written as
+ * `''` is no more identifiable than a missing one.
+ */
+export function aggregateUsageByModel(rows: UsageStatRow[]): ModelUsage[] {
+  const byModel = new Map<string | null, ModelUsage>()
+  for (const r of rows) {
+    const model = r.model?.trim() || null
+    const entry = byModel.get(model) ?? { model, costUsd: 0, sessions: 0, linesAdded: 0, linesRemoved: 0, durationMs: 0 }
+    entry.costUsd += r.costUsd
+    entry.sessions += 1
+    entry.linesAdded += r.linesAdded
+    entry.linesRemoved += r.linesRemoved
+    entry.durationMs += r.durationMs
+    byModel.set(model, entry)
+  }
+  return [...byModel.values()].sort((a, b) => b.costUsd - a.costUsd)
+}
+
+/**
+ * "2h 5m", "5m 30s", "42s" — a duration for the Team page's usage block.
+ *
+ * The same three catalogue keys, and the same rounding, as `formatDuration` in
+ * `components/agent-info-sidebar/UsageCard.tsx`: the two figures describe the same
+ * measurement, one session at a time versus a team's worth, and a reader who saw them
+ * disagree would be right to distrust both.
+ *
+ * THIS IS THE COPY THAT SHOULD SURVIVE. The card's is a private duplicate of this body,
+ * kept alive only because it predates this function — and it already imports `formatUsd`
+ * from this very module, so adopting this one adds no coupling it does not have. Deleting
+ * it is the follow-up; until then the rounding rule is kept in step by hand, which is
+ * exactly the thing a shared function exists to stop.
+ *
+ * `t` is a parameter for the same reason the locale is on `formatUsd`: this is a plain
+ * function, so a hook is impossible here. Callers pass `useT()`.
+ */
+export function formatUsageDuration(ms: number, t: Translate): string {
+  const totalSec = Math.round(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  if (h > 0) return t('duration.hoursMinutes', { hours: h, minutes: m })
+  if (m > 0) return t('duration.minutesSeconds', { minutes: m, seconds: s })
+  return t('relative.seconds', { count: s })
 }
 
 /**


### PR DESCRIPTION
## Description

The model is written to `usage_events` on every session and read back into `UsageStatRow.model`, but nothing consumed it. This adds the missing consumer: a per-model aggregation and the first UI to render the org usage read path, which until now was wired end-to-end with no caller in the renderer.

## Related Issue

Fixes #187

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- `aggregateUsageByModel(rows)` in `usageStats.ts` — cost, sessions, lines and duration per model, sorted by cost descending.
- New `UsageSection` on `DashboardPage` (Team modal) calling the existing `org:getUsageStats` IPC, rendering the totals, the per-member split and the new per-model split.
- `capped` is honoured: a caption states the totals are a floor. The number is read from `rows.length` rather than hardcoded, since `capped` is only ever set when the response hit the limit — so the sentence stays true if `loadOrgUsageStats`'s `LIMIT` moves.
- Rows with no model group under an explicit bucket instead of being dropped. `ModelUsage.model` stays `string | null` rather than using an `'unknown'` sentinel: a model genuinely named `unknown` would otherwise be merged into the missing-model bucket and silently relabelled. The view translates the null; the data layer never does. A test pins that collision.
- `formatUsageDuration(ms, t)` added to `usageStats.ts`, reusing the existing `duration.hoursMinutes` / `duration.minutesSeconds` / `relative.seconds` keys.
- 9 new unit tests, and `dashboard.usage.*` keys in both catalogues.

The section header names the active org: `loadOrgUsageStats` filters on `org_id`, so these are not org-wide totals and should not read as such.

Read-only and additive. `UsageStats` / `UsageStatRow` and the `{ rows, capped }` contract are untouched, so `daily-digest.ts` — the only other consumer — cannot break.

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

`npm test`: 74 files, 1097 tests passing. `tsc --noEmit`: clean. `npm run lint`: 0 errors (3 pre-existing `no-explicit-any` warnings in `Config/RepoPage.tsx`, untouched by this PR).

### Test Steps

Prerequisites: an account belonging to an org that has recorded usage — the section reads the **active** org only. No env var or seed data needed beyond a normal signed-in dev session.

1. Run `npm run desktop` and open the **Team** modal from the sidebar. A "Cost & usage · &lt;org name&gt;" section appears under the skill-hours banner.
2. Check the totals row (cost, sessions, lines, duration), then the per-member split and the per-model split. The per-model rows must be ordered by cost, highest first.
3. Confirm sessions recorded before #186 landed show up as a labelled unknown-model row rather than vanishing — compare the model rows' session counts against the totals row; they must add up.
4. A member row with no `userId` must fall back to `Unassigned`, not render blank.
5. Switch the app language to French and reopen the modal: every label is translated and no raw catalogue key is shown. Model names stay untranslated.
6. If the org has more than 5000 usage rows, a caption below the section states the totals are partial. Otherwise no caption is shown.

## Screenshots

<!-- Skipped: the section renders live org data, so a screenshot would leak member emails and costs. -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

Three follow-ups this PR deliberately does not take on:

- `formatDuration` in `components/agent-info-sidebar/UsageCard.tsx` is now a second copy of `formatUsageDuration`, kept in step by hand. Deleting it and importing the shared one is a small, separate change — it was left out to keep this PR's scope to the ticket.
- The two splits are a grid of `span`s, so a screen reader announces them as an undifferentiated run of text. A `table` with `th scope="col"` would fix it.
- `useOrg()` is a hook with per-instance state, not a context, so `UsageSection` and `RepoSection` each pay the org IPC fan-out when the Team modal opens. The fix belongs in `useOrg.ts`.

Also worth knowing: `CloudStore.loadOrgUsageStats` swallows its Supabase error and returns `{ rows: [], capped: false }`, so a genuinely failed read renders as `$0.00` plus the neutral empty state. Pre-existing in the main process, but this is the first UI where it becomes visible.

`linesAdded` / `linesRemoved` / `durationMs` are aggregated per model as the issue specifies, but only surface in the totals row today — say the word if the per-model grid should carry them too.
