### PR TITLE
[#196] add planning statuses and specPath metadata field

### DIFF
--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -876,6 +876,8 @@ export const en = {
   'duration.minutesSeconds': '{minutes}m {seconds}s',
 
   // ── Agent workflow status (badges) ───────────────────────────────────────
+  'status.planning': 'Planning',
+  'status.planned': 'Planned',
   'status.inProgress': 'In progress',
   'status.committed': 'Committed',
   'status.readyForPR': 'Ready for PR',
@@ -1233,6 +1235,8 @@ export const en = {
   // Lower-case on purpose — these render inside a small inline pill, not as a
   // sentence, and they are a different register from the `status.*` badges.
   'statusPill.none': 'no status',
+  'statusPill.planning': 'planning',
+  'statusPill.planned': 'planned',
   'statusPill.inProgress': 'in progress',
   'statusPill.committed': 'committed',
   'statusPill.readyForPR': 'ready for PR',

--- a/desktop/src/i18n/fr.ts
+++ b/desktop/src/i18n/fr.ts
@@ -866,6 +866,8 @@ export const fr: Record<keyof typeof en, string> = {
   'duration.minutesSeconds': '{minutes} min {seconds} s',
 
   // ── État de workflow d'un agent (badges) ─────────────────────────────────
+  'status.planning': 'Planification',
+  'status.planned': 'Planifié',
   'status.inProgress': 'En cours',
   'status.committed': 'Committé',
   'status.readyForPR': 'Prêt pour la PR',
@@ -1195,6 +1197,8 @@ export const fr: Record<keyof typeof en, string> = {
 
   // ── Sélecteur d'état (barre d'infos de l'agent) ──────────────────────────
   'statusPill.none': 'aucun état',
+  'statusPill.planning': 'planification',
+  'statusPill.planned': 'planifié',
   'statusPill.inProgress': 'en cours',
   'statusPill.committed': 'committé',
   'statusPill.readyForPR': 'prêt pour la PR',

--- a/desktop/src/main/hooks/status-server.test.ts
+++ b/desktop/src/main/hooks/status-server.test.ts
@@ -28,6 +28,7 @@ import {
   setSkillCallback,
   setQuestionCallback,
   setClearQuestionCallback,
+  setMetadataCallback,
 } from './status-server'
 
 describe('parseStatusLinePayload', () => {
@@ -303,6 +304,36 @@ describe('read-back endpoints', () => {
       const { status } = await httpGet('/skill?id=term-1')
       expect(status).toBe(200)
       expect(calls).toHaveLength(0)
+    })
+  })
+
+  describe('GET /metadata', () => {
+    type Received = { id: string; metadata: Record<string, unknown> }
+    let received: Received[] = []
+
+    beforeEach(() => {
+      received = []
+      setMetadataCallback((id, metadata) => received.push({ id, metadata }))
+    })
+
+    // The path is announced BEFORE the spec is written: a planning agent says where
+    // its output will land, so an existence check here would drop the one message
+    // that tells the app a plan is in flight. This one test covers both "specPath is
+    // forwarded" and "no filesystem check happens" — a separate happy-path test would
+    // just repeat the same assertion against a different string.
+    it('forwards specPath to the metadata callback even when the file does not exist yet', async () => {
+      const spec = path.join(TEST_CONFIG_DIR, 'nothing-here', 'spec-does-not-exist.md')
+      expect(fs.existsSync(spec)).toBe(false)
+
+      const { status } = await httpGet(`/metadata?id=term-1&specPath=${encodeURIComponent(spec)}`)
+      expect(status).toBe(200)
+      expect(received).toEqual([{ id: 'term-1', metadata: { specPath: spec } }])
+    })
+
+    it('leaves specPath out entirely when the caller sends none', async () => {
+      const { status } = await httpGet('/metadata?id=term-1&title=Hello')
+      expect(status).toBe(200)
+      expect(received).toEqual([{ id: 'term-1', metadata: { title: 'Hello' } }])
     })
   })
 

--- a/desktop/src/main/hooks/status-server.ts
+++ b/desktop/src/main/hooks/status-server.ts
@@ -354,6 +354,10 @@ export function startStatusServer(): Promise<number> {
           const prRepo = url.searchParams.get('prRepo')  // Repository path for the PR
           const fullStackTaskId = url.searchParams.get('fullStackTaskId')
           const relatedWorktreesRaw = url.searchParams.get('relatedWorktrees')
+          // Absolute path to the spec the planning phase writes. Taken raw, and NOT
+          // checked against the filesystem: the writer announces where the spec will
+          // be, so it legitimately arrives before the file exists.
+          const specPath = url.searchParams.get('specPath')
 
           if (terminalId && metadataCallback) {
             const metadata: Record<string, string | string[] | Record<string, { prUrl?: string }>> = {}
@@ -363,6 +367,7 @@ export function startStatusServer(): Promise<number> {
             if (description) metadata.description = description
             if (status) metadata.status = status
             if (baseBranch) metadata.baseBranch = baseBranch
+            if (specPath) metadata.specPath = specPath
             if (prUrl && prRepo) {
               // Store PR URL per repository
               metadata.repositoryMetadata = { [prRepo]: { prUrl } }

--- a/desktop/src/main/ipc/terminal-handlers.test.ts
+++ b/desktop/src/main/ipc/terminal-handlers.test.ts
@@ -262,8 +262,8 @@ describe('the status contract with the skills', () => {
     // `done` sat in HistoryAction with zero producers. A value in the union that no
     // status maps to is a metric someone will one day try to chart and find empty.
     const produced = new Set(Object.values(STATUS_TO_ACTION).filter(Boolean))
-    const fromStatuses: string[] = ['started', 'committed', 'ready_for_pr', 'pr_created',
-      'ci_green', 'review', 'review_changes_requested', 'review_addressed', 'merged']
+    const fromStatuses: string[] = ['planning', 'planned', 'started', 'committed', 'ready_for_pr',
+      'pr_created', 'ci_green', 'review', 'review_changes_requested', 'review_addressed', 'merged']
     expect([...produced].sort()).toEqual([...fromStatuses].sort())
   })
 })

--- a/desktop/src/main/ipc/terminal-handlers.ts
+++ b/desktop/src/main/ipc/terminal-handlers.ts
@@ -86,6 +86,10 @@ const previousStatus = new Map<string, string>()
  */
 export const STATUS_TO_ACTION: Record<NonNullable<TerminalMetadata['status']>, HistoryAction | null> = {
   '': null, // cleared status: an absence, not an event
+  // The pair, not just the end: `planned` alone says a spec exists, the two together
+  // say how long the idea took to become one.
+  'planning': 'planning',
+  'planned': 'planned',
   'in progress': 'started',
   'committed': 'committed',
   'ready for PR': 'ready_for_pr',

--- a/desktop/src/main/store/CloudStore.ts
+++ b/desktop/src/main/store/CloudStore.ts
@@ -113,6 +113,11 @@ function probeFailure(error: unknown): string {
  * what a reader can measure, not what is worth recording.
  */
 const FLOW_ACTIONS: readonly HistoryAction[] = [
+  // Both halves of the planning phase, deliberately: `planned` alone would give a
+  // milestone with no interval, and the pair is what makes "idea → ticket" measurable
+  // (comparable frequency to `agent_created`, already listed below).
+  'planning',
+  'planned',
   'started',
   'ready_for_pr',
   'pr_created',
@@ -864,7 +869,7 @@ export class CloudStore implements Store {
       status: status ?? null,
       repositories: agent.repositories ?? [],
       // What is left has no column of its own: title, fullStackTaskId,
-      // relatedWorktrees, repositoryMetadata, usage — plus __app, which carries
+      // relatedWorktrees, repositoryMetadata, usage, specPath — plus __app, which carries
       // tsCreate and splitPane, neither of which has anywhere else to live. Its
       // `id` is the one field now duplicated, and only for compatibility: a build
       // older than 20260814090000 reads the app id from here and nowhere else.

--- a/desktop/src/renderer/components/AgentInfoSidebar.tsx
+++ b/desktop/src/renderer/components/AgentInfoSidebar.tsx
@@ -85,7 +85,10 @@ export function AgentInfoSidebar() {
     : activeTerminalId
   const activeTerminal = terminals.find(t => t.id === inspectedTerminalId)
   const metadata = activeTerminal?.metadata
-  const canClose = metadata?.status === 'PR merged' || !metadata?.status
+  // `planned` is a terminal state too: a planning agent ends at a spec and never
+  // reaches `PR merged`, so without it the only way to close one would be to clear
+  // its status first.
+  const canClose = metadata?.status === 'PR merged' || metadata?.status === 'planned' || !metadata?.status
 
   // Get all configured repository paths for the dropdown
   const availableRepos = useMemo(() => {

--- a/desktop/src/renderer/components/agent-info-sidebar/TicketHeader.tsx
+++ b/desktop/src/renderer/components/agent-info-sidebar/TicketHeader.tsx
@@ -10,8 +10,17 @@ import { useT, type MessageKey } from '../../i18n'
 // fixed values that do not follow the theme, so on any of the four light themes the
 // pill was pale blue on white and unreadable. The tokens carry a per-theme value
 // (desktop/src/themes.ts), dark on a light window and bright on a dark one.
+//
+// The nine colour tokens were already spent by the nine entries below, so the two
+// planning statuses re-use `orange` and `cyan` at a lower alpha plus a ring: the ring
+// is what keeps them apart from `ready for PR` and `committed`, which hold the same
+// hue at /20. A neutral grey was not an option — that is UNKNOWN_STATUS_STYLE, and a
+// known status must never look like one this version failed to recognise.
 const STATUS_OPTIONS = [
   { value: '',             labelKey: 'statusPill.none',    bg: 'bg-surface-strong',      text: 'text-text-secondary' },
+  // First in the array because it reads as workflow order: planning precedes any code.
+  { value: 'planning',     labelKey: 'statusPill.planning',    bg: 'bg-orange/10 ring-1 ring-orange/40', text: 'text-orange' },
+  { value: 'planned',      labelKey: 'statusPill.planned',     bg: 'bg-cyan/10 ring-1 ring-cyan/40',     text: 'text-cyan' },
   { value: 'in progress',  labelKey: 'statusPill.inProgress',  bg: 'bg-yellow/20',     text: 'text-yellow' },
   { value: 'committed',    labelKey: 'statusPill.committed',     bg: 'bg-cyan/20',       text: 'text-cyan' },
   { value: 'ready for PR', labelKey: 'statusPill.readyForPR',  bg: 'bg-orange/20',     text: 'text-orange' },

--- a/desktop/src/renderer/pages/Dashboard/parts.tsx
+++ b/desktop/src/renderer/pages/Dashboard/parts.tsx
@@ -11,6 +11,11 @@ import type { MessageKey } from '../../i18n'
 // Workflow-status → label + badge color. Statuses mirror
 // TerminalMetadata.status; anything unrecognized falls through to a neutral pill.
 export const STATUS_CONFIG: Record<string, { labelKey: MessageKey; className: string }> = {
+  // Planning first: it precedes any code. `orange` and `cyan` are the two tokens this
+  // map had not spent yet, so unlike the sidebar picker — where both hues were already
+  // taken and the pills need a ring to stay distinct — plain tints are enough here.
+  planning:             { labelKey: 'status.planning',         className: 'bg-orange/15 text-orange' },
+  planned:              { labelKey: 'status.planned',          className: 'bg-cyan/15 text-cyan' },
   'in progress':        { labelKey: 'status.inProgress',       className: 'bg-accent/15 text-accent' },
   committed:            { labelKey: 'status.committed',        className: 'bg-yellow/15 text-yellow' },
   'ready for PR':       { labelKey: 'status.readyForPR',       className: 'bg-blue/15 text-blue' },

--- a/desktop/src/types.ts
+++ b/desktop/src/types.ts
@@ -165,9 +165,21 @@ export interface TerminalMetadata {
    * months: magic-pr sent it, it landed in agents.status as an off-enum value, and it
    * produced no activity event at all — so "the CI went green" was a thing the product
    * knew and never recorded. A test now locks both directions of that contract.
+   *
+   * `planning` / `planned` are the planning phase that PRECEDES any code: an idea
+   * being turned into a spec, then a spec ready to become a ticket. They are declared
+   * here BEFORE anything sends them, on purpose — the union is closed, so the contract
+   * has to exist before a skill can honour it.
    */
-  status?: '' | 'in progress' | 'committed' | 'ready for PR' | 'PR created' | 'CI green' | 'in review' | 'changes requested' | 'Review addressed' | 'PR merged'
+  status?: '' | 'planning' | 'planned' | 'in progress' | 'committed' | 'ready for PR' | 'PR created' | 'CI green' | 'in review' | 'changes requested' | 'Review addressed' | 'PR merged'
   baseBranch?: string
+  /**
+   * Path to the spec file the planning phase writes. ABSOLUTE: an agent can hold
+   * several repositories, so the renderer has no single root to resolve a relative
+   * path against and must never try. May arrive BEFORE the file exists — the writer
+   * announces where the spec will be, and nothing here checks the filesystem.
+   */
+  specPath?: string
   fullStackTaskId?: string
   relatedWorktrees?: string[]
   repositoryMetadata?: Record<string, RepositoryMetadata>
@@ -942,6 +954,10 @@ export interface CommandHistoryEntry {
 }
 
 export type HistoryAction =
+  /** A planning session opened on an idea (status 'planning'). */
+  | 'planning'
+  /** The plan reached a spec ready to become a ticket (status 'planned'). */
+  | 'planned'
   | 'started'
   | 'committed'
   | 'pr_created'


### PR DESCRIPTION
## Description

`planning` and `planned` join the closed `TerminalMetadata['status']` contract, and `/metadata` learns a `specPath` query param. This is pure contract work: nothing in the product sends either value yet and no existing behaviour changes, which is exactly what makes it mergeable on its own, ahead of the `/magic:plan` skill.

It is the gate the rest of epic #170 branches from — #171 infers "this is a planning agent" from the two statuses rather than adding an agent-kind field, and #194 derives both its display slug (the basename) and its row identity (a hash of the path) from `specPath`.

## Related Issue

Closes #196

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **`desktop/src/types.ts`** — `planning` / `planned` added to `TerminalMetadata['status']` and to `HistoryAction`; new `specPath?: string` field, documented as absolute and as possibly arriving before the file exists.
- **`desktop/src/main/ipc/terminal-handlers.ts`** — both statuses mapped in `STATUS_TO_ACTION` to **non-null** actions. A `null` mapping would have been read as "unmapped" by the contract test; `''` only gets away with it because no skill sends it.
- **`desktop/src/main/store/CloudStore.ts`** — both actions added to `FLOW_ACTIONS` (rationale below), and the `toAgentRow` comment updated to name `specPath` among the fields that ride in the jsonb column.
- **`desktop/src/main/hooks/status-server.ts`** — `specPath` added to the `/metadata` query-param allow-list and to the metadata object, following the neighbouring convention exactly: raw string, conditional inclusion, no coercion, and no check that the file exists.
- **`desktop/src/renderer/components/AgentInfoSidebar.tsx`** — `canClose` now also accepts `planned`, so a planning agent that finished can actually be closed.
- **`TicketHeader.tsx` / `Dashboard/parts.tsx`** — real status pills on both surfaces rather than the neutral unknown-status fallback.
- **`desktop/src/i18n/{en,fr}.ts`** — `status.planning`, `status.planned`, `statusPill.planning`, `statusPill.planned` in both locales.
- **Tests** — `terminal-handlers.test.ts`: the hardcoded `fromStatuses` list extended so the set-equality test passes from the other direction. `status-server.test.ts`: first coverage of the `GET /metadata` route, asserting `specPath` reaches the callback even when the file does not exist yet.

No Supabase migration: `agents.status` and `activity_events.action` are plain `text` with no enum or check constraint, and `specPath` lands in the existing jsonb `metadata` column via `toAgentRow`'s `...rest`.

## Testing

- [x] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`) — 0 errors (3 pre-existing `no-explicit-any` warnings in `Config/RepoPage.tsx`, untouched here)
- [ ] Tested installation script — not applicable
- [ ] Tested affected slash commands — none affected: no skill sends the new statuses or `specPath` yet, which is the point of this story

Also run: `npm test` → 80 files / 1203 tests passing, and `npm run typecheck` in `desktop/` → clean, with no `@ts-expect-error` added anywhere.

### Test Steps

Prerequisites: Node 20 (`.nvmrc`), `npm install` at the root and in `desktop/`, then `npm run desktop`. No env vars, seed data or extra service needed.

1. Open the status selector in an agent's info sidebar. **Expect** `planning` and `planned` listed right after the empty entry, before `in progress` — orange and cyan with a thin ring, **not** the neutral grey unknown-status badge.
2. Set an agent to `planned`, then look at the dashboard list. **Expect** the same two statuses rendering as coloured pills there too, with their labels — not the raw string.
3. Switch the app language between English and French. **Expect** `Planning` / `Planned` and `Planification` / `Planifié` on the dashboard pill, and the lower-case `planning` / `planned` and `planification` / `planifié` in the sidebar picker.
4. With the agent still at `planned`, look at the sidebar's close control. **Expect** it to be available — before this change only `PR merged` (or no status at all) allowed closing.
5. Send a spec path for a file that does **not** exist yet:
   `curl "http://127.0.0.1:$MAGIC_SLASH_PORT/metadata?id=$MAGIC_SLASH_TERMINAL_ID&specPath=/tmp/does-not-exist/.magic/spec-x.md"`
   **Expect** a success response and no error in the logs. Then `curl "http://127.0.0.1:$MAGIC_SLASH_PORT/agent?id=$MAGIC_SLASH_TERMINAL_ID"` and **expect** `specPath` present in the returned metadata.
6. Quit and relaunch the app, then repeat the `GET /agent` call. **Expect** `specPath` still there — this is the "survives a restart" criterion.

## Screenshots

Not attached: the two new pills are the only visual surface, and steps 1–3 above describe exactly what to look for in both themes and both locales. Worth an eyes-on check on the light themes — see the note on the ring below.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly — nothing user-facing to document yet
- [x] My changes generate no new warnings
- [x] I have added/updated tests if applicable
- [x] All linters pass locally
- [ ] I have updated CHANGELOG.md — see the note below

## Additional Notes

### The `FLOW_ACTIONS` decision (required explicitly by the ticket)

**Both `planning` and `planned` are included.** The pair is what makes the interval the product cannot currently measure — "how long does an idea take to become a ticket" — actually computable: `planned` alone gives the far end with no duration behind it. The volume objection against `planning` does not hold either, since `agent_created`, of comparable frequency and meaning, is already a member. Worth remembering that `FLOW_ACTIONS` is a plain literal array and is **not** exhaustiveness-checked against `HistoryAction`, so an omission there would have been silent — hence recording the call rather than leaving it implicit.

### Colour palette

The theme exposes exactly 9 colour tokens and the 9 existing statuses had already spent all of them. `planning` takes orange and `planned` cyan on both surfaces; on the dashboard those two were free, while in the sidebar they are already owned by `ready for PR` and `committed` at `/20`, so the new ones are distinguished by a lower alpha plus `ring-1`. The neutral grey was deliberately avoided — it is `UNKNOWN_STATUS_STYLE`, precisely the fallback the acceptance criteria rule out. The ring is a fairly quiet separator at pill size, so this is the one thing worth a reviewer's eye on the light themes; the alternative would be adding two theme tokens across all four themes, which is well beyond this ticket's scope.

### Placement in `STATUS_OPTIONS`

The two entries sit at index 1 and 2 rather than at index 0. `getStatusOption` returns `STATUS_OPTIONS[0]` as the no-status default, so putting `planning` first would have made it the rendered fallback for an agent with no status — an existing-behaviour change this story must not make. They remain first in workflow order among the real statuses.

### Deliberately out of scope

- `PR_WORKFLOW_STATUSES` (`desktop/src/renderer/utils/prStatuses.ts`) is **unchanged on purpose**: planning precedes any PR, so the new statuses must not count as "has a live PR". A no-op, not an oversight.
- The webapp duplicates the status catalogue (`webapp/lib/teamRows.ts`, `webapp/components/TeamRepos.tsx`, `webapp/lib/i18n/*` `team.status.*`), so a planning agent would show a neutral badge on the Team page. The acceptance criteria cover the sidebar and the dashboard only — flagging it as known debt.
- CHANGELOG.md is left alone: it has no `Unreleased` section and is written per released version by `/magic:release`. The ticket notes this is worth a changelog line, so it should be picked up at release time.

### Open questions for the reviewer

- `specPath` absoluteness is documented but not enforced — a relative value would be accepted and stored silently, then become unresolvable in #171. A `path.isAbsolute()` guard on the route would be one line; I left it out because the ticket states the constraint on the sender rather than as a rejection at the boundary. Happy to add it if you'd rather have it enforced.
- Nothing pins "survives a restart" as a test — it rests on reading the `...rest` → jsonb → `fromAgentRow` round-trip. `CloudStore.test.ts` already has the exact pattern for asserting it, so it would be a small addition if you want the regression lock.
- Neither renderer status map is compiler-checked, so the next status added to the union can still silently render as the unknown pill. Giving them the treatment `STATUS_TO_ACTION` got would be a natural follow-up.
