### PR TITLE
[#189] List the org's repositories during invitation onboarding

### DIFF
--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -785,10 +785,19 @@ export const en = {
   'invite.wizard.emailPlaceholder': 'Email (must match the invitation)',
   'invite.wizard.passwordPlaceholder': 'Password',
   'invite.wizard.accept': 'Accept',
-  'invite.wizard.reposTitle': 'Add your repositories',
-  'invite.wizard.reposHelp':
-    'This is the only thing you set locally — everything else is inherited from your org.',
-  'invite.wizard.addRepo': 'Add a repository folder',
+  'invite.wizard.orgReposTitle': 'Your team’s repositories',
+  'invite.wizard.orgReposHelp':
+    'Point each one at its folder on this machine — the folder can be named anything. This is the only thing you set locally; everything else is inherited from your org.',
+  'invite.wizard.noOrgRepos': 'Your team hasn’t shared any repository yet.',
+  'invite.wizard.linkFolder': 'Link folder',
+  'invite.wizard.changeFolder': 'Change',
+  'invite.wizard.mismatchWarning':
+    'The folder “{folder}” doesn’t look like “{name}”. Link it anyway?',
+  'invite.wizard.belongsToOther':
+    'The folder “{folder}” looks like “{name}”, not this repository. Link it anyway?',
+  'invite.wizard.linkAnyway': 'Link anyway',
+  'invite.wizard.linkInvalid': 'Folder linked, but it can’t be used: {reason}',
+  'invite.wizard.addOtherRepo': 'Add a repository your team doesn’t have',
   'invite.wizard.continue': 'Continue',
   'invite.wizard.doneTitle': 'You’re all set!',
   'invite.wizard.doneNamed': 'You’ve joined {name} and inherited its configuration.',

--- a/desktop/src/i18n/fr.ts
+++ b/desktop/src/i18n/fr.ts
@@ -789,10 +789,19 @@ export const fr: Record<keyof typeof en, string> = {
   'invite.wizard.emailPlaceholder': 'E-mail (doit correspondre à l’invitation)',
   'invite.wizard.passwordPlaceholder': 'Mot de passe',
   'invite.wizard.accept': 'Accepter',
-  'invite.wizard.reposTitle': 'Ajouter vos dépôts',
-  'invite.wizard.reposHelp':
-    'C’est la seule chose que vous réglez en local — tout le reste est hérité de votre organisation.',
-  'invite.wizard.addRepo': 'Ajouter un dossier de dépôt',
+  'invite.wizard.orgReposTitle': 'Les dépôts de votre équipe',
+  'invite.wizard.orgReposHelp':
+    'Indiquez pour chacun son dossier sur cette machine — le dossier peut porter n’importe quel nom. C’est la seule chose que vous réglez en local, tout le reste est hérité de votre organisation.',
+  'invite.wizard.noOrgRepos': 'Votre équipe n’a encore partagé aucun dépôt.',
+  'invite.wizard.linkFolder': 'Associer un dossier',
+  'invite.wizard.changeFolder': 'Changer',
+  'invite.wizard.mismatchWarning':
+    'Le dossier « {folder} » ne ressemble pas à « {name} ». L’associer quand même ?',
+  'invite.wizard.belongsToOther':
+    'Le dossier « {folder} » ressemble à « {name} », pas à ce dépôt. L’associer quand même ?',
+  'invite.wizard.linkAnyway': 'Associer quand même',
+  'invite.wizard.linkInvalid': 'Dossier associé, mais inutilisable : {reason}',
+  'invite.wizard.addOtherRepo': 'Ajouter un dépôt que votre équipe n’a pas',
   'invite.wizard.continue': 'Continuer',
   'invite.wizard.doneTitle': 'Tout est prêt !',
   'invite.wizard.doneNamed': 'Vous avez rejoint {name} et hérité de sa configuration.',

--- a/desktop/src/renderer/components/InvitationOnboardingWizard.tsx
+++ b/desktop/src/renderer/components/InvitationOnboardingWizard.tsx
@@ -37,6 +37,13 @@ interface RowState {
   pending?: { path: string } & Exclude<FolderNameVerdict, { kind: 'none' }>
   /** The re-check's verdict when the bound folder is still not usable. */
   reason?: RepoSetupReason
+  /**
+   * `config:addRepository` succeeds on a folder that does not exist or is not a
+   * git repository, and reports it as a warning instead. The repository really
+   * was added, so this is not an error — but a row that says nothing would be
+   * the same silent success this step exists to remove.
+   */
+  warning?: string
   error?: string
 }
 
@@ -111,6 +118,13 @@ function OrgRepoBindRow({ row, state = {}, onLink, onConfirm, onCancel }: OrgRep
               {t('common.cancel')}
             </button>
           </div>
+        </div>
+      )}
+
+      {/* Added, but the main process flagged the folder — yellow, not red. */}
+      {state.warning && (
+        <div className="mt-2 px-3 py-2 bg-yellow/10 border border-yellow/20 rounded-lg text-xs text-yellow">
+          {state.warning}
         </div>
       )}
 
@@ -290,8 +304,12 @@ export function InvitationOnboardingWizard({ isOpen, onClose, initialToken = '' 
     setError(null)
     setBusy(true)
     try {
-      await addRepository(name, folderPath, [])
+      const result = await addRepository(name, folderPath, [])
       setAddedKeys((prev) => (prev.includes(name) ? prev : [...prev, name]))
+      // Same reasoning as bindFolder's re-check, one round-trip cheaper: this
+      // handler is told about a folder that is not a git repository, so the row
+      // has to say so rather than render as usable.
+      setRowStates((prev) => ({ ...prev, [name]: result?.warning ? { warning: result.warning } : {} }))
     } catch (e) {
       setError(e instanceof Error ? e.message : t('repoSetup.error'))
     } finally {

--- a/desktop/src/renderer/components/InvitationOnboardingWizard.tsx
+++ b/desktop/src/renderer/components/InvitationOnboardingWizard.tsx
@@ -1,10 +1,20 @@
-import { useState, useCallback, useEffect } from 'react'
-import { Mail, ChevronLeft, ChevronRight, X, Check, Folder, Trash2, Loader2 } from 'lucide-react'
+import { useState, useCallback, useEffect, useMemo } from 'react'
+import { Mail, ChevronLeft, ChevronRight, X, Check, Folder, FolderOpen, Loader2 } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
 import { useOrg } from '../hooks/useOrg'
 import { useConfig } from '../hooks/useConfig'
 import { useT } from '../i18n'
 import { INPUT } from '../theme/controls'
+import { repoBasename } from '../../repoMatch'
+import { REASON_META, type RepoSetupReason } from '../utils/repoSetup'
+import {
+  detectFolderNameMismatch,
+  isKeyTaken,
+  listBindableOrgRepos,
+  slugifyRepoName,
+  type FolderNameVerdict,
+  type OrgRepoRow,
+} from '../utils/orgRepoBinding'
 
 interface InvitationOnboardingWizardProps {
   isOpen: boolean
@@ -12,22 +22,120 @@ interface InvitationOnboardingWizardProps {
   initialToken?: string
 }
 
-interface PickedRepo {
-  name: string
-  path: string
+/**
+ * Per-row progress on step 2. Absent = untouched, and every writer sets exactly
+ * one of these — the states are alternatives, never combined.
+ */
+interface RowState {
+  busy?: boolean
+  /**
+   * A picked folder whose name does not look like the repository's, held until
+   * the user confirms. Non-blocking on purpose: a local clone is allowed to be
+   * named anything, so this asks rather than refuses. Carries the verdict itself
+   * so 'belongs-to-other' is the only shape that has an `otherRepoName`.
+   */
+  pending?: { path: string } & Exclude<FolderNameVerdict, { kind: 'none' }>
+  /** The re-check's verdict when the bound folder is still not usable. */
+  reason?: RepoSetupReason
+  error?: string
 }
 
 const TOTAL_STEPS = 3
 
+interface OrgRepoBindRowProps {
+  row: OrgRepoRow
+  state?: RowState
+  onLink: () => void
+  onConfirm: (folderPath: string) => void
+  onCancel: () => void
+}
+
 /**
- * Invitation onboarding: accept token → sign up/in → accept invitation → ask
- * ONLY for repo paths (everything else is inherited from the org). Skippable —
- * the app never blocks on it. Modeled on ProfileOnboardingWizard.
+ * One repository of the organization, with the folder it is bound to on this
+ * machine — or the yellow "no folder yet" state and the button to bind one.
+ *
+ * Local to this wizard on purpose: the launch modal's row answers a different
+ * question ("which of your repositories are broken"), and merging the two would
+ * make each one carry the other's states.
+ */
+function OrgRepoBindRow({ row, state = {}, onLink, onConfirm, onCancel }: OrgRepoBindRowProps) {
+  const t = useT()
+  const pending = state.pending
+
+  return (
+    <div className="px-3 py-2 bg-surface border border-line-field rounded-lg">
+      <div className="flex items-center gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium truncate">{row.displayName}</div>
+          {row.path ? (
+            <div className="text-xs text-text-secondary/50 truncate">{row.path}</div>
+          ) : (
+            // The same state the launch modal names, from the same table — one
+            // vocabulary and one tone for "no folder on this machine".
+            <span className="inline-flex items-center gap-1 mt-1 px-2 py-0.5 text-[11px] rounded-full bg-yellow/10 text-yellow">
+              <FolderOpen className="w-3 h-3" />
+              {t(REASON_META['no-local-path'].labelKey)}
+            </span>
+          )}
+        </div>
+        <button
+          onClick={onLink}
+          disabled={state.busy}
+          className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-accent border border-accent/20 rounded-lg hover:bg-accent/10 transition-all disabled:opacity-40 flex-shrink-0"
+        >
+          {state.busy
+            ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            : <><FolderOpen className="w-3.5 h-3.5" />{t(row.path ? 'invite.wizard.changeFolder' : 'invite.wizard.linkFolder')}</>}
+        </button>
+      </div>
+
+      {/* Name mismatch — a question, never a wall: the user can link anyway. */}
+      {pending && (
+        <div className="mt-2 px-3 py-2 bg-yellow/10 border border-yellow/20 rounded-lg text-xs text-yellow">
+          <p>
+            {pending.kind === 'belongs-to-other'
+              ? t('invite.wizard.belongsToOther', { folder: repoBasename(pending.path), name: pending.otherRepoName })
+              : t('invite.wizard.mismatchWarning', { folder: repoBasename(pending.path), name: row.displayName })}
+          </p>
+          <div className="flex items-center gap-2 mt-2">
+            <button
+              onClick={() => onConfirm(pending.path)}
+              className="px-2.5 py-1 font-medium bg-yellow/15 hover:bg-yellow/25 rounded-lg transition-colors"
+            >
+              {t('invite.wizard.linkAnyway')}
+            </button>
+            <button
+              onClick={onCancel}
+              className="px-2.5 py-1 text-text-secondary hover:text-ink transition-colors"
+            >
+              {t('common.cancel')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* A verdict and a failure are alternatives, so they share one block. */}
+      {(state.reason || state.error) && (
+        <div className="mt-2 px-3 py-2 bg-red/10 border border-red/20 rounded-lg text-xs text-red">
+          {state.reason
+            ? t('invite.wizard.linkInvalid', { reason: t(REASON_META[state.reason].labelKey) })
+            : state.error}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Invitation onboarding: accept token → sign up/in → accept invitation → bind
+ * the org's repositories to their local folders (everything else is inherited
+ * from the org). Skippable — the app never blocks on it. Modeled on
+ * ProfileOnboardingWizard.
  */
 export function InvitationOnboardingWizard({ isOpen, onClose, initialToken = '' }: InvitationOnboardingWizardProps) {
   const { login, signup } = useAuth()
   const { accept } = useOrg()
-  const { loadConfig } = useConfig()
+  const { config, loadConfig, addRepository, updateRepository } = useConfig()
   const t = useT()
 
   const [step, setStep] = useState(1)
@@ -35,10 +143,18 @@ export function InvitationOnboardingWizard({ isOpen, onClose, initialToken = '' 
   const [isNewAccount, setIsNewAccount] = useState(true)
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [repos, setRepos] = useState<PickedRepo[]>([])
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [orgName, setOrgName] = useState<string | null>(null)
+  // The org the invitation landed in, pinned at accept time: step 2 keeps
+  // listing the repositories of the org just joined even if the active org
+  // changes under it mid-flow.
+  const [orgId, setOrgId] = useState<string | null>(null)
+  const [rowStates, setRowStates] = useState<Record<string, RowState>>({})
+  // Repositories added here that the org does not have. They are created
+  // personal, so they never appear among the org rows — listed apart so the
+  // user still sees what they just added.
+  const [addedKeys, setAddedKeys] = useState<string[]>([])
 
   useEffect(() => { setToken(initialToken) }, [initialToken])
 
@@ -69,11 +185,14 @@ export function InvitationOnboardingWizard({ isOpen, onClose, initialToken = '' 
         return
       }
 
+      // `accept` resolves with the org it joined — no need to ask again for it.
       const result = await accept(token.trim())
-      const current = await window.electronAPI.org.current()
-      setOrgName(current?.name ?? null)
-      // Reflect any inherited config merge in the UI immediately.
-      if (result?.config) loadConfig()
+      setOrgId(result?.orgId ?? null)
+      setOrgName((await window.electronAPI.org.current())?.name ?? null)
+      // Reflect the inherited config merge in the UI immediately — step 2 lists
+      // the org's repositories straight out of it, so it must not run on the
+      // pre-invitation config.
+      await loadConfig()
       setStep(2)
     } catch (e) {
       setError(e instanceof Error ? e.message : t('invite.error.acceptFailed'))
@@ -82,32 +201,117 @@ export function InvitationOnboardingWizard({ isOpen, onClose, initialToken = '' 
     }
   }, [busy, token, email, password, isNewAccount, signup, login, accept, loadConfig])
 
-  const handleAddRepo = useCallback(async () => {
+  const repositories = useMemo(() => config?.repositories ?? {}, [config])
+
+  // The org's repositories, by name — what the invitee binds instead of guessing.
+  const orgRows = useMemo(
+    () => listBindableOrgRepos(repositories, orgId),
+    [repositories, orgId],
+  )
+
+  // The extra repositories added from here. They are created personal, so the
+  // personal scope is exactly what builds them — same mapper, same shape as the
+  // org rows. Kept in the order they were added, and anything that has meanwhile
+  // become an org repo is dropped: the org list already has it.
+  const addedRows = useMemo(() => {
+    const personal = new Map(listBindableOrgRepos(repositories, null).map((row) => [row.key, row]))
+    return addedKeys
+      .map((key) => personal.get(key))
+      .filter((row): row is OrgRepoRow => !!row && !orgRows.some((org) => org.key === row.key))
+  }, [addedKeys, repositories, orgRows])
+
+  /**
+   * Bind a folder to an existing repository, then ask the main process whether
+   * that actually produced a usable repo.
+   *
+   * The re-check is not belt and braces: `config:updateRepository` validates the
+   * path but drops the warning it computes, so without it a folder that is not a
+   * git repository — or one that has since moved — binds silently, which is the
+   * failure this step exists to remove. A failed write keeps the row actionable
+   * and claims nothing.
+   */
+  const bindFolder = useCallback(async (key: string, folderPath: string) => {
+    setRowStates((prev) => ({ ...prev, [key]: { busy: true } }))
+    try {
+      await updateRepository(key, { path: folderPath })
+    } catch (e) {
+      setRowStates((prev) => ({
+        ...prev,
+        [key]: { error: e instanceof Error ? e.message : t('repoSetup.error') },
+      }))
+      return
+    }
+    try {
+      const invalid = await window.electronAPI.config.getInvalidRepos()
+      const stillInvalid = invalid.find((repo) => repo.name === key)
+      setRowStates((prev) => ({ ...prev, [key]: stillInvalid ? { reason: stillInvalid.reason } : {} }))
+    } catch (e) {
+      // The write landed; only its verdict is unknown. Say exactly that.
+      setRowStates((prev) => ({
+        ...prev,
+        [key]: { error: e instanceof Error ? e.message : t('repoSetup.unverified') },
+      }))
+    }
+  }, [updateRepository, t])
+
+  /** Pick a folder for one org repo. A name that does not match only warns. */
+  const handleLinkFolder = useCallback(async (row: OrgRepoRow) => {
     const folderPath = await window.electronAPI.dialog.openFolder()
     if (!folderPath) return
-    const folderName = folderPath.split(/[\\/]/).pop() || ''
-    const name = folderName.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase()
-    if (!name) { setError(t('toast.invalidFolderName')); return }
-    if (repos.some(r => r.name === name)) { setError(t('invite.error.repoExists', { name })); return }
     setError(null)
-    setRepos(prev => [...prev, { name, path: folderPath }])
-  }, [repos])
+    // Only the org rows are comparable; a row added from the escape hatch is not
+    // in this list, so it binds without a name check — it has nothing to match.
+    const verdict = detectFolderNameMismatch(folderPath, row.key, orgRows)
+    if (verdict.kind === 'none') {
+      await bindFolder(row.key, folderPath)
+      return
+    }
+    setRowStates((prev) => ({
+      ...prev,
+      [row.key]: { pending: { path: folderPath, ...verdict } },
+    }))
+  }, [orgRows, bindFolder])
 
-  const handleRemoveRepo = useCallback((name: string) => {
-    setRepos(prev => prev.filter(r => r.name !== name))
+  const handleCancelPending = useCallback((key: string) => {
+    setRowStates((prev) => ({ ...prev, [key]: {} }))
   }, [])
 
-  // Step 2 → 3: persist the picked repo paths (inheriting org keywords by name).
+  /**
+   * Escape hatch: a repository the org does not have. Repositories are keyed by
+   * name, so an unchecked add would silently overwrite one of the org's — the
+   * guard runs against the whole config, not against a local list.
+   */
+  const handleAddOtherRepo = useCallback(async () => {
+    const folderPath = await window.electronAPI.dialog.openFolder()
+    if (!folderPath) return
+    const name = slugifyRepoName(repoBasename(folderPath))
+    if (!name) { setError(t('toast.invalidFolderName')); return }
+    if (isKeyTaken(repositories, orgRows, name)) { setError(t('invite.error.repoExists', { name })); return }
+    setError(null)
+    setBusy(true)
+    try {
+      await addRepository(name, folderPath, [])
+      setAddedKeys((prev) => (prev.includes(name) ? prev : [...prev, name]))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('repoSetup.error'))
+    } finally {
+      setBusy(false)
+    }
+  }, [repositories, orgRows, addRepository, t])
+
+  /**
+   * Step 2 → 3. Nothing left to persist — every binding was written as it was
+   * made — so this only re-runs the shared-config merge, best effort, to catch
+   * org repositories that landed after the merge at accept time. It fills only
+   * keys still undefined and never touches `path`, so a repo bound above keeps
+   * both the org's settings and its local folder. Repositories added from the
+   * escape hatch are personal, and `mergeOrgSharedConfig` skips them by design.
+   */
   const handleFinishRepos = useCallback(async () => {
     if (busy) return
     setBusy(true)
     setError(null)
     try {
-      for (const repo of repos) {
-        await window.electronAPI.config.addRepository(repo.name, repo.path, [])
-      }
-      // Newly added repos must also inherit the org's shared config — the merge
-      // at accept time only reached repositories that already existed.
       await window.electronAPI.org.applySharedConfig().catch(() => undefined)
       loadConfig()
       setStep(3)
@@ -116,7 +320,7 @@ export function InvitationOnboardingWizard({ isOpen, onClose, initialToken = '' 
     } finally {
       setBusy(false)
     }
-  }, [busy, repos, loadConfig])
+  }, [busy, loadConfig, t])
 
   if (!isOpen) return null
 
@@ -208,36 +412,39 @@ export function InvitationOnboardingWizard({ isOpen, onClose, initialToken = '' 
           {step === 2 && (
             <div className="space-y-3">
               <div>
-                <div className="text-sm font-medium mb-1">{t('invite.wizard.reposTitle')}</div>
+                <div className="text-sm font-medium mb-1">{t('invite.wizard.orgReposTitle')}</div>
                 <div className="text-xs text-text-secondary/50 mb-3">
-                  {t('invite.wizard.reposHelp')}
+                  {t('invite.wizard.orgReposHelp')}
                 </div>
               </div>
+
+              {/* Scrollable, so an org with twenty repositories stays usable */}
+              <div className="space-y-1.5 max-h-[40vh] overflow-y-auto">
+                {orgRows.length === 0 && addedRows.length === 0 && (
+                  <div className="px-3 py-2 bg-surface border border-line-field rounded-lg text-xs text-text-secondary">
+                    {t('invite.wizard.noOrgRepos')}
+                  </div>
+                )}
+                {[...orgRows, ...addedRows].map((row) => (
+                  <OrgRepoBindRow
+                    key={row.key}
+                    row={row}
+                    state={rowStates[row.key]}
+                    onLink={() => handleLinkFolder(row)}
+                    onConfirm={(folderPath) => bindFolder(row.key, folderPath)}
+                    onCancel={() => handleCancelPending(row.key)}
+                  />
+                ))}
+              </div>
+
               <button
-                onClick={handleAddRepo}
-                className="w-full flex items-center justify-center gap-2 py-3 text-sm border border-dashed border-line-strong rounded-lg text-text-secondary hover:border-accent/40 hover:text-ink transition-colors"
+                onClick={handleAddOtherRepo}
+                disabled={busy}
+                className="w-full flex items-center justify-center gap-2 py-3 text-sm border border-dashed border-line-strong rounded-lg text-text-secondary hover:border-accent/40 hover:text-ink transition-colors disabled:opacity-40"
               >
                 <Folder className="w-4 h-4" />
-                {t('invite.wizard.addRepo')}
+                {t('invite.wizard.addOtherRepo')}
               </button>
-              {repos.length > 0 && (
-                <div className="space-y-1.5">
-                  {repos.map((repo) => (
-                    <div key={repo.name} className="flex items-center gap-2 px-3 py-2 bg-surface border border-line-field rounded-lg">
-                      <div className="flex-1 min-w-0">
-                        <div className="text-sm font-medium truncate">{repo.name}</div>
-                        <div className="text-xs text-text-secondary/50 truncate">{repo.path}</div>
-                      </div>
-                      <button
-                        onClick={() => handleRemoveRepo(repo.name)}
-                        className="p-1 text-text-secondary/50 hover:text-red transition-colors"
-                      >
-                        <Trash2 className="w-3.5 h-3.5" />
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              )}
             </div>
           )}
 

--- a/desktop/src/renderer/utils/orgRepoBinding.test.ts
+++ b/desktop/src/renderer/utils/orgRepoBinding.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import type { RepositoryConfig } from '../../types'
+import {
+  detectFolderNameMismatch,
+  isKeyTaken,
+  listBindableOrgRepos,
+  type OrgRepoRow,
+} from './orgRepoBinding'
+
+function repo(overrides: Partial<RepositoryConfig> = {}): RepositoryConfig {
+  return { path: '/Users/me/dev/repo', keywords: [], ...overrides }
+}
+
+// An invitee's config right after accepting: the org's repositories arrive
+// unbound, and the key of the second `api` carries an org suffix.
+const REPOS: Record<string, RepositoryConfig> = {
+  'web': repo({ orgId: 'org-1', name: 'web', path: '', needsLocalPath: true }),
+  'api (Acme)': repo({ orgId: 'org-1', name: 'api', path: '', needsLocalPath: true }),
+  'infra': repo({ orgId: 'org-1', name: 'infra', path: '/Users/me/dev/infra' }),
+  'notes': repo({ orgId: null }),
+  'scratch': repo(),
+  'other-org': repo({ orgId: 'org-2', name: 'billing' }),
+}
+
+describe('listBindableOrgRepos', () => {
+  it('lists only the repositories of that org', () => {
+    const rows = listBindableOrgRepos(REPOS, 'org-1')
+    expect(rows.map((r) => r.key)).toEqual(['api (Acme)', 'infra', 'web'])
+  })
+
+  it('excludes personal repositories, whether orgId is null or absent', () => {
+    const rows = listBindableOrgRepos(REPOS, 'org-1')
+    expect(rows.some((r) => r.key === 'notes' || r.key === 'scratch')).toBe(false)
+    // …and they are exactly what the personal scope returns — the scope the
+    // wizard reuses to list the repositories added from its escape hatch.
+    expect(listBindableOrgRepos(REPOS, null).map((r) => r.key)).toEqual(['notes', 'scratch'])
+  })
+
+  it('shows the org name, not the key, when the two differ', () => {
+    const row = listBindableOrgRepos(REPOS, 'org-1').find((r) => r.key === 'api (Acme)')
+    // The key is what a config write takes; the name is what the invitee reads.
+    expect(row).toEqual({ key: 'api (Acme)', displayName: 'api', path: '' })
+  })
+
+  it('falls back to the key when the repository has no cloud name', () => {
+    const rows = listBindableOrgRepos({ solo: repo({ orgId: 'org-1' }) }, 'org-1')
+    expect(rows[0].displayName).toBe('solo')
+  })
+
+  it('separates bound from unbound rows — an empty path is "no folder yet"', () => {
+    const rows = listBindableOrgRepos(REPOS, 'org-1')
+    expect(rows.find((r) => r.key === 'infra')?.path).toBe('/Users/me/dev/infra')
+    expect(rows.find((r) => r.key === 'web')?.path).toBe('')
+  })
+
+  it('sorts by display name, so a suffixed key does not jump the list', () => {
+    const rows = listBindableOrgRepos(REPOS, 'org-1')
+    expect(rows.map((r) => r.displayName)).toEqual(['api', 'infra', 'web'])
+  })
+})
+
+describe('detectFolderNameMismatch', () => {
+  const rows = listBindableOrgRepos(REPOS, 'org-1')
+
+  it('says nothing when the folder is named like the repository', () => {
+    expect(detectFolderNameMismatch('/Users/me/dev/api', 'api (Acme)', rows)).toEqual({ kind: 'none' })
+  })
+
+  it('ignores case and punctuation, exactly like the add path does', () => {
+    expect(detectFolderNameMismatch('/Users/me/dev/API', 'api (Acme)', rows)).toEqual({ kind: 'none' })
+  })
+
+  it('warns when the folder name differs — without blocking the binding', () => {
+    // The case from the ticket: org repo `api`, local clone `api-service`.
+    expect(detectFolderNameMismatch('/Users/me/dev/api-service', 'api (Acme)', rows))
+      .toEqual({ kind: 'mismatch' })
+  })
+
+  it('names the other repository when the folder matches one of them', () => {
+    expect(detectFolderNameMismatch('/Users/me/dev/web', 'api (Acme)', rows))
+      .toEqual({ kind: 'belongs-to-other', otherRepoName: 'web' })
+  })
+
+  it('handles Windows separators', () => {
+    expect(detectFolderNameMismatch('C:\\dev\\web', 'api (Acme)', rows))
+      .toEqual({ kind: 'belongs-to-other', otherRepoName: 'web' })
+  })
+
+  it('still compares when the path carries a trailing separator', () => {
+    // repoBasename strips it; a naive split would yield '' and skip the check.
+    expect(detectFolderNameMismatch('/Users/me/dev/web/', 'api (Acme)', rows))
+      .toEqual({ kind: 'belongs-to-other', otherRepoName: 'web' })
+    expect(detectFolderNameMismatch('/Users/me/dev/api/', 'api (Acme)', rows))
+      .toEqual({ kind: 'none' })
+  })
+
+  it('stays silent when the target row is unknown or the folder unnameable', () => {
+    expect(detectFolderNameMismatch('/Users/me/dev/api-service', 'ghost', rows)).toEqual({ kind: 'none' })
+    expect(detectFolderNameMismatch('', 'api (Acme)', rows)).toEqual({ kind: 'none' })
+  })
+})
+
+describe('isKeyTaken', () => {
+  const rows: OrgRepoRow[] = listBindableOrgRepos(REPOS, 'org-1')
+
+  it('rejects a slug that already keys a repository, org or personal', () => {
+    expect(isKeyTaken(REPOS, rows, 'web')).toBe(true)
+    expect(isKeyTaken(REPOS, rows, 'notes')).toBe(true)
+  })
+
+  it('rejects a slug matching an org repository whose key is suffixed', () => {
+    // `api` keys nothing, but adding it would duplicate the org's `api (Acme)`.
+    expect(isKeyTaken(REPOS, rows, 'api')).toBe(true)
+  })
+
+  it('accepts a repository the org does not have', () => {
+    expect(isKeyTaken(REPOS, rows, 'sandbox')).toBe(false)
+  })
+})

--- a/desktop/src/renderer/utils/orgRepoBinding.ts
+++ b/desktop/src/renderer/utils/orgRepoBinding.ts
@@ -1,0 +1,103 @@
+import type { RepositoryConfig } from '../../types'
+import { repoBasename } from '../../repoMatch'
+import type { RepoScope } from './repoRows'
+
+/**
+ * One organization repository, as the invitation wizard presents it: something
+ * to bind to a local folder, never something to create.
+ *
+ * `key` is the record key in `Config.repositories` — the argument every config
+ * write takes — while `displayName` is the repository's real name in the cloud.
+ * The two differ when the key carries an org suffix (`api (Acme)`), so binding
+ * must use the key and the UI must show the name. An empty `path` is the
+ * "no folder on this machine yet" state, the same rule the main process
+ * validates by (`main/config/repo-validation.ts`).
+ */
+export interface OrgRepoRow {
+  key: string
+  displayName: string
+  path: string
+}
+
+/** What a picked folder says about the repository it is about to be bound to. */
+export type FolderNameVerdict =
+  | { kind: 'none' }
+  | { kind: 'mismatch' }
+  | { kind: 'belongs-to-other'; otherRepoName: string }
+
+/**
+ * The name a folder would get if it were added as a repository — the exact
+ * normalization `addRepository` callers apply, kept here so the comparison and
+ * the escape hatch cannot drift apart.
+ */
+export function slugifyRepoName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase()
+}
+
+/**
+ * The organization's repositories, as rows to bind.
+ *
+ * Scoped exactly like the Team page: `RepoScope` is an org id, or null for the
+ * repositories that belong to no org.
+ */
+export function listBindableOrgRepos(
+  repositories: Record<string, RepositoryConfig>,
+  scope: RepoScope,
+): OrgRepoRow[] {
+  const rows = Object.entries(repositories)
+    .filter(([, repo]) => (repo.orgId ?? null) === scope)
+    .map(([key, repo]) => ({
+      key,
+      displayName: repo.name ?? key,
+      path: repo.path ?? '',
+    }))
+
+  rows.sort((a, b) => a.displayName.localeCompare(b.displayName))
+  return rows
+}
+
+/**
+ * Whether the folder the user just picked looks like the repository they picked
+ * it for.
+ *
+ * The folder name is only a hint — a mismatch is surfaced, never enforced,
+ * because a local clone is allowed to be named anything. 'belongs-to-other' is
+ * the sharper case: the folder matches ANOTHER repository of the list, so the
+ * user most likely clicked the wrong row.
+ *
+ * A `targetKey` absent from `rows` yields 'none': rows outside the org list
+ * (the ones added from the escape hatch) have nothing to be compared against.
+ */
+export function detectFolderNameMismatch(
+  pickedPath: string,
+  targetKey: string,
+  rows: OrgRepoRow[],
+): FolderNameVerdict {
+  const target = rows.find((row) => row.key === targetKey)
+  if (!target) return { kind: 'none' }
+
+  const picked = slugifyRepoName(repoBasename(pickedPath))
+  if (!picked || picked === slugifyRepoName(target.displayName)) return { kind: 'none' }
+
+  const other = rows.find(
+    (row) => row.key !== targetKey && slugifyRepoName(row.displayName) === picked,
+  )
+  if (other) return { kind: 'belongs-to-other', otherRepoName: other.displayName }
+
+  return { kind: 'mismatch' }
+}
+
+/**
+ * Whether adding a repository under `slug` would collide with something the user
+ * already has. Repositories are keyed by name, so an unchecked add silently
+ * overwrites — and a slug matching one of the org's repositories is exactly the
+ * duplicate this wizard exists to prevent, even when the keys differ.
+ */
+export function isKeyTaken(
+  repositories: Record<string, RepositoryConfig>,
+  rows: OrgRepoRow[],
+  slug: string,
+): boolean {
+  if (slug in repositories) return true
+  return rows.some((row) => slugifyRepoName(row.displayName) === slug)
+}


### PR DESCRIPTION
## Description

Step 2 of the invitation onboarding wizard used to open a blind folder picker, derive a repository name from the folder's basename, and call `config.addRepository(name, folderPath, [])`. Whenever the invitee's clone was not named exactly as the admin named the repo (`api` shared by the org, `~/dev/api-service` on the machine), this silently produced a useless duplicate entry with none of the org's settings, while the real org repo stayed flagged `needsLocalPath` and yellow.

The org's repositories were already in `config.repositories` — `CloudStore.toRepositoryRecord` builds a record for every repository the user can see, each carrying `needsLocalPath: !r.path`. Step 2 now lists them and binds a folder to the repo the invitee actually picked, via `updateRepository(key, { path })`.

## Related Issue

Closes #189

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- Step 2 of `InvitationOnboardingWizard.tsx` now lists the org repositories the invitee inherited, sorted by display name, instead of opening a blind folder picker. Each unbound row shows the shared "no local folder" state; each bound row shows its path and a "Change" action.
- "Link folder" writes `updateRepository(key, { path })` — never `addRepository` — so the repo keeps its identity and the org's shared config (languages, commit/PR format, keywords) rather than spawning a second entry.
- A non-blocking inline warning fires when the picked folder's name does not match the target repo, and names the other repository when the folder looks like it belongs to a different row. The invitee can still confirm with "Link anyway". Comparing `git remote get-url origin` is deliberately left to #129.
- Every write is followed by a `config.getInvalidRepos()` re-check, because `config:updateRepository` computes `validateRepoPath`'s warning and drops it (unlike `config:addRepository`, which returns it). Without this, a missing or non-git folder would bind silently — the very failure mode this issue is about.
- The escape hatch for repos the org does not have is kept, now deduplicated against the whole config and the listed org rows via `isKeyTaken`, so an added slug can no longer collide with an inherited repo.
- New pure util `desktop/src/renderer/utils/orgRepoBinding.ts` (`listBindableOrgRepos`, `detectFolderNameMismatch`, `isKeyTaken`) with 16 unit tests, following the `repoSetup.ts` / `repoRows.ts` convention. It separates the config **record key** from `RepositoryConfig.name`, which diverge when `CloudStore` suffixes keys on cross-org name collisions.
- New `invite.wizard.*` keys in `en.ts` and `fr.ts`, with the three orphaned ones removed; parity kept.
- `RepoSetupWizard`, the main process, the preload bridge and the IPC handlers are untouched — the change is renderer-only, as the issue asks.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

`npm test` → 75 files, 1113 tests passing (including the en/fr i18n parity test). `tsc --noEmit` on `desktop/tsconfig.json` → clean. `npm run lint` → 0 errors (3 pre-existing `no-explicit-any` warnings in the untouched `RepoPage.tsx`).

### Test Steps

Prerequisites: `npm run desktop` from the repo root, and an account that is a member of an organization sharing at least one repository the account has no local path for.

1. Open the invitation onboarding wizard and reach step 2. **Expected:** the org's repositories are listed by name, each unbound one carrying the yellow "no local folder" state — no folder picker opens on its own.
2. Click "Link folder" on the row for a repo named `api`, and select a clone whose folder is named differently (e.g. `~/dev/api-service`). **Expected:** an inline warning appears on that row, with "Link anyway" and "Cancel"; nothing is written until you choose.
3. Confirm with "Link anyway", then open Settings → Repositories. **Expected:** exactly one `api` entry, now bound to the chosen path, still carrying the org's languages, commit/PR format and keywords. No `api-service` entry was created.
4. Back in step 2, click "Link folder" and pick a folder that is not a git repository. **Expected:** the row reports the reason in red instead of showing a success.
5. Click "Add a repository your team doesn't have" and pick any folder. **Expected:** the repo is added and listed. Retry with a folder whose slugified name collides with one of the org rows. **Expected:** the add is refused with the "already exists" message.
6. With an account that inherited no org repositories, reach step 2. **Expected:** the "no org repositories" message plus the escape hatch alone — and "Skip"/Escape still leave the wizard as before.

## Screenshots

N/A — reviewed from the code; no screenshot captured for this PR.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md (if applicable)

## Additional Notes

- **Not exercised in the running app.** Verification was static: unit tests, typecheck and lint. The six steps above have not been walked through in a live Electron session.
- **Known gap worth a look during review:** `ensureHydrated()` is memoized and only reset on sign-out. On the "already signed in" entry path (Settings → cloud account), `acceptInvitation` creates the membership but nothing re-hydrates the repository records — so `loadConfig()` may return a config without the newly joined org's repos, the step shows the empty state, and the invitee is pushed back to the escape hatch. A forced rehydrate (or a retry affordance on the empty state) would close it; it felt beyond the scope of this issue.
- Related, out of scope: `config:updateRepository` could return `pathValidation.warning` the way `config:addRepository` does. Two renderer call sites currently compensate with a full `getInvalidRepos()` round-trip that re-stats every configured repository to learn about one folder.
- Also unchanged: an unconfirmed mismatch warning is silently dropped if the invitee clicks Continue without answering it, and nothing guards against two rows being bound to the same folder.
