### PR TITLE
feat(plan): Jira ticket creation with real epic/story hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Plan**: New `/magic:plan` skill — turn an idea into a spec and GitHub tickets
+- **Plan**: New `/magic:plan` skill — turn an idea into a spec, then an epic and its stories in Jira or GitHub with a real parent/child hierarchy
 
 ## [0.74.3] - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 | Skill             | Description                                       |
 | ----------------- | ------------------------------------------------- |
-| `/magic:plan`     | Turn an idea into a spec and GitHub tickets       |
+| `/magic:plan`     | Turn an idea into a spec and tracker tickets      |
 | `/magic:start`    | Start a task from a Jira ticket or GitHub issue   |
 | `/magic:continue` | Resume work on an existing ticket                 |
 | `/magic:commit`   | Create an atomic commit with conventional message |
@@ -158,7 +158,7 @@ One Next.js deployment on Vercel answers on three hosts:
 2. Writes a spec you can read and correct: scope, approach, open questions
 3. Proposes an epic and its stories, split at the granularity `plan.splitting` sets
 4. Waits for your approval — nothing is filed until you accept the structure
-5. Creates the epic and its stories, with labels, acceptance criteria and assignee
+5. Creates the epic and its stories in Jira or GitHub, with a real parent/child hierarchy, labels, acceptance criteria and assignee
 
 > **Note:** Use this when the ticket does not exist yet. Once it does, `/magic:start` is what picks
 > it up — `/magic:plan` runs before it in the cycle, never instead of it.

--- a/skills/magic-plan/SKILL.md
+++ b/skills/magic-plan/SKILL.md
@@ -360,6 +360,13 @@ forward required fields it cannot fill itself — today only Jira's, as `must_as
 does not break the rule above: neither the code nor the config can answer it, and the tracker
 refuses the creation without it.
 
+When they do not all fit this batch alongside the framing questions, display
+`MSG_JIRA_TOO_MANY_FIELDS` and follow the option the user picks. Its first option asks the overflow
+in one further `AskUserQuestion` immediately after this batch — the only second round this step ever
+makes, and the reason the cap is tested here rather than at Step 2.3, which cannot know what this
+batch will hold. Never drop a field silently: one mandatory field left unasked comes back as a 400
+at creation time, after the whole brainstorm.
+
 It belongs here rather than at Step 2.3 because the spec only exists from Step 2.4, so a value
 collected at 2.3 has nowhere to be recorded — and an unrecorded answer is one nothing keeps once the
 session ends. Detection at 2.3, the question here, and Step 5 is still the first step that writes

--- a/skills/magic-plan/SKILL.md
+++ b/skills/magic-plan/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: magic:plan
-description: Turns an idea into tickets — brainstorm, a reviewable spec, then an epic with its sub-issues. Use this skill when nothing has been created yet and the user is floating an idea rather than resuming tracked work. Triggers on "I have an idea", "j'ai une idée", "what if we did", "et si on faisait", "we should add", "on devrait ajouter", "could we", "est-ce qu'on pourrait", "brainstorm", "réfléchir à", "plan a feature", "planifier une feature", "create the tickets for", "créer les tickets pour", "break this down into stories", "découper en stories", "write the spec", "écrire la spec", "je pense à un truc", or any proposal for work that has no ticket behind it yet. Do NOT use this skill when the work already exists in a tracker — "PROJ-123", "#456", "work on X", "travailler sur X", "start", "commencer" all mean the ticket is already there, so use /magic:start instead.
+description: Turns an idea into tickets — brainstorm, a reviewable spec, then an epic and its stories. Use this skill when nothing has been created yet and the user is floating an idea rather than resuming tracked work. Triggers on "I have an idea", "j'ai une idée", "what if we did", "et si on faisait", "we should add", "on devrait ajouter", "could we", "est-ce qu'on pourrait", "brainstorm", "réfléchir à", "plan a feature", "planifier une feature", "create the tickets for", "créer les tickets pour", "break this down into stories", "découper en stories", "write the spec", "écrire la spec", "je pense à un truc", or any proposal for work that has no ticket behind it yet. Do NOT use this skill when the work already exists in a tracker — "PROJ-123", "#456", "work on X", "travailler sur X", "start", "commencer" all mean the ticket is already there, so use /magic:start instead.
 argument-hint: <idea or feature description>
-allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, mcp__github__*
+allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, mcp__github__*, mcp__atlassian__*
 ---
 
 # magic-slash v0.74.3 - /plan
@@ -21,7 +21,8 @@ Follow each step in order. Each step builds on the previous one.
 - `references/messages.md` — All bilingual messages (MSG_*). Read the relevant section as needed (not the whole file at once).
 - `references/spec-template.md` — The spec's filename, structure, progressive-write order and closing append. Read in Step 2, before creating the file.
 - `references/sizing.md` — The single-story-vs-epic heuristic, the breakdown rules and the acceptance-criteria formats. Read in Step 5.
-- `references/trackers.md` — Tracker detection, creation calls, the parent/child hierarchy and partial-failure handling. Read in Step 7, after approval; its §1 documents the detection Step 2 performs.
+- `references/trackers.md` — Tracker detection, creation calls, the parent/child hierarchy and partial-failure handling. Read §1 in Step 2.3 (detection, the carried resolution, and the refusal); read §2-§4 in Step 7, after approval.
+- `references/jira-fields.md` — Jira site, project and issue-type resolution, and the required-field discovery that must happen before the structure is proposed. Read in Step 2.3, only when the tracker resolved to Jira.
 - `references/api.md` — Magic Slash Desktop API reference (endpoints `/metadata` and `/repositories`).
 
 ## Step 0: Configuration
@@ -91,7 +92,8 @@ Read `.repositories.<key>.plan` for the repository selected in Step 2. Defaults,
 | Key | Default | Used in |
 | --- | --- | --- |
 | `tracker` | `ask` | Step 2.3 |
-| `jiraProject`, `issueTypes` | `''` / `Epic`+`Story` | reserved for #199 — unused today |
+| `jiraProject` | `''` | Step 2.3, then carried to Step 3.3 and Step 7 — the Jira project key the tickets are filed under |
+| `issueTypes.epic`, `issueTypes.story` | `Epic` / `Story` | Step 2.3, then carried to Step 7 |
 | `useRepoTemplates` | `true` | Step 7 |
 | `splitting` | `balanced` | Step 5 |
 | `acceptanceCriteria` | `checklist` | Step 5, Step 7 |
@@ -105,6 +107,21 @@ plan.
 
 Note what is **not** in that table: the depth of the codebase exploration, and the human review
 before creation. Neither is configurable, by design.
+
+### 0.5: Check the Atlassian integration
+
+Read `integrations.atlassian` from config. Default: `true` (backward compatibility). It is
+account-level, not per-repository, so it is read here rather than with the `plan` block above.
+
+```bash
+# Every bash block runs in its own shell: $MS_PORT does not survive from Step 0.1,
+# so resolve it again here. One line, and it costs nothing to repeat.
+MS_PORT="${MAGIC_SLASH_PORT:-$(cat ~/.config/magic-slash/port 2>/dev/null)}"
+curl -sf --max-time 5 "http://127.0.0.1:$MS_PORT/config" | jq -r '.integrations.atlassian // true'
+```
+
+Store the result as `$ATLASSIAN_ENABLED` — the same value, read the same way, as Step 0.3 of
+`/magic:start`. Step 2.3 is where it decides anything (`references/trackers.md` §1.2).
 
 ## Step 1: Capture the idea
 
@@ -155,14 +172,20 @@ Follow `references/trackers.md` §1: `plan.tracker` first (`jira` / `github` / `
 repository's `issues.githubIssuesUrl` / `issues.jiraUrl`, then the GitHub remote, asking with
 `MSG_TRACKER_ASK` only when it is still genuinely ambiguous.
 
-**If the tracker resolves to Jira: display `MSG_JIRA_NOT_AVAILABLE` and stop.** Jira creation is
-not implemented (#199).
+Resolve it **once**, at this step, and carry the result: §1.1 of that file defines what to carry and
+which of the three consumers — this step's Jira discovery, Step 3.3's duplicate search, Step 7's
+creation — reads each value. Nothing re-derives it.
 
-The stop happens **here**, before the brainstorm — not at Step 7. An hour of exploration, framing
-and spec-writing that ends on "I cannot create this" is a worse outcome than a refusal on the second
-question, and the user can still redirect the idea at a GitHub-tracked repository or file the Jira
-ticket by hand. Never fall back to creating a GitHub issue for a Jira-tracked repository either:
-that files tickets in a backlog that project's team does not read.
+**If the tracker resolves to Jira**, apply `references/trackers.md` §1.2 before going any further:
+it decides whether Jira can receive a ticket at all and refuses the run with
+`MSG_JIRA_NOT_CONFIGURED` when it cannot.
+
+**If it can**, read `references/jira-fields.md` now and run its pass. Its `## Usage` table is what
+it hands forward, and Step 4 owns the question for whatever it could not fill.
+
+Both of those happen **here**, before the brainstorm — not at Step 7. Anything that would refuse the
+write has to be found before an hour of exploration, framing and spec-writing, not after: a refusal
+on the second question still leaves the user able to redirect the idea or file the ticket by hand.
 
 ### 2.4: Create the spec file
 
@@ -285,15 +308,28 @@ exactly the kind of question that must not be asked.
 ### 3.3: Check for duplicates
 
 When `plan.duplicateCheck` is `true` (the default), search the tracker for existing work before
-proposing anything new. Use `mcp__github__search_issues` with the strongest nouns from the idea,
-across **open and closed** issues: a closed one is often the more valuable find, because it may
-carry the reason this was rejected before.
+proposing anything new — the tracker **carried** from Step 2.3, never re-derived. Search on the
+strongest nouns from the idea, across **open and closed** tickets: a closed one is often the more
+valuable find, because it may carry the reason this was rejected before.
+
+| Tracker | Call | Scope |
+| --- | --- | --- |
+| GitHub | `mcp__github__search_issues` | the `owner/repo` carried from Step 2.3 |
+| Jira | `mcp__atlassian__searchJiraIssuesUsingJql` | `plan.jiraProject`, on the carried `cloudId` |
+
+The Jira call takes the same `{"jql": …, "fields": [...]}` shape `/magic:start` uses, scoped to the
+project and asking only for `summary`, `status` and `issuetype`:
+`project = PROJ AND text ~ "rate limit" ORDER BY updated DESC`. No status clause — `text ~` already
+spans open and closed issues, and filtering on status would drop exactly the closed ticket worth
+finding. Report the issue key (`PROJ-123`), not a `#number`.
 
 - **Matches found** → display `MSG_DUPLICATES_FOUND` and ask. Every entry states *why* it looked
   related; an unexplained list is noise the user has to re-investigate. Write the list into the
   spec's `## Related tickets` whatever the answer is.
-- **Nothing found** → display `MSG_NO_DUPLICATES` and write `None found` into that section.
-- **Search fails twice** → display `MSG_GITHUB_ERROR` and continue with `Not checked` in the spec.
+- **Nothing found** → display `MSG_NO_DUPLICATES`, with `{searched_scope}` = the Scope cell above,
+  and write `None found` into that section.
+- **Search fails twice** → display `MSG_TRACKER_ERROR` — `{tracker}` = the tracker that did not
+  answer, `{operation}` = `duplicate search` — and continue with `Not checked` in the spec.
   A failed duplicate check degrades the run; it does not end it. But `Not checked` and `None found`
   are different facts and must never read the same.
 
@@ -317,8 +353,23 @@ Ask few questions and ask them well. Two questions that change the shape of the 
 confirm what the exploration already showed. If the idea is unambiguous after Step 3 — and small,
 well-specified ideas often are — ask nothing and say so in one line.
 
+**Fields the tracker requires that nothing else can answer.** When Step 2.3's pre-flight handed
+forward required fields it cannot fill itself — today only Jira's, as `must_ask_fields`
+(`references/jira-fields.md` §2) — ask for them inside this same `AskUserQuestion` batch, using
+`MSG_JIRA_REQUIRED_FIELDS`, whose note owns the shape of the question. This is the one addition that
+does not break the rule above: neither the code nor the config can answer it, and the tracker
+refuses the creation without it.
+
+It belongs here rather than at Step 2.3 because the spec only exists from Step 2.4, so a value
+collected at 2.3 has nowhere to be recorded — and an unrecorded answer is one nothing keeps once the
+session ends. Detection at 2.3, the question here, and Step 5 is still the first step that writes
+`## Proposed tickets`.
+
 Write each resolved answer into the spec's `## Framing decisions` table **as it is answered**, with
-its reason. A decision recorded without its reason is a decision nobody can revisit later.
+its reason. A decision recorded without its reason is a decision nobody can revisit later. A Jira
+required-field answer is recorded the same way, its reason naming the issue type that required it —
+that row is the audit trail of what was sent to Jira and why, and it is what makes the spec explain
+the created ticket on its own, to a reader now or to a resume feature later.
 
 ## Step 5: Sizing
 
@@ -375,12 +426,13 @@ rm -f .magic/.mp-title
 
 ## Step 7: Ticket creation
 
-Read `references/trackers.md` and follow it. That file owns the creation calls
-(`mcp__github__issue_write`), the real hierarchy (`mcp__github__sub_issue_write` — the epic becomes
-a parent issue with its stories as sub-issues, never a markdown checklist), the repository issue
-templates under `.github/ISSUE_TEMPLATE/*` when `plan.useRepoTemplates` is on, `plan.defaultLabels`,
-the `plan.assignToMe` assignee, and the partial-failure rules. Its `## Usage` table is the contract
-it returns on.
+Read `references/trackers.md` and follow the branch of the tracker carried from Step 2.3. That file
+owns the creation calls (`mcp__github__issue_write`, `mcp__atlassian__createJiraIssue`), the real
+hierarchy (GitHub sub-issues via `mcp__github__sub_issue_write`; on Jira the native `parent`, the
+`Epic Link` field or an issue link, whichever the project exposes — never a markdown checklist), the
+templates honoured when `plan.useRepoTemplates` is on (`.github/ISSUE_TEMPLATE/*`, or the Jira issue
+type's description template), `plan.defaultLabels`, the `plan.assignToMe` assignee, and the
+partial-failure rules. Its `## Usage` table is the contract it returns on.
 
 Two things this step must get right, whatever the tracker:
 
@@ -438,8 +490,9 @@ there.
 
 ## Step 9: Record the run
 
-**Always run this, as the very last thing you do — including when the workflow stopped early**, on
-the Jira refusal of Step 2.3 as much as on a completed creation.
+**Always run this, as the very last thing you do — including when the workflow stopped early**, on a
+Step 2.3 refusal (`MSG_JIRA_NOT_CONFIGURED`, or a Jira project that does not resolve) as much as on
+a completed creation.
 
 Magic Slash opened a run record when this skill started. This closes it. Without it the run stays
 open and is counted as *abandoned*, so finished work disappears from the usage statistics.

--- a/skills/magic-plan/references/jira-fields.md
+++ b/skills/magic-plan/references/jira-fields.md
@@ -176,11 +176,25 @@ classification instead of through a missed field:
 
 `assignee` is the harder of the two, because whether it auto-fills is only knowable once
 `trackers.md` §3.6's `atlassianUserInfo` → `lookupJiraAccountId` pair has run. When the field is
-**required**, run that resolution here, in this pass, and carry the account id — §3.6 resolves it
-once per run anyway, so this spends no extra call, it only moves it earlier. §3.6's "create the
-issues unassigned" fallback is not available on a required `assignee`: unassigned is the rejection.
-When the field is optional, nothing changes — §3.6 keeps resolving it at creation time and drops it
-on a rejection.
+**required**, run that resolution here, in this pass, and return the account id as the
+`assignee_account_id` row of `## Usage` — that row is the only thing that carries it forward, and a
+value this paragraph resolves but the contract does not return is a value Step 7 never sees. §3.6
+resolves it once per run anyway, so this spends no extra call, it only moves it earlier. §3.6's
+"create the issues unassigned" fallback is not available on a required `assignee`: unassigned *is*
+the rejection. When the field is optional, nothing changes — §3.6 keeps resolving it at creation time
+and drops it on a rejection.
+
+So a required `assignee` has **two possible provenances and one destination**, and both provenances
+end up in the same parameter:
+
+| Case | Value comes from | Travels as |
+| --- | --- | --- |
+| `plan.assignToMe` true, id resolved | this pass | the `assignee_account_id` row of `## Usage` |
+| `plan.assignToMe` false, or no id resolved | Step 4's answer | a `required_field_answers` entry, converted per §3 |
+
+Whichever provenance applies, the value is sent as `createJiraIssue`'s `assignee_account_id`
+parameter and **never** through `additional_fields` — `trackers.md` §3.2 owns that routing rule and
+states the exception explicitly.
 
 Neither field stops being config-driven. `plan.defaultLabels` and `plan.assignToMe` still decide what
 is *sent* whenever they hold a value; the rule above only decides what happens when they hold none
@@ -360,6 +374,7 @@ This table is the whole contract; `SKILL.md` restates none of it:
 | `epic_link_field_id` | the epic-link `customfield_XXXXX` on the **story** type's screen, empty when none | `trackers.md` §3.4 route 2 |
 | `description_template` | per type, the `description` field's default, empty when it has none | `trackers.md` §3.5 |
 | `screen_omits` | which of `labels` / `assignee` are absent, per type | `trackers.md` §3.6 |
+| `assignee_account_id` | the account id resolved by §2 for a **required** `assignee` when `plan.assignToMe` is true; empty in every other case | `trackers.md` §3.2, §3.6 |
 | `degraded` | what could not be read, empty when everything resolved | `MSG_JIRA_FIELDS_UNKNOWN` (§4), never silent |
 
 Nothing here is written to the spec: the spec does not exist yet at Step 2.3. The values travel as

--- a/skills/magic-plan/references/jira-fields.md
+++ b/skills/magic-plan/references/jira-fields.md
@@ -219,6 +219,46 @@ Three things it does not cover, because it renders a ticket where this renders a
   without, so a mandatory field is always listed however short its rendering — a silently dropped
   one is §4's forbidden false "nothing required", arriving by another route.
 
+**Rendering the question is only half of it — the answer has to be converted back.** Everything
+above turns a Jira field into something a person can answer. Nothing above turns what they answered
+into something `createJiraIssue` accepts, and the two shapes are not the same: a select rendered as
+the options `P1 / P2 / P3` comes back as the string `P1`, while the API wants an object. Sending the
+display value straight through is the same 400 this pass exists to move earlier, arriving one step
+later. So carry each field's `schema` from §1.3 alongside its `allowedValues`, and convert by it:
+
+| Field `schema` | Answered as | Sent as |
+| --- | --- | --- |
+| `type: string` | free text | the string |
+| `type: number` | free text | a number, unquoted |
+| `type: date` / `datetime` | free text | `YYYY-MM-DD` / ISO 8601 |
+| `type: option` | one option | `{"id": "<option id>"}` |
+| `type: array`, `items: option` | one or more options | `[{"id": "<option id>"}, …]` |
+| `type: array`, `items: string` | free text | `["a", "b"]` |
+| `type: user` | a name or email, in plain words | `{"accountId": "<id>"}` |
+| `type: array`, `items: user` | the same, one or more | `[{"accountId": "<id>"}, …]` |
+| `type: group` | free text | `{"name": "<group>"}` |
+| `type: array`, `items: version` / `component` | one or more options | `[{"id": "<id>"}, …]` |
+| `type: priority` | one option | `{"id": "<option id>"}` |
+
+Two rules are what make that table safe:
+
+- **Resolve an option to the `id` of the `allowedValues` entry the user picked** — never re-type its
+  label into `{"value": …}`. The label is what was displayed; the id is what the project stores.
+  Labels get renamed and can repeat across contexts, ids do not. This is why `allowedValues` must
+  travel **with their ids** rather than as a list of strings: a question built from labels alone
+  cannot be converted back. `{"value": …}` is a legitimate fallback only for an entry that carries
+  no id.
+- **A user field's answer is not an account id yet.** It arrives as a name or an email in plain
+  words, so it goes through `mcp__atlassian__lookupJiraAccountId` — the same call `trackers.md` §3.6
+  uses — before being sent. If it resolves to nothing, or to several people, ask again rather than
+  sending a guess: a wrong assignee is worse than a rejected creation, because it succeeds.
+
+One destination rule goes with them: **`assignee` is the exception that takes no object.** It has its
+own `createJiraIssue` parameter, `assignee_account_id`, carrying the bare account id string;
+`{"accountId": …}` is for the *other* user-picker fields, which travel in `additional_fields`.
+`trackers.md` §3.2 already states that `assignee_account_id` never goes through `additional_fields` —
+this is the shape half of that same statement.
+
 **That file's field cap does not transfer here; its ranking does.** Its cap is a context-volume
 guard on a *read*, where the fields are candidates and dropping one past the limit costs nothing —
 so the number is deliberately not restated here, because it is not a threshold this file has. Every
@@ -315,7 +355,7 @@ This table is the whole contract; `SKILL.md` restates none of it:
 | `cloudId` | the resolved site id | Step 3.3's JQL, `trackers.md` §3.3's create calls |
 | `project_key` | `plan.jiraProject`, confirmed to resolve | same |
 | `issue_types` | `{epic, story}` → `{id, name}` — the id for §1.3, the name for the create call | `trackers.md` §3.2 |
-| `must_ask_fields` | per field: id, name, requiring types, cardinality, `allowedValues` | `MSG_JIRA_REQUIRED_FIELDS` |
+| `must_ask_fields` | per field: id, name, requiring types, cardinality, its `schema`, and `allowedValues` **with their ids** | `MSG_JIRA_REQUIRED_FIELDS`, then §3's conversion |
 | `story_has_parent_field` | true when the story type's create screen carries `parent` | `trackers.md` §3.4 route 1 |
 | `epic_link_field_id` | the epic-link `customfield_XXXXX` on the **story** type's screen, empty when none | `trackers.md` §3.4 route 2 |
 | `description_template` | per type, the `description` field's default, empty when it has none | `trackers.md` §3.5 |

--- a/skills/magic-plan/references/jira-fields.md
+++ b/skills/magic-plan/references/jira-fields.md
@@ -1,0 +1,296 @@
+# Jira field discovery
+
+Read this file in Step 2.3, and only when the tracker resolved to Jira. It owns the read-only pass
+that answers three questions before anything is written: which Jira site, which issue types the
+configured names map to, and which required fields the skill cannot fill on its own.
+
+This pass is **read-only, and it runs before the spec exists**. It creates nothing, records nothing,
+and defers every question it *can* defer to Step 4 — which owns the asking, while the spec's
+`## Framing decisions` owns the record. The two it cannot defer are stops, not questions about
+content (§1.2, §4): there is nothing downstream to defer them to, and no spec yet to record an
+answer in — a stop leaves no record at all, which is why what it says has to name the config change
+that fixes it.
+
+Why so early, when the values are only needed at creation? Because required fields vary by project
+**and** by issue type, so nothing in the config can predict them. Discovering them at write time
+means a 400 arriving after the brainstorm, the framing and the approval — which is exactly the
+outcome this file exists to remove. `references/trackers.md` §3.2 consumes what this returns.
+
+## 1. The three calls, in order
+
+They are **successive calls, not alternatives**. Each one needs the previous one's answer: the site
+before the project, the project's types before a type's fields.
+
+### 1.1 The site — `cloudId`
+
+Call `mcp__atlassian__getAccessibleAtlassianResources` and take the `cloudId` of the site holding
+the project.
+
+Resolve it **within the run**, every run, exactly as every other skill in this repository does.
+Never persist it, and never derive it from `issues.jiraUrl`: a site can be reached through a vanity
+domain, and no URL contains a `cloudId`. With several accessible sites and no way to tell which one
+holds `plan.jiraProject`, the project lookup in §1.2 is what settles it — try the sites in the order
+returned and keep the one where the project resolves.
+
+### 1.2 The project's issue types — and the names in `plan.issueTypes`
+
+Call `mcp__atlassian__getJiraProjectIssueTypesMetadata` for `plan.jiraProject`. It returns the issue
+types that project actually offers, each with an **id** and a **name**.
+
+That list is **paged**, and its `maxResults` defaults to 50: page with `startAt` until the response
+is exhausted before concluding anything about a name, exactly as §1.3 does. A project with more than
+fifty issue types is unlikely, but the configured type falling off page one would produce a refusal
+saying the project has no issue type of that name when it has one.
+
+Resolve `plan.issueTypes.epic` and `plan.issueTypes.story` **by name** against that list, and carry
+**both** values of each resolved type — its **id** and its **name**. The two calls downstream want
+different ones: `getJiraIssueTypeMetaWithFields` takes the id, as `issueTypeId` (§1.3), and
+`createJiraIssue` takes the name, as `issueTypeName` (`trackers.md` §3.2). What the resolution is
+*for* is unchanged — `plan.issueTypes.*` may name a type this project does not offer, and that
+check still happens here; only which value each call receives differs.
+
+- Match on the name, case-insensitively, trimming whitespace. Nothing else — do not match on a
+  substring, or `Sub-task` would satisfy `Task`.
+- **Never hardcode "Epic" and "Story".** They are only the *defaults* of two config keys, and an
+  instance renames them freely: `Initiative`, `Feature`, `Chantier`, `Task`, `Requirement` are all
+  real. A project that renamed them is one of this feature's acceptance criteria, not an edge case.
+- A configured name **absent from the project**, or a project key that resolves nowhere, stops the
+  pass — it is never a question. §4 owns what each stop says. Never guess, and never fall back to
+  whatever type looks epic-shaped: picking the wrong type files a whole breakdown under a type the
+  project's board does not display.
+
+§4's rule is the only behaviour, and it does not depend on which of the two names is missing: this
+pass runs at Step 2.3 while the sizing verdict is Step 5, so at this point nothing knows yet whether
+the run would have needed the epic type. What the refusal does carry is **which** of the two is
+missing — a missing epic type is far more often a `plan.issueTypes.epic` typo than a project that
+cannot hold epics, and naming it is what lets the user fix the right key.
+
+### 1.3 That type's required fields
+
+Call `mcp__atlassian__getJiraIssueTypeMetaWithFields` **once per resolved type** — the epic type and
+the story type — passing the project and, as `issueTypeId`, the type **id** from §1.2.
+
+Pass `requiredFieldsOnly: false` **explicitly**. It defaults to `true`, and that default returns
+only the mandatory fields — but four of the five rows below are *optional* fields on almost every
+project (`parent`, `labels`, `assignee`, and `description`'s default). Left at the default they all
+read as absent: every project falls to `trackers.md` §3.4's weakest hierarchy route, `defaultLabels`
+and `assignToMe` are silently dropped as `screen_omits`, and no description template is ever found.
+This is not an over-fetch to optimise back to the default.
+
+**The field list is paged, so page it.** Ask for a generous `maxResults`, then keep calling with an
+advancing `startAt` until the response is exhausted — and classify nothing until it is. Widening the
+read to the whole create screen is exactly what makes truncation possible for the first time: on a
+company-managed project with a large screen, `parent`, the epic-link field, `labels`, `assignee` or
+the `description` default can each sit past page one. Classified from page one alone they read as
+absent, which collapses the project onto `trackers.md` §3.4's weakest hierarchy route and drops
+`plan.defaultLabels` and `plan.assignToMe` into `screen_omits` — the outcome the paragraph above
+exists to prevent, arriving by a quieter route because the pass reports success. **A partial read is
+never a complete create screen.**
+
+It returns the create screen of *that* type in *that* project: one entry per field, each carrying
+its own `fieldId`, its `name` — the display name — whether it is `required`, its `schema`, its
+`allowedValues` when it has them, and its default value when it has one. Two types in the same
+project routinely disagree, which is why this is one call per type rather than one call per project.
+
+Five things this response answers that nothing else can, and that later steps depend on. Read them
+all off this one response: every row below is a value `trackers.md` §1.1 carries, so no later step
+calls this again.
+
+| Question | Answered by | Consumed by |
+| --- | --- | --- |
+| which fields are mandatory | `required: true` | §2, then Step 4's question |
+| whether the story type exposes a native `parent` | the presence of the `parent` field | `trackers.md` §3.4, route 1 |
+| the epic-link field's id | `schema.custom` = `com.pyxis.greenhopper.jira:gh-epic-link`, on the story type's screen | `trackers.md` §3.4, route 2 |
+| whether the type carries a description template | the `description` field's default value | `trackers.md` §3.5 |
+| whether `labels` / `assignee` are even on the create screen | their presence | `trackers.md` §3.6 |
+
+**Display names come from each field's own `name`** — there is no map to ask for. That name is what
+turns `customfield_10045` into "Acceptance criteria" in the question the user is eventually asked,
+and a question naming raw field ids is a question nobody can answer. When an entry carries no
+`name`, fall back to the raw id and say the display name could not be read (§3).
+
+**Match the epic-link field on `schema.custom`, never on a display name.** The value is
+`com.pyxis.greenhopper.jira:gh-epic-link` on every site, while the label is translated — a German
+instance shows "Epic-Verknüpfung", a French one "Lien de l'Epic". A name match would miss those and
+drop them to §3.4's weakest route, which is the one case route 2 exists for.
+
+**Take that id from the story type's create screen**, and only that one. Both screens are read here,
+but the value is sent on exactly one call — the story's, per `trackers.md` §3.4 route 2 — so the
+story's screen is the only one whose answer can be honoured. It stays a single carried value rather
+than a per-type one for the same reason: the epic's own screen has no use for it.
+
+**Four response members read above are not in the tool's documented parameter list.** Its schema
+documents parameters only; per-field `name`, `allowedValues`, `hasDefaultValue`/`defaultValue` and
+`schema.custom` all match Jira's `FieldMetaData` shape without the wrapper promising them. That is
+the hedge `jira-custom-fields.md` §2 applies to its own undocumented `-comment`: plausible, not
+verified. The one to confirm first is the **description template arriving as the `description`
+field's default** — its silent absence is indistinguishable from a project that has no template —
+which is why `trackers.md` §3.7's manual pass carries a row for it. A member that is simply not
+there is treated as §4 treats an unread screen: unknown, never absent.
+
+`skills/magic-start/references/jira-custom-fields.md` §2 is the model for the *shape* parser only
+(see §3). Its `expand: "names"` belongs to the `getJiraIssue` call **that** file makes and does not
+transfer here: `getJiraIssueTypeMetaWithFields` has no `expand` parameter, and none is needed.
+
+## 2. Classifying what is required
+
+§1.3's response now carries the optional fields too, so the split starts by **filtering on each
+field's own `required` flag**: an optional field is never asked for, however unfamiliar it looks.
+Then split the required ones of each type into two lists. Only the second reaches Step 4.
+
+**Auto-filled — the skill supplies these, so they are never asked:**
+
+| Field | Filled with |
+| --- | --- |
+| `project` | `plan.jiraProject` |
+| `issuetype` | the **name** resolved in §1.2, sent as `issueTypeName` |
+| `summary` | the ticket title from the spec's breakdown |
+| `description` | the body composed per `trackers.md` §3.3 |
+| `reporter` | the calling user; Jira defaults it, so send nothing unless the field rejects that |
+| `parent` | the epic key, on a story — `trackers.md` §3.4 route 1, not a value to ask for |
+| anything carrying a usable default | that default, stated in one line so a silent choice is visible |
+| `labels`, `assignee` | `plan.defaultLabels`, `plan.assignToMe` — config, not a question |
+
+"A usable default" means the response's `hasDefaultValue` is true and the default is a real value.
+A default that is an empty string, an empty array or a placeholder option is not usable — treat the
+field as must-ask.
+
+**Must-ask — everything else that is `required`**, which in practice means the project's mandatory
+custom fields: a required "Team", "Component", "Sprint", "Severity", "Business value". Carry, per
+field: its `fieldId`, its display name from its own `name`, which issue type required it, whether it
+takes one value or several, and its `allowedValues` if it declares them.
+
+Deduplicate across the two types by field id, but **keep which types required it**: a field
+mandatory on the story type and not on the epic is a different situation, and Step 4's question says
+so rather than making the user infer it.
+
+An empty must-ask list is the common case, and it is a legitimate answer — but only when the calls
+in §1 all succeeded. See §4.
+
+## 3. Rendering the expected value
+
+The question shown to the user has to state what a valid value looks like, and Jira returns those
+values in several shapes. Apply `skills/magic-start/references/jira-custom-fields.md` §3 rather than
+restating it: its shape list (plain string, ADF document, option object or array of them, array of
+strings), its fallback to the raw `customfield_XXXXX` id when no display name resolves, its
+1500-character truncation and its credential-stripping rule all hold here, for its reasons. Forking
+it would let the two drift. What does **not** carry over is how that file obtains the display names:
+here they arrive on each field's own `name` (§1.3), with no `expand` involved.
+
+Three things it does not cover, because it renders a ticket where this renders a question:
+
+- An **option object or array of them** becomes the question's *options*, not prose. A free-text
+  answer on a select field is a 400 waiting to happen.
+- Shapes that cannot be a prompt at all — user and group pickers, dates, bare numbers — are asked
+  for in plain words, naming the field and what Jira expects.
+- Its **20-character floor does not transfer.** There the guard picks the field most likely to hold
+  a spec, and dropping a short one is safe. Here every field is one Jira will reject the creation
+  without, so a mandatory field is always listed however short its rendering — a silently dropped
+  one is §4's forbidden false "nothing required", arriving by another route.
+
+**That file's field cap does not transfer here; its ranking does.** Its cap is a context-volume
+guard on a *read*, where the fields are candidates and dropping one past the limit costs nothing —
+so the number is deliberately not restated here, because it is not a threshold this file has. Every
+field here is one Jira refuses the creation without: there is nothing this file could drop at any
+count that it would be safe to drop. What does carry over is the *ranking*, applied to different
+things: there, candidate fields by how likely one is to hold a specification; here, fields that are
+*already* mandatory, so the order is by how answerable each one is (a required select with
+`allowedValues` is more answerable than a required free-text audit field), with length only breaking
+ties. That order no longer decides what is dropped, only what is asked first.
+
+The one real limit is how many questions a single `AskUserQuestion` batch can carry, which is a
+property of that call and not a number configured here. Pack the must-ask set into as few questions
+as will hold it, per `MSG_JIRA_REQUIRED_FIELDS`'s note. **When the packed set still will not fit that
+batch, neither drop a field nor refuse the run**: display `MSG_JIRA_TOO_MANY_FIELDS` — which names
+the count, the fields, and how many of them fit — and let the user choose between
+
+- **asking in more than one round**: the fields that fit ride in Step 4's batch, the rest come as one
+  further `AskUserQuestion` straight after it, and the creation runs with every value answered;
+- **asking only what fits**: the creation runs with the rest unanswered and Jira rejects the issues
+  that need them, surfaced as `trackers.md` §4's failure naming the field — the 400 this pass exists
+  to move earlier, now chosen with that consequence stated rather than met by surprise;
+- **stopping**, and giving those fields a default in the project's own configuration or dropping the
+  requirement, then running this again.
+
+A project with nine mandatory custom fields is a company-managed project doing something ordinary,
+so the overflow is a choice rather than a dead end. What stays forbidden is the fourth option:
+**dropping any of them quietly**, which is §4's false "nothing required" arriving by another route.
+
+## 4. Degradation — never fabricate "nothing required"
+
+Every call in §1 can fail, and the failure mode that matters is a specific one: **a failed call must
+never be reported as "no required fields".** A false "nothing required" is precisely the
+400-after-a-brainstorm this whole pass exists to prevent, and it is worse than the 400 was, because
+the user was told the check had run.
+
+| Failure | Behaviour |
+| --- | --- |
+| `getAccessibleAtlassianResources` fails or returns no site | stop; no site is reachable, so no brainstorm |
+| `plan.jiraProject` resolves on no accessible site | stop; name the key and the sites checked |
+| `getJiraProjectIssueTypesMetadata` fails | stop; no issue type can be resolved, and creation needs one |
+| a configured issue-type name is absent | stop the pass, never ask — see below |
+| `getJiraIssueTypeMetaWithFields` fails for one type | the pass continues **degraded** — see below |
+| a `startAt` page of that call fails mid-list | the screen was read incompletely: the five §1.3 values are **unknown**, not false — see below |
+| `$ATLASSIAN_ENABLED` is `false` | this pass never runs — `trackers.md` §1.2 already refused the tracker |
+
+**A configured issue-type name the project does not have stops the pass**, and stops it with
+`MSG_JIRA_NOT_CONFIGURED` whose `{reason}` names the project's *actual* types, so the user fixes
+`plan.issueTypes`. It is deliberately not an `AskUserQuestion`: silently picking a different type
+files the epic under the wrong type, which is §1.2's whole point. This is the one place that
+behaviour is stated — `trackers.md` §3.7 expects exactly this refusal.
+
+**A `getJiraIssueTypeMetaWithFields` failure on one type is the only non-stop failure here** —
+whether it is the first call or a later page of it. Name the type that could not be read and that
+mandatory fields on it are unknown, then let the user choose between continuing with that risk
+stated and stopping. That is what `degraded` carries, and `MSG_JIRA_FIELDS_UNKNOWN` is the message
+that surfaces it — an `AskUserQuestion` whose body carries those two options, per the convention
+`MSG_APPROVAL` and `MSG_TRACKER_ASK` follow: a promised choice needs a message that presents it.
+
+`MSG_TRACKER_ERROR` is deliberately **not** that message. It closes on "the spec is intact", and at
+Step 2.3 there is no spec — Step 2.4 is what creates it — so at this one call site it would state
+something untrue. It stays what it already is: the Step 3.3 and Step 7 message for a tracker that
+stopped answering after the spec exists.
+
+**On a page that fails mid-list, the same invariant governs the other four values**
+(`story_has_parent_field`, `epic_link_field_id`, `description_template`, `screen_omits`): it is the
+rule this section opens with, applied to a screen read in part rather than not at all, so they are
+reported as **unknown** and never as `false`, an empty id or an omitted field. "Not seen yet" is not
+"absent", and a partially read screen presented as a complete one is the same fabrication as a
+failed call presented as "nothing required". `trackers.md` §3.4's `unknown` rule is what consumes
+that invariant: an `unknown` value makes its route **attempted**, not skipped, so a partial read
+costs a call rather than the hierarchy.
+
+The last line of a *stop* is always the same: nothing was created, nothing was explored, and the
+config change that fixes it is named. A stop here costs the user one question; a fabricated pass
+costs them the whole session.
+
+Retry a failing call **once** before treating it as a failure — these are network calls and a single
+timeout is not a verdict.
+
+## Usage
+
+Step 2.3 of `SKILL.md` reads this file **only** when the tracker resolved to Jira. Once read,
+execute §1, then §2, then §3 — with §4 governing every call in all three — and return these values.
+This table is the whole contract; `SKILL.md` restates none of it:
+
+| Returned | Shape | Consumer |
+| --- | --- | --- |
+| `cloudId` | the resolved site id | Step 3.3's JQL, `trackers.md` §3.3's create calls |
+| `project_key` | `plan.jiraProject`, confirmed to resolve | same |
+| `issue_types` | `{epic, story}` → `{id, name}` — the id for §1.3, the name for the create call | `trackers.md` §3.2 |
+| `must_ask_fields` | per field: id, name, requiring types, cardinality, `allowedValues` | `MSG_JIRA_REQUIRED_FIELDS` |
+| `story_has_parent_field` | true when the story type's create screen carries `parent` | `trackers.md` §3.4 route 1 |
+| `epic_link_field_id` | the epic-link `customfield_XXXXX` on the **story** type's screen, empty when none | `trackers.md` §3.4 route 2 |
+| `description_template` | per type, the `description` field's default, empty when it has none | `trackers.md` §3.5 |
+| `screen_omits` | which of `labels` / `assignee` are absent, per type | `trackers.md` §3.6 |
+| `degraded` | what could not be read, empty when everything resolved | `MSG_JIRA_FIELDS_UNKNOWN` (§4), never silent |
+
+Nothing here is written to the spec: the spec does not exist yet at Step 2.3. The values travel as
+`references/trackers.md` §1.1's carried resolution, which is why no later step calls any of §1's
+three calls again.
+
+**If this file is missing on disk**: do not improvise the discovery, and do not proceed as if there
+were no required fields. Say in one line that Jira field discovery cannot run because its reference
+file is absent, that mandatory custom fields on the project would therefore only surface as a
+rejection at creation time, and offer the two honest options — continue with that risk stated in the
+open, or stop before the brainstorm. Silence on this point is the one thing that is not allowed.

--- a/skills/magic-plan/references/jira-fields.md
+++ b/skills/magic-plan/references/jira-fields.md
@@ -94,7 +94,10 @@ project routinely disagree, which is why this is one call per type rather than o
 
 Five things this response answers that nothing else can, and that later steps depend on. Read them
 all off this one response: every row below is a value `trackers.md` §1.1 carries, so no later step
-calls this again.
+calls this again — with one exception, and only one. When paging stopped early and a row came back
+`unknown`, `trackers.md` §3.4's `unknown` rule finishes that read at Step 7 rather than letting
+"not seen" harden into "absent". Re-reading a half-read screen is not re-deriving what is already
+known; it is the only way that row ever becomes known.
 
 | Question | Answered by | Consumed by |
 | --- | --- | --- |
@@ -199,10 +202,16 @@ things: there, candidate fields by how likely one is to hold a specification; he
 ties. That order no longer decides what is dropped, only what is asked first.
 
 The one real limit is how many questions a single `AskUserQuestion` batch can carry, which is a
-property of that call and not a number configured here. Pack the must-ask set into as few questions
-as will hold it, per `MSG_JIRA_REQUIRED_FIELDS`'s note. **When the packed set still will not fit that
-batch, neither drop a field nor refuse the run**: display `MSG_JIRA_TOO_MANY_FIELDS` — which names
-the count, the fields, and how many of them fit — and let the user choose between
+property of that call and not a number configured here. **That limit is not this pass's to test.**
+This pass runs at Step 2.3, while the batch is packed at Step 4 alongside Step 4's own framing
+questions — and only there is it known how many of the must-ask fields actually fit. So what §3
+hands forward is the *ranked* must-ask set and nothing more; the overflow is detected and surfaced
+at Step 4, per `MSG_JIRA_REQUIRED_FIELDS`'s note, and the ranking above is what decides which fields
+make the cut when it happens.
+
+**When the packed set will not fit that batch, Step 4 neither drops a field nor refuses the run**:
+it displays `MSG_JIRA_TOO_MANY_FIELDS` — which names the count, the fields, and how many of them
+fit — and lets the user choose between
 
 - **asking in more than one round**: the fields that fit ride in Step 4's batch, the rest come as one
   further `AskUserQuestion` straight after it, and the creation runs with every value answered;
@@ -287,7 +296,8 @@ This table is the whole contract; `SKILL.md` restates none of it:
 
 Nothing here is written to the spec: the spec does not exist yet at Step 2.3. The values travel as
 `references/trackers.md` §1.1's carried resolution, which is why no later step calls any of §1's
-three calls again.
+three calls again — except to finish a read that paging left incomplete, per §1.3's `unknown`
+exception and `trackers.md` §3.4's rule.
 
 **If this file is missing on disk**: do not improvise the discovery, and do not proceed as if there
 were no required fields. Say in one line that Jira field discovery cannot run because its reference

--- a/skills/magic-plan/references/jira-fields.md
+++ b/skills/magic-plan/references/jira-fields.md
@@ -152,11 +152,39 @@ Then split the required ones of each type into two lists. Only the second reache
 | `reporter` | the calling user; Jira defaults it, so send nothing unless the field rejects that |
 | `parent` | the epic key, on a story — `trackers.md` §3.4 route 1, not a value to ask for |
 | anything carrying a usable default | that default, stated in one line so a silent choice is visible |
-| `labels`, `assignee` | `plan.defaultLabels`, `plan.assignToMe` — config, not a question |
+| `labels` | `plan.defaultLabels` — but **only when it is non-empty**, see below |
+| `assignee` | the resolved account id — **only when `plan.assignToMe` is true**, see below |
 
 "A usable default" means the response's `hasDefaultValue` is true and the default is a real value.
 A default that is an empty string, an empty array or a placeholder option is not usable — treat the
 field as must-ask.
+
+**Config auto-fills a field only when it actually carries a value**, and the same test applies to it.
+`plan.defaultLabels` defaults to `[]` and `plan.assignToMe` to `false`, so on a project whose create
+screen makes `labels` or `assignee` **required** those two rows auto-fill nothing — and a field
+classified as auto-filled that nothing fills is refused by Jira at creation, after the brainstorm and
+after the approval. That is exactly the 400 this pass exists to move earlier, arriving through the
+classification instead of through a missed field:
+
+| Required field | Config | Classification |
+| --- | --- | --- |
+| `labels` | `plan.defaultLabels` non-empty | auto-filled |
+| `labels` | `plan.defaultLabels` empty — its default | **must-ask** |
+| `assignee` | `plan.assignToMe` true **and** an account id resolved | auto-filled |
+| `assignee` | `plan.assignToMe` false — its default | **must-ask** |
+| `assignee` | `plan.assignToMe` true but no account id resolves | **must-ask** |
+
+`assignee` is the harder of the two, because whether it auto-fills is only knowable once
+`trackers.md` §3.6's `atlassianUserInfo` → `lookupJiraAccountId` pair has run. When the field is
+**required**, run that resolution here, in this pass, and carry the account id — §3.6 resolves it
+once per run anyway, so this spends no extra call, it only moves it earlier. §3.6's "create the
+issues unassigned" fallback is not available on a required `assignee`: unassigned is the rejection.
+When the field is optional, nothing changes — §3.6 keeps resolving it at creation time and drops it
+on a rejection.
+
+Neither field stops being config-driven. `plan.defaultLabels` and `plan.assignToMe` still decide what
+is *sent* whenever they hold a value; the rule above only decides what happens when they hold none
+and Jira insists.
 
 **Must-ask — everything else that is `required`**, which in practice means the project's mandatory
 custom fields: a required "Team", "Component", "Sprint", "Severity", "Business value". Carry, per

--- a/skills/magic-plan/references/messages.md
+++ b/skills/magic-plan/references/messages.md
@@ -89,8 +89,8 @@ tracker qui recevra les tickets, et l'endroit où je cherche les doublons.
 ```text
 Where should the tickets be created for **{repo}**?
 
-The repository declares both a Jira project and GitHub issues, and `plan.tracker`
-is set to "ask", so this one is yours to answer.
+`plan.tracker` is set to "ask" and the repository's own configuration does not
+settle it, so this one is yours to answer.
 ```
 
 ### fr
@@ -98,43 +98,103 @@ is set to "ask", so this one is yours to answer.
 ```text
 Où faut-il créer les tickets pour **{repo}** ?
 
-Le repository déclare à la fois un projet Jira et des issues GitHub, et
-`plan.tracker` vaut "ask" : c'est donc à toi de trancher.
+`plan.tracker` vaut "ask" et la configuration du repository ne tranche pas : c'est
+donc à toi de décider.
 ```
 
-## MSG_JIRA_NOT_AVAILABLE
+> Offer only the trackers `references/trackers.md` §1 says can actually receive a ticket — an option
+> whose answer leads straight to `MSG_JIRA_NOT_CONFIGURED` is a question asked for nothing. Label
+> each with its concrete destination (`PROJ`, `github.com/acme/api`), never with the bare product
+> name, for the same reason `MSG_APPROVAL` names the backlog rather than the tracker.
+>
+> Ask this **once** per run. `references/trackers.md` §1.1 carries the answer forward for every
+> later consumer, so no step re-asks.
+
+## MSG_TRACKER_NONE
 
 ### en
 
 ```text
-🚧 Jira ticket creation is not available yet
+❌ **{repo}** has no backlog to file into
 
-**{repo}** files its tickets in Jira, and this skill can only create GitHub issues
-for now — Jira support is tracked in #199.
+No GitHub remote, no `issues.githubIssuesUrl`, and no `plan.jiraProject` — so there
+is nowhere for these tickets to go, and nothing worth asking either: every option I
+could offer leads to the same dead end.
 
-I'm stopping here rather than after the brainstorm: an hour of exploration and
-framing that ends on "I can't create this" is worse than a refusal on the first
-question.
-
-In the meantime you can either point this idea at a GitHub-tracked repository, or
-create the Jira ticket by hand and pick it up with `/magic:start {JIRA-KEY}`.
+Give it one of the two and run this again — `plan.jiraProject`, the Jira project
+key, in the repository's Plan settings, or `issues.githubIssuesUrl`, the repository
+that holds the issues. Nothing was explored and nothing was created.
 ```
 
 ### fr
 
 ```text
-🚧 La création de tickets Jira n'est pas encore disponible
+❌ **{repo}** n'a aucun backlog où déposer les tickets
 
-**{repo}** gère ses tickets dans Jira, et cette skill ne sait créer que des issues
-GitHub pour l'instant — le support Jira est suivi dans #199.
+Pas de remote GitHub, pas de `issues.githubIssuesUrl`, pas de `plan.jiraProject` :
+il n'y a nulle part où créer ces tickets, et rien à te demander non plus — toutes
+les options que je pourrais proposer mènent à la même impasse.
+
+Renseigne l'un des deux et relance — `plan.jiraProject`, la clé du projet Jira,
+dans les réglages Plan du repository, ou `issues.githubIssuesUrl`, le repository
+qui héberge les issues. Rien n'a été exploré et rien n'a été créé.
+```
+
+> `{repo}` is the repository resolved at Step 2.1. This is a refusal, not a question:
+> `references/trackers.md` §1 reaches it only when **neither** tracker qualifies, and offering a
+> tracker that cannot receive a ticket is the one thing rows 3 and 5 forbid. It fires at Step 2.3,
+> before the brainstorm, for `MSG_JIRA_NOT_CONFIGURED`'s reason.
+>
+> Name the two settings rather than implying a mistake: a repository added by path and never cloned
+> reaches this legitimately, and it is a configuration that was never made, not one that is wrong.
+
+## MSG_JIRA_NOT_CONFIGURED
+
+### en
+
+```text
+❌ Jira is the tracker for **{repo}**, but it cannot receive tickets
+
+{reason}
+
+I'm stopping here rather than after the brainstorm: an hour of exploration and
+framing that ends on "I can't create this" is worse than a refusal on the second
+question.
+
+I will not file this in GitHub instead — a Jira-destined idea landing in a backlog
+that project's team does not read is worse than no ticket at all. Either fix the
+setting ({fix}), or create the Jira ticket by hand and pick it up with
+`/magic:start {JIRA-KEY}`.
+```
+
+### fr
+
+```text
+❌ Jira est le tracker de **{repo}**, mais il ne peut pas recevoir de tickets
+
+{reason}
 
 Je m'arrête maintenant plutôt qu'après le brainstorm : une heure d'exploration et
 de cadrage qui finit par « je ne peux pas créer ça » est pire qu'un refus à la
-première question.
+deuxième question.
 
-En attendant, tu peux soit viser un repository suivi sur GitHub, soit créer le
-ticket Jira à la main et l'attaquer avec `/magic:start {JIRA-KEY}`.
+Je ne vais pas les créer dans GitHub à la place — une idée destinée à Jira posée
+dans un backlog que l'équipe de ce projet ne lit pas est pire que pas de ticket du
+tout. Soit tu corriges le réglage ({fix}), soit tu crées le ticket Jira à la main
+et tu l'attaques avec `/magic:start {JIRA-KEY}`.
 ```
+
+> `{reason}` names the exact blocker, in one line — `the Atlassian integration is off for this
+> account`, `plan.jiraProject is empty`, `PROJ resolves on none of the sites I can reach`, `the
+> project has no issue type named "Story"`, `Jira did not answer`. The first two are
+> `references/trackers.md` §1.2's conditions; the rest are `references/jira-fields.md` §4's stops,
+> which this message also carries. `{fix}` names where each is fixed: the integrations toggle, the
+> repository's Plan settings, the Jira project itself, or nothing at all when Jira is simply down.
+> Never merge them into a vague "Jira is not configured" — they are fixed in different places, and
+> one of them is not the user's fault.
+>
+> `{JIRA-KEY}` is displayed as written: the ticket does not exist yet, so there is no key to
+> substitute.
 
 ## MSG_SPEC_CREATED
 
@@ -206,7 +266,8 @@ Options :
 3. Continuer avec un périmètre réduit — j'intègre le recouvrement au cadrage
 ```
 
-> Format each entry as `  - #{number}: {title} ({state}) — {why_related}` with its URL.
+> Format each entry as `  - {id}: {title} ({state}) — {why_related}` with its URL, where `{id}`
+> is `#{number}` on GitHub and the issue key (`PROJ-123`) on Jira.
 > Never list a ticket without saying why it looked related: an unexplained list is noise
 > the user has to re-investigate themselves.
 
@@ -223,6 +284,176 @@ Options :
 ```text
 🔗 Aucun ticket existant ne couvre ça — rien trouvé dans {searched_scope}.
 ```
+
+> `{searched_scope}` is the scope the search actually ran against — `acme/api` on GitHub, `PROJ` on
+> Jira. "Nothing found" means nothing without saying where.
+
+## MSG_JIRA_REQUIRED_FIELDS
+
+### en
+
+```text
+**{project}** makes {field_count} field(s) mandatory that I cannot fill myself
+
+{field_list}
+
+Jira refuses a creation that omits them, so I need the values before proposing the
+structure — not at creation time, where the answer would come back as a 400 after
+the whole brainstorm.
+```
+
+### fr
+
+```text
+**{project}** rend obligatoires {field_count} champ(s) que je ne peux pas remplir seul
+
+{field_list}
+
+Jira refuse une création qui les omet : il me faut donc les valeurs avant de
+proposer la structure, et pas au moment de la création, où la réponse serait un 400
+après tout le brainstorm.
+```
+
+> `{project}` is the carried `project_key`, `{field_count}` the length of `must_ask_fields`, and
+> `{field_list}` one line per field: `  - {display name} — required on {issue type}`, plus the
+> expected shape when it is not a plain string. Name the issue type: a field mandatory on the story
+> type and not on the epic is a different situation, and the user is entitled to see which.
+>
+> These fields ride **inside Step 4's `AskUserQuestion` batch** — never a separate round-trip. That
+> batch is capped in how many questions one call can carry, and Step 4's own framing questions are
+> in it too, so one question carries **several fields** whenever they can be answered together: a
+> group of short free-text or single-select fields becomes one question listing them, and only a
+> field that needs its own options list gets a question to itself. Pack them into as few questions
+> as will hold them, and put the framing questions in the same call.
+>
+> When even that will not fit the batch, **drop nothing**: display `MSG_JIRA_TOO_MANY_FIELDS` and
+> let the user pick one of its three options. A mandatory field quietly left unasked comes back as a
+> 400 at creation time, after the whole brainstorm — which is the outcome
+> `references/jira-fields.md` exists to remove.
+>
+> Render each field per `references/jira-fields.md` §3, which decides when a field becomes options
+> and when it becomes a plain-words question.
+
+## MSG_JIRA_TOO_MANY_FIELDS
+
+### en
+
+```text
+⚠️ **{project}** makes {field_count} fields mandatory — more than one round of
+framing questions can ask for
+
+{field_list}
+
+{fit_count} of them fit into the framing questions. A mandatory field I never ask
+about comes back as a 400 at creation time, after the whole brainstorm, and
+quietly dropping the rest is the one thing I will not do.
+
+Options:
+1. Ask in a second round — the {overflow_count} that did not fit, in one extra
+   batch of questions right after the framing ones
+2. Ask only the {fit_count} that fit — creation is then rejected on the rest, and
+   I report that rejection with the field it names
+3. Stop — give these fields a default in the project's own configuration, or stop
+   requiring the ones that do not need to be, then run this again
+
+Nothing has been created yet.
+```
+
+### fr
+
+```text
+⚠️ **{project}** rend obligatoires {field_count} champs — plus qu'un tour de
+questions de cadrage ne peut en demander
+
+{field_list}
+
+{fit_count} d'entre eux tiennent dans les questions de cadrage. Un champ
+obligatoire que je n'ai pas demandé revient en 400 au moment de la création, après
+tout le brainstorm, et abandonner les autres en silence est la seule chose que je
+ne ferai pas.
+
+Options :
+1. Demander en deux tours — les {overflow_count} restants, dans un lot de
+   questions juste après celles de cadrage
+2. Ne demander que les {fit_count} qui tiennent — la création sera alors refusée
+   sur les autres, et je signale ce refus avec le champ qu'il nomme
+3. Arrêter — donne une valeur par défaut à ces champs dans la configuration du
+   projet, ou arrête de rendre obligatoires ceux qui n'ont pas à l'être, puis
+   relance
+
+Rien n'a encore été créé.
+```
+
+> `{project}` is the carried `project_key`, `{field_count}` the number of mandatory fields the
+> discovery pass found that it cannot fill itself, `{fit_count}` how many of them Step 4's question
+> batch can carry, and `{overflow_count}` the rest. `{field_list}` uses the same one-line-per-field
+> rendering as `MSG_JIRA_REQUIRED_FIELDS` and lists **every** field, the overflow included: not
+> dropping one in silence is the whole point, and a field the user cannot see is one they cannot
+> decide about.
+>
+> This is the surface for **both** of `references/jira-fields.md` §3's overflow cases — a must-ask
+> set larger than one `AskUserQuestion` batch can hold, and the same set still not fitting after
+> packing. Same cause, same three options, so one message rather than two. There is no field-count
+> threshold behind it: nine mandatory fields is an ordinary company-managed project, and the only
+> limit is what one batch can carry.
+>
+> Options 1 and 2 both continue the run, so this is an `AskUserQuestion` and not a refusal. Option 2
+> is chosen with its consequence already stated: the creation reaches `references/trackers.md` §4
+> with a rejection naming the field, reported as the failure it is. Option 3 stops at Step 2.3,
+> before the brainstorm.
+
+## MSG_JIRA_FIELDS_UNKNOWN
+
+### en
+
+```text
+⚠️ I could not read the create screen for **{issue_type}** in {project}
+
+{operation} failed twice, so I do not know which fields that issue type makes
+mandatory. Everything else resolved — this is one type's field list, not Jira
+being unreachable.
+
+If a mandatory custom field is hiding there, creating the tickets comes back as a
+400, after the brainstorm and the spec — the one outcome this check exists to
+prevent. So the risk is yours to take or refuse.
+
+Options:
+1. Continue — I plan as usual, and that field, if it exists, surfaces at creation
+2. Stop — nothing has been created and nothing explored yet
+```
+
+### fr
+
+```text
+⚠️ Je n'ai pas pu lire l'écran de création de **{issue_type}** dans {project}
+
+{operation} a échoué deux fois : je ne sais donc pas quels champs ce type d'issue
+rend obligatoires. Tout le reste a été résolu — c'est la liste des champs d'un
+type, pas Jira qui est injoignable.
+
+S'il s'y cache un champ obligatoire, la création reviendra en 400 au moment de
+créer les tickets, après le brainstorm et la spec — exactement ce que cette
+vérification sert à éviter. C'est donc à toi de prendre le risque ou de refuser.
+
+Options :
+1. Continuer — je planifie normalement, et ce champ, s'il existe, apparaîtra à la
+   création
+2. Arrêter — rien n'a été créé et rien n'a encore été exploré
+```
+
+> `{issue_type}` is the type whose create screen could not be read — the epic type or the story
+> type, named, because which one it is decides what the risk covers. `{project}` is the carried
+> `project_key` and `{operation}` is what was attempted, in the user's words: `the required-field
+> discovery`.
+>
+> This fires at **Step 2.3**, before the spec exists, which is why it says nothing about a spec
+> being intact and why `MSG_TRACKER_ERROR` is not the message here. It carries its own options
+> because `references/jira-fields.md` §4 promises a choice, and a promised choice needs a message
+> that presents it — the convention `MSG_APPROVAL` and `MSG_TRACKER_ASK` already follow.
+>
+> It is the only non-stop outcome in that section; every other failure there is a stop with
+> `MSG_JIRA_NOT_CONFIGURED`. On option 1, `references/trackers.md` §3.4's `unknown` rule governs the
+> values that were not read: their routes are attempted, not skipped.
 
 ## MSG_SIZING_VERDICT
 
@@ -323,8 +554,9 @@ Options :
 3. Arrêter — je garde la spec, je ne crée rien
 ```
 
-> `{tracker_target}` is the concrete destination, e.g. `github.com/acme/api` — never the bare
-> word "GitHub". The user is approving a write to a specific backlog and is entitled to see which.
+> `{tracker_target}` is the concrete destination — `github.com/acme/api`, or `PROJ` on
+> `acme.atlassian.net` — never the bare word "GitHub" or "Jira". The user is approving a write to a
+> specific backlog and is entitled to see which.
 > Option 3 keeps the spec on disk: the thinking is worth keeping even when the tickets are not.
 
 ## MSG_TICKETS_CREATED
@@ -337,7 +569,7 @@ Options :
 ✅ {ticket_count} tickets created in {tracker_target}
 
 {ticket_list}
-
+{hierarchy_route}
 📄 Spec updated with the links — {spec_path}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -351,15 +583,21 @@ Options :
 ✅ {ticket_count} tickets créés dans {tracker_target}
 
 {ticket_list}
-
+{hierarchy_route}
 📄 Spec mise à jour avec les liens — {spec_path}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 > On an epic breakdown, render `{ticket_list}` as the hierarchy that was actually created:
-> the epic on its own line, each story indented under it, every line carrying `#{number}` and
-> its URL. A flat list would hide whether the parent/child links landed.
+> the epic on its own line, each story indented under it, every line carrying the
+> tracker-issued identifier — `#{number}` on GitHub, `PROJ-123` on Jira — and its URL. A flat
+> list would hide whether the parent/child links landed.
+>
+> `{hierarchy_route}` is one line naming the route the parent/child links actually took — native
+> `parent`, `Epic Link`, or an issue link (`references/trackers.md` §3.4). Which one landed decides
+> what the epic will show in the Jira UI, so it is a fact about the result, not an implementation
+> detail. On GitHub there is only one route: leave it empty.
 
 ## MSG_PARTIAL_CREATION
 
@@ -411,32 +649,38 @@ laisserait des doublons dans le backlog.
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-> `{created_list}` and `{failed_list}` carry one line each, with the failure reason on the
-> failed ones (`403 — no write access`, `422 — label does not exist`, …). "Something went wrong"
-> is not a reason, and the user cannot resume from it.
+> `{created_list}` and `{failed_list}` carry one line each. A created line names the
+> tracker-issued identifier (`#412`, `PROJ-1234`) and its URL; a failed one names the reason
+> (`403 — no write access`, `422 — label does not exist`, `400 — field "Team" is required on
+> Story`, …). "Something went wrong" is not a reason, and the user cannot resume from it.
 
-## MSG_GITHUB_ERROR
+## MSG_TRACKER_ERROR
 
 ### en
 
 ```text
-⚠️ GitHub is not answering ({operation} failed twice)
+⚠️ {tracker} is not answering ({operation} failed twice)
 
 {consequence}
 
-The spec is intact — nothing about it depends on GitHub being reachable.
+The spec is intact — nothing about it depends on {tracker} being reachable.
 ```
 
 ### fr
 
 ```text
-⚠️ GitHub ne répond pas (échec de {operation} deux fois de suite)
+⚠️ {tracker} ne répond pas (échec de {operation} deux fois de suite)
 
 {consequence}
 
-La spec est intacte — rien en elle ne dépend de la disponibilité de GitHub.
+La spec est intacte — rien en elle ne dépend de la disponibilité de {tracker}.
 ```
 
+> `{tracker}` is the product name — `GitHub` or `Jira`. This is the one message about a tracker
+> being unreachable rather than about a specific backlog, so the name is what the user needs here;
+> `MSG_APPROVAL` and `MSG_TICKETS_CREATED` still name the concrete destination. `{operation}` names
+> what was attempted, in the user's words — `duplicate search`, `ticket creation`.
+>
 > `{consequence}` states what the run loses, not what broke: `duplicate check skipped, the
 > backlog may already hold this idea` for a failed search, `no ticket was created` for a failed
 > write. A search failure degrades the run; a write failure ends it.

--- a/skills/magic-plan/references/messages.md
+++ b/skills/magic-plan/references/messages.md
@@ -399,8 +399,15 @@ Rien n'a encore été créé.
 >
 > Options 1 and 2 both continue the run, so this is an `AskUserQuestion` and not a refusal. Option 2
 > is chosen with its consequence already stated: the creation reaches `references/trackers.md` §4
-> with a rejection naming the field, reported as the failure it is. Option 3 stops at Step 2.3,
-> before the brainstorm.
+> with a rejection naming the field, reported as the failure it is. Option 3 stops at **Step 4** —
+> after the framing dialogue, before Step 5 writes `## Proposed tickets`, and long before anything is
+> created.
+>
+> This message fires at Step 4 and **not** at Step 2.3, unlike every other message the discovery pass
+> can raise. `{fit_count}` is how many fields Step 4's batch can carry *alongside its own framing
+> questions*, and that is only knowable there — a count produced at 2.3 would be a guess about a
+> batch not yet composed. What still happens at 2.3 is the detection of the fields themselves, which
+> is what keeps the 400 out of creation time; only the question about how to ask them waits.
 
 ## MSG_JIRA_FIELDS_UNKNOWN
 

--- a/skills/magic-plan/references/spec-template.md
+++ b/skills/magic-plan/references/spec-template.md
@@ -102,8 +102,10 @@ afterwards — what the user asked for and what we concluded are two different r
 | --- | --- | --- |
 | {the ambiguity} | {what was decided} | {the reason, in one line} |
 
-{One row per question actually resolved with the user in Step 4. A decision with no reason is a
-decision nobody can revisit six weeks later.}
+{One row per question actually resolved with the user in Step 4, plus — on a Jira run — one row per
+mandatory custom field answered there, its reason naming the issue type that required it. A decision
+with no reason is a decision nobody can revisit six weeks later, and that Jira row is the record of
+which value was sent to Jira and why, so the spec explains the created ticket on its own.}
 
 ### Non-goals
 
@@ -120,7 +122,7 @@ the plan belongs here — this is what makes the sizing verdict auditable.}
 
 ## Related tickets
 
-- #{number}: {title} ({state}) — {relation: duplicate / overlaps / prior art / rejected before}
+- {id}: {title} ({state}) — {relation: duplicate / overlaps / prior art / rejected before}
 
 {`None found` when the duplicate check ran and found nothing. `Not checked` when
 `plan.duplicateCheck` is off or the search failed — those are different facts and must not read
@@ -152,11 +154,15 @@ the format is `none`.}
 
 | Ticket | Kind | Title | URL |
 | --- | --- | --- | --- |
-| #{number} | epic \| story | {title} | {url} |
+| {id} | epic \| story | {title} | {url} |
 
 {Appended in Step 7, after creation. Absent until then — an empty table implies a failure that did
 not happen.}
 ```
+
+`{id}` is whatever the tracker issues: `#{number}` on GitHub, an issue key like `PROJ-123` on Jira.
+The column is `Ticket` rather than `Number` because half the trackers this skill writes to do not
+issue one.
 
 On a single-story verdict, `## Proposed tickets` holds exactly one entry and there is no epic. Keep
 the section heading plural anyway: the format is frozen, and Step 7 looks for it by name.
@@ -167,7 +173,7 @@ indistinguishable from a duplicate check that never ran.
 ## 5. The append after creation
 
 Once the tickets exist, fill `## Created tickets` and set `Status: tickets created`. Do this even on
-a partial failure — especially then, since the created numbers are the only thing that cannot be
+a partial failure — especially then, since the created identifiers are the only thing that cannot be
 regenerated from the rest of the file. List what exists; the failures are reported to the user by
 `MSG_PARTIAL_CREATION` and belong in the spec only as an absence.
 

--- a/skills/magic-plan/references/trackers.md
+++ b/skills/magic-plan/references/trackers.md
@@ -75,7 +75,8 @@ This is what makes "asks exactly once" true. A branch that re-derives the tracke
 `MSG_TRACKER_ASK` a second time on a `plan.tracker: ask` repository, which reads as the skill having
 forgotten the answer — and a branch that re-resolves the `cloudId` or the issue-type ids spends
 calls to learn what it already knows. `references/jira-fields.md` owns those calls and the rules
-behind them; §3 spends none of them a second time.
+behind them; §3 spends none of them a second time, with the single exception §3.4's `unknown` rule
+names — a create screen that paging left half-read is finished there rather than guessed at.
 
 ### 1.2 When the resolved tracker cannot receive a ticket
 
@@ -279,7 +280,7 @@ is what decides whether the epic will show a progress bar in the Jira UI.
 | --- | --- | --- | --- |
 | 1 | native `parent` | `story_has_parent_field` is true, or `unknown` | send `parent` with the epic key in the story's create call |
 | 2 | the epic-link custom field | `epic_link_field_id` is set, or `unknown` | send it with the epic key in `additional_fields` |
-| 3 | an issue link | neither of the above | `mcp__atlassian__createIssueLink` once both issues exist |
+| 3 | an issue link | neither of the above, or both were rejected | create the story unparented, then `mcp__atlassian__createIssueLink` |
 
 **`unknown` is not `false`, so the route is attempted rather than skipped.** `jira-fields.md` §4
 reports these values as `unknown` — never as `false`, an empty id or an omitted field — when the
@@ -303,12 +304,19 @@ epic key through it regardless — that is what modern team-managed projects acc
 an epic. On an instance where `parent` really is subtask-only, the call is rejected and route 2
 takes over, which is one of the reasons the cascade has three routes rather than one.
 
-**That rejection is a retry, not a §4 failure.** Re-create the same story with the epic link carried
-in `additional_fields` (route 2), and only if *that* call also fails does §4 apply. Be precise about
-the state this leaves: the rejected route-1 call created nothing, so there is no orphan story to
-delete and nothing to roll back — which is exactly what makes the retry safe and keeps §4's
-never-roll-back rule intact. Reporting a partial creation here would report a failure on a project
-where route 2 was about to work.
+**A rejection advances the cascade; it is not a §4 failure.** Re-create the same story with the
+epic link carried in `additional_fields` (route 2). If *that* call is rejected too, one route is
+left, and reaching it takes a step the other two do not need: **create the story unparented** — no
+`parent`, no epic-link field — and then link it with route 3. Route 3 is the only route whose
+hierarchy is a second call, which is precisely why it is the only one that needs the story to exist
+first. §4 applies only when route 3 itself fails: either its unparented create, or its link call.
+
+Be precise about the state a rejection leaves: a rejected create call created nothing, so there is
+no orphan story to delete and nothing to roll back — which is what makes advancing safe and keeps
+§4's never-roll-back rule intact. Reporting a partial creation on a rejection would report a failure
+on a project where the next route was about to work. The one state that is *not* clean is route 3's
+own window: between the unparented create and the link, the story exists with no parent. If the link
+fails there both issues exist, and that is §4's mildest case — reported, never rolled back.
 
 **Never hardcode a `customfield_` id for route 2.** The epic-link field has a different numeric id
 on every Jira site; a hardcoded one either 400s or, worse, writes into an unrelated field that
@@ -325,17 +333,19 @@ as `skills/magic-start/references/dependencies.md` §2.1 states for the blocker 
 literal string `Relates` and say the link type resolution degraded, per the route-announcement rule
 above.
 
-**Derive the direction from the type you kept, never from a convention.** `createIssueLink` takes an
-`inwardIssue` and an `outwardIssue`, and the link reads *outward → inward*: "`outwardIssue` {the
-type's `outward` label} `inwardIssue`". So read the two labels of the type actually chosen and place
-the issues accordingly, the way `skills/magic-start/references/dependencies.md` §2.1 reasons from
-`type.inward` rather than from a hardcoded name. When the kept type's `outward` label is the
-parent-side one — "is Epic of", "is parent of" — the **epic** is `outwardIssue` and the **story** is
-`inwardIssue`. When its `outward` label is the child-side one — "is child of", "is Story of" — the
-two swap: the story is `outwardIssue` and the epic is `inwardIssue`. Deriving it from the labels is
-what lets a site whose type is named the other way round still get a correct link. On the `Relates`
-last resort both labels say the same thing: the type is symmetric, the order carries no meaning, and
-either one is right.
+**Derive the direction from the type you kept, never from a convention.** `createIssueLink` takes
+an `inwardIssue` and an `outwardIssue`, and the tool's own example fixes which is which: for "A is
+blocked by B" it documents `inwardIssue: B, outwardIssue: A`. On the `Blocks` type `outward` is
+"blocks" and `inward` is "is blocked by", so B — the `inwardIssue` — is the one that *blocks*. The
+rule that follows is **`inwardIssue` {the type's `outward` label} `outwardIssue`**, and
+`skills/magic-start/references/dependencies.md` §2.1 states the same thing for the blocker gate:
+for "A is blocked by B", `inwardIssue` is B, the blocker. Read the two labels of the type actually
+chosen and place the issues by that rule. When the kept type's `outward` label is the parent-side
+one — "is Epic of", "is parent of" — the **epic** is `inwardIssue` and the **story** is
+`outwardIssue`. When its `outward` label is the child-side one — "is child of", "is Story of" — the
+two swap. Deriving it from the labels is what lets a site whose type is named the other way round
+still get a correct link. On the `Relates` last resort both labels say the same thing: the type is
+symmetric, the order carries no meaning, and either one is right.
 
 **A link created in the wrong direction is a silent failure.** `createIssueLink` accepts it, returns
 success, and the response looks exactly like a correct one — the relation simply reads the wrong way
@@ -392,13 +402,20 @@ When `plan.useRepoTemplates` is `false`, use the §3.3 structure.
   `screen_omits` naming `labels` on a screen read to the end. An `unknown` one is not an omission:
   per §3.4's `unknown` rule the labels are sent, and dropped only if the call comes back rejected on
   that field.
-- **Assignee**: §2.6's rule, with `mcp__atlassian__lookupJiraAccountId` in place of
-  `mcp__github__get_me` and the account id in place of the login — resolved once per run, not per
-  issue, and sent as `assignee_account_id`, which is a parameter of its own and not an
-  `additional_fields` entry. As with `labels`, an issue type whose create screen has no `assignee`
-  field is named by the carried `screen_omits`: say so and continue, rather than failing a creation
-  over it — and an `unknown` there reads as §3.4's rule says, the account id sent and dropped only on
-  a rejection.
+- **Assignee**: §2.6's rule, with the account id in place of the login — resolved once per run, not
+  per issue, and sent as `assignee_account_id`, which is a parameter of its own and not an
+  `additional_fields` entry. Resolving "me" takes **two calls, in this order**, because Jira exposes
+  no single equivalent of `mcp__github__get_me`: `mcp__atlassian__atlassianUserInfo` first — it takes
+  no parameters and answers who the authenticated user is — then
+  `mcp__atlassian__lookupJiraAccountId` with that identity as its `searchString`, since that tool is
+  a search and has no current-user mode. Skip the second call when the first already carries an
+  account id. **Never substitute a search term of your own**: §2.6 forbids inferring the identity
+  from `git config user.email`, and a `searchString` invented here is that same guess wearing a Jira
+  parameter. If neither call yields an account id, say so in one line and create the issues
+  unassigned — `plan.assignToMe` is a convenience, never worth failing a creation over. As with
+  `labels`, an issue type whose create screen has no `assignee` field is named by the carried
+  `screen_omits`: say so and continue — and an `unknown` there reads as §3.4's rule says, the account
+  id sent and dropped only on a rejection.
 
 ### 3.7 Manual verification
 
@@ -460,19 +477,21 @@ and which hierarchy links landed. On any failure:
 4. Send the metadata call anyway (Step 7.1 of `SKILL.md`), carrying whatever ticket id does exist.
    A half-created plan is still a plan the sidebar should show.
 
-**One rejection is not a failure here, and the sequence above must not fire on it**: a story create
-call rejected on `parent` (§3.4, route 1). That is the cascade advancing to route 2 — the story is
-re-created with the epic link in `additional_fields` — and the rejected call created nothing, so
-there is no partial state to report and no orphan to clean up. Only if the route-2 call also fails
-is this a failure, and then it is one failure, not two.
+**A rejection on the hierarchy is not a failure here, and the sequence above must not fire on it**:
+a story create call rejected on `parent` (§3.4, route 1) or on the epic-link field (route 2). That
+is the cascade advancing — to route 2, then to route 3, which creates the story unparented and links
+it — and each rejected call created nothing, so there is no partial state to report and no orphan to
+clean up. This becomes a failure only when route 3 fails: its unparented create, or its link call.
+Then it is one failure, not three.
 
 A hierarchy link that fails while both issues exist is the mildest case and still gets reported:
 the tickets are usable, but the epic will show no progress and the story no parent, so someone has
 to link them by hand. Say exactly that, and list the story keys so it takes one edit.
 
-That covers both branches — a failed `mcp__github__sub_issue_write` on GitHub, and on Jira every one
-of §3.4's three routes exhausted or the chosen one rejected. A degraded route that *did* land
-(route 3) is not this case: §3.4 announces that as a success with its route.
+That covers both branches — a failed `mcp__github__sub_issue_write` on GitHub, and on Jira route 3
+failing after routes 1 and 2 were unavailable or rejected, which is what "all three exhausted"
+means. A rejection on route 1 or 2 alone is not this case, per the rule above, and neither is a
+degraded route that *did* land: §3.4 announces route 3 as a success carrying its route.
 
 ## Usage
 

--- a/skills/magic-plan/references/trackers.md
+++ b/skills/magic-plan/references/trackers.md
@@ -398,7 +398,11 @@ When `plan.useRepoTemplates` is `false`, use the §3.3 structure.
   that does happen is the `labels` field being absent from that issue type's create screen, which
   company-managed projects do configure — and the carried `screen_omits` already names it, *before*
   any call. Drop the labels then, say in one line that the issue type carries no `labels` field, and
-  create the issue without them. Never discover this as an error. That is the `false` reading —
+  create the issue without them. Never discover this as an error. **A `labels` field the screen makes
+  *required* while `plan.defaultLabels` is empty is a different case and is not dropped**:
+  `jira-fields.md` §2 classified it must-ask, so its value comes from `required_field_answers` and
+  rides in `additional_fields` like any other answer. Dropping it here would be the 400 that pass
+  exists to prevent. That is the `false` reading —
   `screen_omits` naming `labels` on a screen read to the end. An `unknown` one is not an omission:
   per §3.4's `unknown` rule the labels are sent, and dropped only if the call comes back rejected on
   that field.
@@ -412,7 +416,11 @@ When `plan.useRepoTemplates` is `false`, use the §3.3 structure.
   account id. **Never substitute a search term of your own**: §2.6 forbids inferring the identity
   from `git config user.email`, and a `searchString` invented here is that same guess wearing a Jira
   parameter. If neither call yields an account id, say so in one line and create the issues
-  unassigned — `plan.assignToMe` is a convenience, never worth failing a creation over. As with
+  unassigned — `plan.assignToMe` is a convenience, never worth failing a creation over. **That
+  fallback is unavailable when the screen makes `assignee` required**: there, unassigned *is* the
+  rejection, so `jira-fields.md` §2 has already classified the field must-ask — whether because
+  `plan.assignToMe` is false or because no account id resolved — and its value arrives through
+  `required_field_answers`. As with
   `labels`, an issue type whose create screen has no `assignee` field is named by the carried
   `screen_omits`: say so and continue — and an `unknown` there reads as §3.4's rule says, the account
   id sent and dropped only on a rejection.
@@ -441,6 +449,11 @@ be observed.
     that answer.
 - `plan.tracker: jira`, `plan.jiraProject` empty.
   - Expected: `MSG_JIRA_NOT_CONFIGURED` before the brainstorm, no GitHub fallback.
+- A create screen that makes `labels` **required**, with `plan.defaultLabels` left at its `[]`
+  default — then the same with `assignee` required and `plan.assignToMe` left at `false`.
+  - Expected: both reach Step 4's question as must-ask fields, per `jira-fields.md` §2, and creation
+    succeeds with the answered values. What must **not** happen is the field being treated as
+    config-filled and the creation rejected on it after the approval.
 - The story type uncreatable for the user, the epic type creatable.
   - Expected: the epic survives; the report names its key and URL plus every story that did not
     land, with its reason; `## Created tickets` holds the epic; nothing is rolled back.

--- a/skills/magic-plan/references/trackers.md
+++ b/skills/magic-plan/references/trackers.md
@@ -1,16 +1,19 @@
 # Tracker abstraction
 
-Read this file in Step 7, once the user has approved the ticket structure. It owns everything
-about turning the approved breakdown into real tickets: which tracker receives them, what each
-tracker requires, how a parent/child hierarchy is created, and how a partial failure is reported.
+Read §1 in Step 2.3, when the tracker is resolved, and §2-§4 in Step 7 once the user has approved
+the ticket structure. This file owns everything about turning an approved breakdown into real
+tickets: which tracker receives them, what each tracker requires, how a parent/child hierarchy is
+created, and how a partial failure is reported.
 
-It is a **branch per tracker**, on purpose. Adding Jira (#199) or Linear later fills in a section
-here and touches nothing in `SKILL.md`: the steps before this file are tracker-agnostic — an idea,
-a spec, a sizing verdict and an approval mean the same thing whatever the backlog is. If a new
-tracker ever forces a change to `SKILL.md`, the abstraction has leaked and the fix belongs here.
+It is a **branch per tracker**, on purpose. GitHub (§2) and Jira (§3) each own their own section
+and neither touches `SKILL.md`: the steps before this file are tracker-agnostic — an idea, a spec,
+a sizing verdict and an approval mean the same thing whatever the backlog is. Adding Linear later
+fills a third section here. If a new tracker ever forces a change to `SKILL.md`, the abstraction
+has leaked and the fix belongs here.
 
-Step 2 already resolved **which** tracker, and stopped the skill if it was one this file cannot
-serve. Reaching Step 7 therefore means the tracker is supported — do not re-detect it.
+Step 2 already resolved **which** tracker, and refused the run only when the resolved tracker
+cannot receive a ticket at all (§1.2). Reaching Step 7 therefore means the tracker is usable — do
+not re-detect it and do not re-ask: §1.1's carried resolution is the only source for it.
 
 ## 1. Detection — owned by Step 2, documented here
 
@@ -20,17 +23,76 @@ skill *before* the brainstorm, not after it. The resolution order:
 | Order | Source | Outcome |
 | --- | --- | --- |
 | 1 | `plan.tracker` is `github` or `jira` | that tracker, no question asked |
-| 2 | `plan.tracker` is `ask`, and exactly one of `issues.githubIssuesUrl` / `issues.jiraUrl` is set | the one that is set |
+| 2 | `plan.tracker` is `ask` and only one of `issues.githubIssuesUrl` / `issues.jiraUrl` is set | the one that is set |
 | 3 | `plan.tracker` is `ask`, and both are set | ask with `MSG_TRACKER_ASK` |
 | 4 | `plan.tracker` is `ask`, and neither is set, but `git remote get-url origin` is a GitHub remote | GitHub |
-| 5 | nothing resolves | ask with `MSG_TRACKER_ASK`, listing only supported trackers |
+| 5 | nothing resolves | ask with `MSG_TRACKER_ASK`, offering every tracker that can actually receive a ticket |
 
 Row 4 is what makes the common case silent: a repository cloned from GitHub with no `issues.*`
 configured at all still plans without a question. Row 2 beats row 4 deliberately — an explicitly
 configured Jira project outranks the fact that the code happens to live on GitHub.
 
+Rows 3 and 5 offer **every tracker that could actually receive the tickets, and only those**. Jira
+qualifies when `integrations.atlassian` is on and `plan.jiraProject` is set — the project key alone
+is enough, even with `issues.jiraUrl` empty, because the key is what a write needs while that URL
+only decides whether a browse link can be displayed (§3.1). GitHub qualifies when
+`issues.githubIssuesUrl` is set, or the `origin` remote is a GitHub one.
+
+When **neither** qualifies — no GitHub remote, no `issues.githubIssuesUrl`, no `plan.jiraProject` —
+there is nothing to ask: a question whose only options lead nowhere is worse than a refusal. Refuse
+the run with `MSG_TRACKER_NONE`, which names the two settings that would give this repository a
+backlog, at Step 2.3, before the brainstorm, for §1.2's reason. A repository added by path and never
+cloned reaches this legitimately.
+
 An unknown value in `plan.tracker` (the field is `string`-typed jsonb the webapp writes wholesale,
 so it can hold anything) is treated as `ask`, never as a failure.
+
+### 1.1 The resolution is carried, not re-derived
+
+The resolution has **three** consumers, not one: the required-field discovery of Step 2.3, the
+duplicate search of Step 3.3, and the creation in Step 7. Resolve it once, at Step 2.3, and carry
+these values for the rest of the run:
+
+| Carried | Shape | Read by |
+| --- | --- | --- |
+| `tracker` | `github` / `jira` | Step 3.3, Step 7 |
+| `tracker_target` | `github.com/acme/api`, or `PROJ` on the Jira site | `MSG_APPROVAL`, `MSG_TICKETS_CREATED` |
+| `owner/repo` | GitHub only, parsed per §2.1 | §2.3, Step 3.3 |
+| `required_field_answers` | Jira only, the Step 4 answers keyed by field id | §3.2 |
+
+On a Jira run, **everything `references/jira-fields.md`'s `## Usage` table returns is carried
+alongside those** — the site, the project key, the issue types, the must-ask fields, the four
+create-screen values §3.4-§3.6 read, and `degraded`. That table is the contract for their shapes and
+their consumers and it is deliberately **not restated here**: two tables listing the same rows are
+two tables that drift. What §1.1 owns is that the resolution exists, travels, and has those three
+consumers — not the row-by-row shapes.
+
+`required_field_answers` is the one Jira row above because it is the one that pass does not produce:
+it comes from **Step 4**, which asks for the pass's `must_ask_fields` once the spec exists to record
+the answers in.
+
+This is what makes "asks exactly once" true. A branch that re-derives the tracker asks
+`MSG_TRACKER_ASK` a second time on a `plan.tracker: ask` repository, which reads as the skill having
+forgotten the answer — and a branch that re-resolves the `cloudId` or the issue-type ids spends
+calls to learn what it already knows. `references/jira-fields.md` owns those calls and the rules
+behind them; §3 spends none of them a second time.
+
+### 1.2 When the resolved tracker cannot receive a ticket
+
+Jira resolves (row 1, 2, 3 or 5) but `integrations.atlassian` is `false`, or `plan.jiraProject` is
+empty: **refuse the run** with `MSG_JIRA_NOT_CONFIGURED`, at Step 2.3, before the brainstorm.
+
+Two things that refusal must not become:
+
+- **Never a silent fallback to GitHub.** Filing a Jira-destined idea in a GitHub backlog nobody on
+  that project reads is the failure mode this file exists to prevent. A ticket in the wrong tracker
+  is worse than no ticket: it looks filed.
+- **Never a refusal after the brainstorm.** The two conditions are known from the config alone, so
+  there is nothing to explore before checking them. An hour of framing that ends on "I cannot
+  create this" is the outcome the Step 2.3 placement exists to avoid.
+
+`MSG_JIRA_NOT_CONFIGURED` names which of the two conditions fired, because they are fixed in
+different places — the integrations toggle and the repository's Plan settings.
 
 ## 2. GitHub — implemented
 
@@ -130,40 +192,264 @@ When `plan.useRepoTemplates` is `false`, or no template directory exists, use th
   change between two calls in the same run. When it is `false` (the default), send no assignee at
   all; do not guess from the git config `user.email`.
 
-## 3. Jira — not implemented (#199)
+## 3. Jira — implemented
 
-**This section is deliberately empty.** Jira creation is not available, and Step 2 stops the skill
-with `MSG_JIRA_NOT_AVAILABLE` before any exploration happens. Nothing downstream should attempt a
-Jira write, and no fallback should quietly file a Jira-destined idea as a GitHub issue instead —
-that would put tickets in a backlog nobody on that project reads.
+Every rule below is explicit about what is discovered before a call and what is never guessed at
+call time: this is the only branch in the product that writes to Jira, and a guess here files a real
+issue in a real backlog.
 
-When #199 lands, this is the slot it fills, and the shape it has to fill:
+Where a rule is identical to GitHub's, this section points at §2 rather than restating it. When a
+third tracker arrives, the shared rules move up into a preamble and both branches point at that.
 
-| Concern | What #199 must supply |
-| --- | --- |
-| Target project | `plan.jiraProject` (config key already exists), plus the `cloudId` |
-| Issue types | `plan.issueTypes.epic` / `plan.issueTypes.story` (config keys already exist) |
-| Creation call | `mcp__atlassian__createJiraIssue`, epic first, then stories |
-| Hierarchy | the project's own epic link — parent field or `Epic Link`, discovered per project, never hardcoded |
-| Required fields | discovered with `mcp__atlassian__getJiraIssueTypeMetaWithFields`; a mandatory custom field is a hard blocker, not something to guess |
-| Templates | the project's description template, when `plan.useRepoTemplates` is on |
-| Labels / assignee | `plan.defaultLabels` and `plan.assignToMe`, resolved via `mcp__atlassian__lookupJiraAccountId` |
-| Gate to remove | the Step 2 stop, and this section's header |
+### 3.1 Resolving the target
 
-Everything before Step 7 already works for Jira as written — the idea, the spec, the framing and
-the sizing never touch a tracker. That is the whole point of this file existing.
+The destination is `plan.jiraProject` — the project **key**, e.g. `PROJ` — on the site named by the
+`cloudId` carried in §1.1.
+
+`issues.jiraUrl` is **not** the target. It is the base of the browse URL shown to the user
+(`{jiraUrl}/browse/PROJ-123`) and nothing else — one site hosts many projects, so the project key
+comes from `plan.jiraProject` and the site from the carried `cloudId`, never from that URL.
+
+When `issues.jiraUrl` is empty, the issues are still created and still reported — use the `self`
+link the create response returns and say the browse URL is unconfigured, rather than inventing a
+host.
+
+### 3.2 Required fields
+
+Discovered **before** the structure is proposed, never at write time. `references/jira-fields.md`
+§2 owns the auto-fill/must-ask split: every field on the create screen is either filled from there
+or answered from the carried `required_field_answers`. What is decided *here* is only this:
+
+| Field | Source | Notes |
+| --- | --- | --- |
+| `summary` | the spec's breakdown section | imperative, no ticket-type prefix — `Add …`, not `[Story] Add …` |
+| `description` | generated **from the spec** | never from conversation memory; see §3.3 |
+| the parent link | §3.4 | a hierarchy decision, not a body field |
+
+`issueTypeName` carries the **name** of the type resolved in `jira-fields.md` §1.2 — that is the
+only issue-type parameter `createJiraIssue` has. The id carried alongside it is what the discovery
+call consumed (`jira-fields.md` §1.3) and is not sent here. The resolution itself still matters for
+its original reason: `plan.issueTypes.*` may name a type this project does not offer, and that stops
+the run before the brainstorm rather than producing a guess.
+
+**`additional_fields` is the only channel for a field with no parameter of its own.** It takes a
+JSON object keyed by field name or field id, and it is how three things reach the create call: the
+epic-link custom field (§3.4 route 2), `labels` (§3.6), and every answer in the carried
+`required_field_answers`. `summary`, `description` with `contentFormat`, `assignee_account_id` and
+`parent` each have their own parameter — they never go through `additional_fields`.
+
+**Send a per-type field only on the type that required it.** `jira-fields.md` §2 deliberately keeps
+which issue type made each field mandatory: a "Team" required on the story type is not on the epic's
+create screen, and sending it there is a rejection on a field that project never asked for.
+
+The description is written in `languages.ticket`, per §2.2 — same rule, same reason: the spec *is*
+the source text, so a description in another language would mean it was composed from somewhere
+else.
+
+A required field arriving at §3.3 without a value is a **defect in the discovery pass, not
+something to guess**. Say which field and which issue type, and do not send a call whose only
+possible answer is a 400.
+
+### 3.3 Creating an issue
+
+Use `mcp__atlassian__createJiraIssue`, one call per ticket.
+
+Create the **epic first**, then the stories, for §2.3's reason: the parent must exist before a child
+can point at it.
+
+Compose each description from **§2.3's five spec sections, in §2.3's order**, including its
+per-story slicing and its omission of section 3 on the epic. That list is deliberately not restated
+here: there is **one** body format in this file and §2.3 holds it. A second, Jira-flavoured
+structure would make two tickets planned by the same skill from the same spec read differently
+depending on which backlog they landed in — and the spec is what the user approved, in both cases.
+
+Pass the description as markdown text and let the tool carry it; do not hand-build an ADF document.
+If a call is rejected on the body shape, retry it once with the same five sections as plain text
+with plain headings, and say in one line that the formatting degraded — the content of a ticket
+matters and its rich text does not.
+
+### 3.4 The hierarchy — three discovered routes, not a guess
+
+A Jira epic/story hierarchy is not one mechanism but three, and which one a project exposes depends
+on the Jira version and the project type. Try them in this order, stop at the first that works, and
+**state which one landed** — that is a stated requirement of this feature, not a nicety, because it
+is what decides whether the epic will show a progress bar in the Jira UI.
+
+| # | Route | Available when | How |
+| --- | --- | --- | --- |
+| 1 | native `parent` | `story_has_parent_field` is true, or `unknown` | send `parent` with the epic key in the story's create call |
+| 2 | the epic-link custom field | `epic_link_field_id` is set, or `unknown` | send it with the epic key in `additional_fields` |
+| 3 | an issue link | neither of the above | `mcp__atlassian__createIssueLink` once both issues exist |
+
+**`unknown` is not `false`, so the route is attempted rather than skipped.** `jira-fields.md` §4
+reports these values as `unknown` — never as `false`, an empty id or an omitted field — when the
+create screen was read only in part, and `unknown` means "not seen", not "absent". A route attempted
+on an `unknown` value either works, because the field was there and simply unread, or it is rejected
+and the cascade advances exactly as it does for a rejection below. Only `false` or an empty value
+skips a route, and only because it means the screen was read to the end and the field genuinely is
+not there. Reading `unknown` as `false` drops a partially-read screen straight onto route 3, which
+is the outcome that file's paging rules exist to prevent. Route 2 is the one route with nothing to
+send on `unknown` — there is no id yet — so there the attempt is to finish the read that stopped,
+paging `getJiraIssueTypeMetaWithFields` for the story type again, and route 3 follows only once that
+read completes with no epic-link field. §3.5 and §3.6 read their own carried values the same way.
+
+**Route 1 costs no extra call**, which is why it is first: `parent` is part of the story's create
+payload, so the story is parented the instant it exists and there is no window in which it is an
+orphan. Routes 2 and 3 exist for older instances and for projects whose create screen does not
+carry `parent`.
+
+`createJiraIssue` documents its `parent` parameter as "Parent for subtasks", and route 1 sends the
+epic key through it regardless — that is what modern team-managed projects accept for a story under
+an epic. On an instance where `parent` really is subtask-only, the call is rejected and route 2
+takes over, which is one of the reasons the cascade has three routes rather than one.
+
+**That rejection is a retry, not a §4 failure.** Re-create the same story with the epic link carried
+in `additional_fields` (route 2), and only if *that* call also fails does §4 apply. Be precise about
+the state this leaves: the rejected route-1 call created nothing, so there is no orphan story to
+delete and nothing to roll back — which is exactly what makes the retry safe and keeps §4's
+never-roll-back rule intact. Reporting a partial creation here would report a failure on a project
+where route 2 was about to work.
+
+**Never hardcode a `customfield_` id for route 2.** The epic-link field has a different numeric id
+on every Jira site; a hardcoded one either 400s or, worse, writes into an unrelated field that
+happens to share the number. Use the carried `epic_link_field_id`, sent in `additional_fields` per
+§3.2 — `jira-fields.md` §1.3 already read that create screen and matched the field on its
+`schema.custom`. Empty means route 2 is unavailable: fall through to route 3, never guess an id, and
+never re-read the screen looking for one. `unknown` is the one case where you do re-read, per the
+rule above — empty and unknown are different answers.
+
+**Never hardcode a link type name for route 3.** Link type names are configured per site, exactly
+as `skills/magic-start/references/dependencies.md` §2.1 states for the blocker gate. Call
+`mcp__atlassian__getIssueLinkTypes` and keep the type whose labels mean parent/child — "Epic-Story",
+"Parent-Child", and "Relates" only as a last resort. If `getIssueLinkTypes` fails, fall back to the
+literal string `Relates` and say the link type resolution degraded, per the route-announcement rule
+above.
+
+**Derive the direction from the type you kept, never from a convention.** `createIssueLink` takes an
+`inwardIssue` and an `outwardIssue`, and the link reads *outward → inward*: "`outwardIssue` {the
+type's `outward` label} `inwardIssue`". So read the two labels of the type actually chosen and place
+the issues accordingly, the way `skills/magic-start/references/dependencies.md` §2.1 reasons from
+`type.inward` rather than from a hardcoded name. When the kept type's `outward` label is the
+parent-side one — "is Epic of", "is parent of" — the **epic** is `outwardIssue` and the **story** is
+`inwardIssue`. When its `outward` label is the child-side one — "is child of", "is Story of" — the
+two swap: the story is `outwardIssue` and the epic is `inwardIssue`. Deriving it from the labels is
+what lets a site whose type is named the other way round still get a correct link. On the `Relates`
+last resort both labels say the same thing: the type is symmetric, the order carries no meaning, and
+either one is right.
+
+**A link created in the wrong direction is a silent failure.** `createIssueLink` accepts it, returns
+success, and the response looks exactly like a correct one — the relation simply reads the wrong way
+round in the Jira UI, where the story appears to be the parent of its epic. Nothing downstream
+detects it and no message reports it, which is why the direction is derived from the resolved type's
+own labels rather than assumed: a backwards Epic↔Story link is the failure this route exists to
+avoid, and it is the one failure here that would be reported as a success.
+
+Route 3 is the weakest outcome and is named as such. A plain issue link gives no progress bar on the
+epic and no parent breadcrumb on the story — but it is a relation, and unlinked issues are what the
+"a real hierarchy, visible as such in the Jira UI" requirement forbids. Report route 3 as a
+hierarchy that landed **in a degraded form**: not a success to be quiet about, not a failure to be
+reported as one.
+
+**Depth is one level, per §2.4** — with one difference: Jira will happily nest further than GitHub
+does, so here it is a rule to enforce rather than one the tracker enforces for you.
+
+A hierarchy call that fails while both issues exist is §4's mildest case, and it is still reported.
+
+### 3.5 Description templates
+
+When `plan.useRepoTemplates` is `true` (the default), honour the project's own description template
+— the carried `description_template` for that issue type, which is what someone filing by hand sees
+pre-filled in the create screen.
+
+- §2.5's fill rules apply unchanged, for its reasons: map the spec onto the template's **own**
+  headings, never append the §3.3 structure below them, and give a section the spec cannot answer an
+  explicit `N/A` rather than leaving the placeholder as shipped.
+- An empty `description_template` means the type has no template. Use the §3.3 structure.
+- An **`unknown`** one does not mean that. Per §3.4's `unknown` rule the value was never read, so
+  there is no template text to fill: use the §3.3 structure, but say in one line that the type's
+  template could not be read. A body composed as if the project had no template is a claim this run
+  is not in a position to make.
+
+**The epic still carries no acceptance criteria.** `references/sizing.md` §3.5 states that as a
+contract — the epic is done when its stories are, and criteria on both levels means the same
+requirement is checked twice and drifts in one of the two places. A description template with an
+"Acceptance criteria" heading does **not** override it: on the epic that heading is filled with an
+explicit `N/A` and a one-line pointer to the stories. A template decides the shape of a body, never
+what the body is allowed to assert.
+
+When `plan.useRepoTemplates` is `false`, use the §3.3 structure.
+
+### 3.6 Labels and assignee
+
+- **Labels**: `plan.defaultLabels` on every created issue, epic included, sent in
+  `additional_fields` per §3.2 — `createJiraIssue` has no `labels` parameter. Jira labels are
+  **free-form** — an unknown one is created on the spot — so there is no missing-label rejection to
+  recover from and §2.6's GitHub 422 retry has **no equivalent here**; do not copy it. The failure
+  that does happen is the `labels` field being absent from that issue type's create screen, which
+  company-managed projects do configure — and the carried `screen_omits` already names it, *before*
+  any call. Drop the labels then, say in one line that the issue type carries no `labels` field, and
+  create the issue without them. Never discover this as an error. That is the `false` reading —
+  `screen_omits` naming `labels` on a screen read to the end. An `unknown` one is not an omission:
+  per §3.4's `unknown` rule the labels are sent, and dropped only if the call comes back rejected on
+  that field.
+- **Assignee**: §2.6's rule, with `mcp__atlassian__lookupJiraAccountId` in place of
+  `mcp__github__get_me` and the account id in place of the login — resolved once per run, not per
+  issue, and sent as `assignee_account_id`, which is a parameter of its own and not an
+  `additional_fields` entry. As with `labels`, an issue type whose create screen has no `assignee`
+  field is named by the carried `screen_omits`: say so and continue, rather than failing a creation
+  over it — and an `unknown` there reads as §3.4's rule says, the account id sent and dropped only on
+  a rejection.
+
+### 3.7 Manual verification
+
+`skills/evals/eval_set.json` is trigger-only — a query mapped to an expected skill — so no eval
+entry can exercise a Jira write. This checklist is the verification instead, run by hand against a
+real Jira project before this branch is trusted. One entry per scenario: the setup, then what must
+be observed.
+
+- Renamed issue types — epic type `Initiative`, story type `Task`, `plan.issueTypes` set to those
+  names.
+  - Expected: creation succeeds, the issues carry those types, and nothing anywhere says "Epic" or
+    "Story".
+- `plan.issueTypes.story` names an absent type.
+  - Expected: `MSG_JIRA_NOT_CONFIGURED` lists real types, no question, no ticket.
+- A mandatory custom field on the story type only — typically a required "Team" or "Component"
+  select.
+  - Expected: Step 4 asks once, inside the framing batch, offering its `allowedValues`; the answer
+    lands in `## Framing decisions`; creation succeeds; the epic is never asked.
+- Both `issues.jiraUrl` and `issues.githubIssuesUrl`, `plan.tracker: jira`.
+  - Expected: no tracker question, tickets in Jira.
+- The same repository, `plan.tracker: ask`.
+  - Expected: exactly **one** question, at Step 2.3 — the duplicate check and the creation reuse
+    that answer.
+- `plan.tracker: jira`, `plan.jiraProject` empty.
+  - Expected: `MSG_JIRA_NOT_CONFIGURED` before the brainstorm, no GitHub fallback.
+- The story type uncreatable for the user, the epic type creatable.
+  - Expected: the epic survives; the report names its key and URL plus every story that did not
+    land, with its reason; `## Created tickets` holds the epic; nothing is rolled back.
+- A team-managed project, then an older company-managed one.
+  - Expected: a real parent/child relation visible in the Jira UI both times, and a line naming the
+    route used — `parent`, then `epic_link`.
+- A project whose story create screen pre-fills a description template.
+  - Expected: that template arrives as the `description` field's default value in
+    `jira-fields.md` §1.3's response — the read-but-undocumented assumption that file flags — and
+    §3.5's fill rules shape the body, not §3.3's structure.
+
+An observed outcome that differs from the expected one is a defect in this file, not a project
+misconfiguration: §3.2 and §3.4 exist precisely so that project variation is discovered rather than
+assumed.
 
 ## 4. Partial failure
 
 Ticket creation is **not** transactional and must not pretend to be. Several calls are made in
 sequence, and any one of them can fail on its own.
 
-**Never roll back.** A created issue is a real issue with a real number, and closing or deleting it
-to restore a clean slate destroys a URL that may already be in someone's notification feed. Report
-instead.
+**Never roll back.** A created issue is a real issue with a real identifier — `#412`, `PROJ-1234` —
+and closing or deleting it to restore a clean slate destroys a URL that may already be in someone's
+notification feed. Report instead.
 
-Track, as you go: which tickets were created (number + URL), which failed and with what reason, and
-which sub-issue links landed. On any failure:
+Track, as you go: which tickets were created (identifier + URL), which failed and with what reason,
+and which hierarchy links landed. On any failure:
 
 1. Stop the creation sequence. Do not keep creating stories under an epic that failed to be created
    — they would be orphans with no parent to attach to.
@@ -171,27 +457,38 @@ which sub-issue links landed. On any failure:
    anything. If the report is the only record and the session ends, the numbers are lost.
 3. Display `MSG_PARTIAL_CREATION` with the created list, the failed list, and a per-failure reason
    precise enough to resume from — the HTTP status and what it was refusing, not "an error".
-4. Send the metadata call anyway (Step 7 of `SKILL.md`), carrying whatever ticket id does exist.
+4. Send the metadata call anyway (Step 7.1 of `SKILL.md`), carrying whatever ticket id does exist.
    A half-created plan is still a plan the sidebar should show.
 
-A sub-issue link that fails while both issues exist is the mildest case and still gets reported:
+**One rejection is not a failure here, and the sequence above must not fire on it**: a story create
+call rejected on `parent` (§3.4, route 1). That is the cascade advancing to route 2 — the story is
+re-created with the epic link in `additional_fields` — and the rejected call created nothing, so
+there is no partial state to report and no orphan to clean up. Only if the route-2 call also fails
+is this a failure, and then it is one failure, not two.
+
+A hierarchy link that fails while both issues exist is the mildest case and still gets reported:
 the tickets are usable, but the epic will show no progress and the story no parent, so someone has
-to link them by hand. Say exactly that.
+to link them by hand. Say exactly that, and list the story keys so it takes one edit.
+
+That covers both branches — a failed `mcp__github__sub_issue_write` on GitHub, and on Jira every one
+of §3.4's three routes exhausted or the chosen one rejected. A degraded route that *did* land
+(route 3) is not this case: §3.4 announces that as a success with its route.
 
 ## Usage
 
-Step 7 of `SKILL.md` reads this file **after** the user has approved the structure. Once read,
-execute §1's already-resolved outcome, then the matching tracker section, then §4 if anything
-fails, and return these values — this table is the whole contract; `SKILL.md` restates none of it:
+Step 7 of `SKILL.md` reads §2-§4 **after** the user has approved the structure. Once read, execute
+§1's already-resolved outcome, then the matching tracker section, then §4 if anything fails, and
+return these values — this table is the whole contract; `SKILL.md` restates none of it:
 
 | Returned | Shape | Consumer |
 | --- | --- | --- |
-| `tracker` | `github` (only supported value today) | Step 7 metadata, `MSG_TICKETS_CREATED` |
-| `tracker_target` | concrete destination, e.g. `github.com/acme/api` | `MSG_APPROVAL`, `MSG_TICKETS_CREATED` |
-| `created` | ordered list of `{id, title, url, kind}`, `kind` ∈ `epic` / `story` | spec append, metadata, `MSG_NEXT_STEPS` |
+| `tracker` | `github` or `jira` | Step 7 metadata, `MSG_TICKETS_CREATED` |
+| `tracker_target` | concrete destination — `github.com/acme/api`, or `PROJ` on `{jiraUrl}` / on the resolved site when that URL is unset | `MSG_APPROVAL`, `MSG_TICKETS_CREATED` |
+| `created` | ordered list of `{id, title, url, kind}`, `kind` ∈ `epic` / `story`; `id` is `#412` or `PROJ-1234` | spec append, metadata, `MSG_NEXT_STEPS` |
 | `failed` | list of `{title, reason}`, empty on success | `MSG_PARTIAL_CREATION` |
-| `hierarchy_ok` | true when every sub-issue link landed | `MSG_TICKETS_CREATED` / `MSG_PARTIAL_CREATION` |
-| `primary_ticket_id` | the epic on a breakdown, the story on a single | `ticketId` in the Step 7 metadata call |
+| `hierarchy_ok` | true when every parent/child link landed | `MSG_TICKETS_CREATED` / `MSG_PARTIAL_CREATION` |
+| `hierarchy_route` | Jira only: `parent` / `epic_link` / `issue_link` | `{hierarchy_route}` in `MSG_TICKETS_CREATED` |
+| `primary_ticket_id` | the epic on a breakdown, the story on a single — `#412` or `PROJ-1234` | `ticketId` in the Step 7.1 metadata call |
 
 `primary_ticket_id` is the epic on a breakdown because the agent planned the whole epic — that is
 what this terminal did. `MSG_NEXT_STEPS` still offers the **first story** for `/magic:start`: what

--- a/skills/magic-plan/references/trackers.md
+++ b/skills/magic-plan/references/trackers.md
@@ -239,6 +239,13 @@ epic-link custom field (§3.4 route 2), `labels` (§3.6), and every answer in th
 `required_field_answers`. `summary`, `description` with `contentFormat`, `assignee_account_id` and
 `parent` each have their own parameter — they never go through `additional_fields`.
 
+**The answers travel already converted.** `required_field_answers` holds each value in the shape
+`createJiraIssue` accepts — an option object, an array of them, an account id object — never the
+display string the user answered with. `jira-fields.md` §3 owns that conversion and the table that
+drives it; what §3.2 owns is only putting the converted value in the right channel. A display value
+arriving here unconverted is the same defect as a missing one, and gets the same treatment as the
+rule below: name the field, and do not send a call whose only possible answer is a 400.
+
 **Send a per-type field only on the type that required it.** `jira-fields.md` §2 deliberately keeps
 which issue type made each field mandatory: a "Team" required on the story type is not on the epic's
 create screen, and sending it there is a rejection on a field that project never asked for.
@@ -454,6 +461,12 @@ be observed.
   - Expected: both reach Step 4's question as must-ask fields, per `jira-fields.md` §2, and creation
     succeeds with the answered values. What must **not** happen is the field being treated as
     config-filled and the creation rejected on it after the approval.
+- A required single-select custom field, then a required user-picker one — a "Severity" with
+  `allowedValues`, and a "Reviewer" naming a person.
+  - Expected: the select is asked with its options and sent as `{"id": …}` resolved from the picked
+    `allowedValues` entry, not as its label; the user-picker answer goes through
+    `lookupJiraAccountId` and is sent as `{"accountId": …}`. Creation succeeds. What must **not**
+    happen is the displayed string reaching `additional_fields` verbatim.
 - The story type uncreatable for the user, the epic type creatable.
   - Expected: the epic survives; the report names its key and URL plus every story that did not
     land, with its reason; `## Created tickets` holds the epic; nothing is rolled back.

--- a/skills/magic-plan/references/trackers.md
+++ b/skills/magic-plan/references/trackers.md
@@ -432,26 +432,39 @@ When `plan.useRepoTemplates` is `false`, use the §3.3 structure.
   per §3.4's `unknown` rule the labels are sent, and dropped only if the call comes back rejected on
   that field.
 - **Assignee**: §2.6's rule, with the account id in place of the login — resolved once per run, not
-  per issue, and sent as `assignee_account_id`, which is a parameter of its own and not an
-  `additional_fields` entry. **Read the carried `assignee_account_id` first**: on a required
-  `assignee` the pre-flight already resolved it (`jira-fields.md` §2), and re-resolving here would
-  spend the same two calls again to learn the same answer. It is empty in every other case, and only
-  then does the resolution below run. Resolving "me" takes **two calls, in this order**, because Jira exposes
-  no single equivalent of `mcp__github__get_me`: `mcp__atlassian__atlassianUserInfo` first — it takes
-  no parameters and answers who the authenticated user is — then
-  `mcp__atlassian__lookupJiraAccountId` with that identity as its `searchString`, since that tool is
-  a search and has no current-user mode. Skip the second call when the first already carries an
-  account id. **Never substitute a search term of your own**: §2.6 forbids inferring the identity
-  from `git config user.email`, and a `searchString` invented here is that same guess wearing a Jira
-  parameter. If neither call yields an account id, say so in one line and create the issues
-  unassigned — `plan.assignToMe` is a convenience, never worth failing a creation over. **That
-  fallback is unavailable when the screen makes `assignee` required**: there, unassigned *is* the
-  rejection, so `jira-fields.md` §2 has already classified the field must-ask — whether because
-  `plan.assignToMe` is false or because no account id resolved — and its value arrives through
-  `required_field_answers`. As with
-  `labels`, an issue type whose create screen has no `assignee` field is named by the carried
-  `screen_omits`: say so and continue — and an `unknown` there reads as §3.4's rule says, the account
-  id sent and dropped only on a rejection.
+  per issue, and sent as `assignee_account_id`, a parameter of its own and never an
+  `additional_fields` entry (§3.2). The value has three possible sources, **tried in this order**.
+  The first that yields an id wins, and no later source is consulted:
+
+  1. **The carried `assignee_account_id`** (`jira-fields.md`'s `## Usage`). Set when `assignee` is
+     required and `plan.assignToMe` is true: the pre-flight already resolved it, and re-resolving
+     here would spend the same two calls to learn the same answer.
+  2. **The `assignee` entry of `required_field_answers`.** Set when `assignee` is required and the
+     pre-flight did *not* fill it — `plan.assignToMe` false, or its lookup failed — so
+     `jira-fields.md` §2 classified the field must-ask and Step 4 asked for it. **That answer is a
+     specific person the user chose, not you.** Falling through to source 3 here assigns the issue
+     to the authenticated user instead, and Jira *accepts* that: the creation succeeds, the wrong
+     person is assigned, and nothing downstream ever reports it. This source is the whole reason the
+     order is written down rather than left to read naturally.
+  3. **The current user**, and only when `plan.assignToMe` is true — the ordinary `assignToMe` path,
+     on a project where `assignee` is optional.
+
+  Source 3 takes **two calls, in this order**, because Jira exposes no single equivalent of
+  `mcp__github__get_me`: `mcp__atlassian__atlassianUserInfo` first — it takes no parameters and
+  answers who the authenticated user is — then `mcp__atlassian__lookupJiraAccountId` with that
+  identity as its `searchString`, since that tool is a search with no current-user mode. Skip the
+  second call when the first already carries an account id. **Never substitute a search term of your
+  own**: §2.6 forbids inferring the identity from `git config user.email`, and a `searchString`
+  invented here is that same guess wearing a Jira parameter.
+
+  When no source yields an id, the field's own status decides. **Optional**: say so in one line and
+  create the issues unassigned — `plan.assignToMe` is a convenience, never worth failing a creation
+  over. **Required**: unassigned *is* the rejection, and sources 1 and 2 are precisely the two paths
+  `jira-fields.md` §2 guarantees for that case, so arriving here empty on a required field is a
+  defect in the discovery pass — report it as §3.2's closing rule says, and do not send a call whose
+  only possible answer is a 400. As with `labels`, an issue type whose create screen has no
+  `assignee` field is named by the carried `screen_omits`: say so and continue — and an `unknown`
+  there reads as §3.4's rule says, the account id sent and dropped only on a rejection.
 
 ### 3.7 Manual verification
 
@@ -480,8 +493,10 @@ be observed.
 - A create screen that makes `labels` **required**, with `plan.defaultLabels` left at its `[]`
   default — then the same with `assignee` required and `plan.assignToMe` left at `false`.
   - Expected: both reach Step 4's question as must-ask fields, per `jira-fields.md` §2, and creation
-    succeeds with the answered values. What must **not** happen is the field being treated as
-    config-filled and the creation rejected on it after the approval.
+    succeeds with the answered values. Two things must **not** happen: the field being treated as
+    config-filled and the creation rejected on it after the approval, and — for `assignee` — the
+    answer being ignored in favour of §3.6 source 3, which would assign the issue to *you* and
+    succeed. Check who the created issues are actually assigned to, not just that they were created.
 - The same required `assignee`, this time with `plan.assignToMe` **true** — the other provenance.
   - Expected: no question at all; the pre-flight resolves the account id, carries it as
     `assignee_account_id`, and the created issues are assigned to you. What must **not** happen is

--- a/skills/magic-plan/references/trackers.md
+++ b/skills/magic-plan/references/trackers.md
@@ -236,8 +236,26 @@ the run before the brainstorm rather than producing a guess.
 **`additional_fields` is the only channel for a field with no parameter of its own.** It takes a
 JSON object keyed by field name or field id, and it is how three things reach the create call: the
 epic-link custom field (§3.4 route 2), `labels` (§3.6), and every answer in the carried
-`required_field_answers`. `summary`, `description` with `contentFormat`, `assignee_account_id` and
-`parent` each have their own parameter — they never go through `additional_fields`.
+`required_field_answers` — **except `assignee`**. `summary`, `description` with `contentFormat`,
+`assignee_account_id` and `parent` each have their own parameter, so they never go through
+`additional_fields`.
+
+**`assignee` is the one field that is both.** It can be a `required_field_answers` entry — a project
+that makes it mandatory while `plan.assignToMe` is false sends the user to Step 4 like any other
+must-ask field (`jira-fields.md` §2) — *and* it has its own `createJiraIssue` parameter. The two
+rules above would send it to both places, so the exception wins: whichever of its two provenances
+applies, the value goes in `assignee_account_id`.
+
+| Provenance | Carried as | Sent as |
+| --- | --- | --- |
+| the pre-flight resolved it (`plan.assignToMe` true) | `jira-fields.md`'s `assignee_account_id` | `assignee_account_id` |
+| Step 4 answered it (must-ask) | a `required_field_answers` entry | `assignee_account_id`, **not** `additional_fields` |
+
+And it is a **bare account id string** in both cases, not the `{"accountId": …}` object other
+user-picker fields use — `jira-fields.md` §3's conversion table states that exception at the shape
+level; this is the routing half of it. An `assignee` answer left in `additional_fields` is either
+rejected or, worse, accepted while the issue stays unassigned — a silent miss on a field the project
+declared mandatory.
 
 **The answers travel already converted.** `required_field_answers` holds each value in the shape
 `createJiraIssue` accepts — an option object, an array of them, an account id object — never the
@@ -415,7 +433,10 @@ When `plan.useRepoTemplates` is `false`, use the §3.3 structure.
   that field.
 - **Assignee**: §2.6's rule, with the account id in place of the login — resolved once per run, not
   per issue, and sent as `assignee_account_id`, which is a parameter of its own and not an
-  `additional_fields` entry. Resolving "me" takes **two calls, in this order**, because Jira exposes
+  `additional_fields` entry. **Read the carried `assignee_account_id` first**: on a required
+  `assignee` the pre-flight already resolved it (`jira-fields.md` §2), and re-resolving here would
+  spend the same two calls again to learn the same answer. It is empty in every other case, and only
+  then does the resolution below run. Resolving "me" takes **two calls, in this order**, because Jira exposes
   no single equivalent of `mcp__github__get_me`: `mcp__atlassian__atlassianUserInfo` first — it takes
   no parameters and answers who the authenticated user is — then
   `mcp__atlassian__lookupJiraAccountId` with that identity as its `searchString`, since that tool is
@@ -461,6 +482,10 @@ be observed.
   - Expected: both reach Step 4's question as must-ask fields, per `jira-fields.md` §2, and creation
     succeeds with the answered values. What must **not** happen is the field being treated as
     config-filled and the creation rejected on it after the approval.
+- The same required `assignee`, this time with `plan.assignToMe` **true** — the other provenance.
+  - Expected: no question at all; the pre-flight resolves the account id, carries it as
+    `assignee_account_id`, and the created issues are assigned to you. What must **not** happen is
+    the id being resolved and then lost between the pass and the create call.
 - A required single-select custom field, then a required user-picker one — a "Severity" with
   `allowedValues`, and a "Reviewer" naming a person.
   - Expected: the select is asked with its options and sent as `{"id": …}` resolved from the picked


### PR DESCRIPTION
## Description

Implements the Jira branch of `/magic:plan`'s tracker abstraction. `references/trackers.md` §3 goes
from the deliberate "not implemented (#199)" stub to a working branch: epic-then-stories creation via
`mcp__atlassian__createJiraIssue`, a real epic/story hierarchy, and required-field discovery that runs
**before** the structure is proposed rather than surfacing as a 400 after a ten-minute brainstorm.

This is the product's first Jira **write** — the four other skills only read, comment and transition.
The change is markdown-only: #197 already shipped every config key (`plan.jiraProject`,
`plan.issueTypes.*`, `languages.ticket`, `issues.jiraUrl`), its types, JSON schema, migration and UI,
so no TypeScript, SQL or UI work was needed.

The GitHub branch (§2) is **byte-identical** to `main` — verified with `cmp`, not asserted.

## Related Issue

Fixes #199

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Changes Made

- **`references/trackers.md`** — §3 rewritten as an implemented branch (§3.1 target → §3.7 manual
  verification), mirroring §2's subsection rhythm and pointing at it rather than forking the body
  format. New §1.1 (the resolution is carried, not re-derived — three consumers now, not one) and
  §1.2 (explicit refusal, never a silent fallback to GitHub). §4 reworded for `PROJ-123` keys plus
  the Jira-specific "epic created, hierarchy link failed" case.
- **`references/jira-fields.md`** (new) — the read-only required-field pre-flight, modelled on
  `magic-start/references/jira-custom-fields.md`. Three successive calls, not alternatives:
  `getAccessibleAtlassianResources` → `getJiraProjectIssueTypesMetadata` (resolve
  `plan.issueTypes.*` by name to their ids) → `getJiraIssueTypeMetaWithFields` per type. Reuses that
  file's shape parser rather than forking it.
- **Hierarchy, three routes, and the route is announced** — native `parent`, else the `Epic Link`
  custom field matched on `schema.custom` (never a display name: a German instance shows
  "Epic-Verknüpfung"), else `createIssueLink` with the type resolved through `getIssueLinkTypes`.
  Route 3 is reported as a hierarchy that landed *in a degraded form*.
- **`references/messages.md`** — `MSG_JIRA_NOT_AVAILABLE` deleted; `MSG_GITHUB_ERROR` renamed to
  `MSG_TRACKER_ERROR` with a `{tracker}` placeholder; `MSG_TRACKER_ASK` generalised; five keys added
  (`MSG_JIRA_NOT_CONFIGURED`, `MSG_JIRA_REQUIRED_FIELDS`, `MSG_JIRA_TOO_MANY_FIELDS`,
  `MSG_TRACKER_NONE`, `MSG_JIRA_FIELDS_UNKNOWN`). 21 keys, each with both `### en` and `### fr`.
- **`SKILL.md`** — `mcp__atlassian__*` added to `allowed-tools`; `integrations.atlassian` read into
  `$ATLASSIAN_ENABLED`; the Step 2.3 hard stop removed; Step 3.3's duplicate search branched on the
  carried tracker (`searchJiraIssuesUsingJql` scoped to `plan.jiraProject`); Step 4 folds in the
  required-field question and its overflow round.
- **`references/spec-template.md`** — the `## Created tickets` `Ticket` column admits `PROJ-123`
  alongside `#412`.
- **`README.md` / `CHANGELOG.md`** — the `/magic:plan` wording is no longer GitHub-only.

## Testing

- [ ] Tested locally with Claude Code
- [x] Ran linters (`npm run lint`)
- [ ] Tested installation script
- [ ] Tested affected slash commands

> **Not yet exercised against a live Jira project.** The two unchecked boxes above are deliberate:
> this PR changes instruction files that an agent executes, and the only real test is a run against
> a Jira instance with a renamed issue type and a mandatory custom field. `references/trackers.md`
> §3.7 carries the nine-scenario checklist for that pass. `npm test` (1255 tests) and `npm run lint`
> both pass, but neither covers `skills/` — `vitest.config.ts` includes only `desktop/src/**` and
> `webapp/lib/**`, and `skills/evals/eval_set.json` is trigger-only (query → expected skill), so no
> automated assertion could cover this change.

### Test Steps

Prerequisites: Node 20 (`nvm use`), Magic Slash Desktop running, and a Jira project you can create
issues in — configured on a repo via `plan.tracker: jira` and `plan.jiraProject`.
  - Preview: https://magic-slash-elm1j5pw1-xrequillarts-projects.vercel.app — this PR's actual deployed code; migrations, deletions and seeding still need local.

1. **Zero regression on GitHub.** Run `/magic:plan` on a repo with a GitHub remote and no Jira
   config. Expect the #198 flow unchanged end to end, and no mention of Jira anywhere. Then confirm
   mechanically: `git diff main -- skills/magic-plan/references/trackers.md` shows no line inside
   `## 2. GitHub — implemented`.
2. **Nominal Jira run.** Set `plan.tracker: jira` and `plan.jiraProject`, then `/magic:plan` on an
   idea large enough to break down. Expect the epic and its stories in Jira with a **real**
   hierarchy — a progress bar on the epic, a parent breadcrumb on the stories — and the final report
   naming which of the three routes landed.
3. **Renamed issue types.** Point `plan.issueTypes.epic` / `.story` at a project whose types are
   named something other than "Epic"/"Story". Expect creation to succeed on those names. Then set
   `plan.issueTypes.epic` to a name the project does not have: expect `MSG_JIRA_NOT_CONFIGURED`
   naming the project's *actual* types, and no question.
4. **Mandatory custom field.** Use a project with a required custom field on the story type. Expect
   the question to arrive inside the framing dialogue (Step 4), **before** Step 5 writes
   `## Proposed tickets` — not as a 400 at creation time — and the answer recorded in the spec's
   `## Framing decisions` with the issue type that required it.
5. **Both trackers.** On a repo declaring both, set `plan.tracker` and expect no question; set it to
   `ask` and expect `MSG_TRACKER_ASK` exactly once, never twice.
6. **Mid-breakdown failure.** Interrupt or reject a story creation partway. Expect no rollback, the
   spec's `## Created tickets` populated with what exists, and `MSG_PARTIAL_CREATION` naming the
   HTTP status and what it refused.

`references/trackers.md` §3.7 is the authoritative checklist — it covers three further scenarios
(a story type the user cannot create, an empty project key, team-managed vs company-managed
hierarchy) with their observable expectations.

## Screenshots

N/A — no UI surface. The change is entirely skill instruction files plus two documentation lines.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added/updated tests if applicable
- [x] All linters pass locally
- [x] I have updated CHANGELOG.md (if applicable)

## Additional Notes

**Why no test was added.** `vitest.config.ts` covers only `desktop/src/**` and `webapp/lib/**`; the
repo has no precedent for asserting on skill markdown, and adding the first such test on a PR whose
acceptance criteria include "the GitHub branch is untouched" seemed the wrong place for it. A
text-reading test over `skills/magic-plan/` — every referenced `MSG_*` exists with both language
blocks, no orphan keys, `allowed-tools` covers every `mcp__*` prefix actually invoked — would have
caught the `mcp__atlassian__*` omission this PR fixes, and is worth its own issue.

**Two follow-ups this PR deliberately does not do:**

1. `desktop/src/main/hooks/claude-hooks-config.ts` does not pre-approve
   `getJiraProjectIssueTypesMetadata`, `getJiraIssueTypeMetaWithFields`, `createJiraIssue`,
   `createIssueLink` or `lookupJiraAccountId`. The Jira path will therefore prompt at the two
   moments the comment above the GitHub grant says it must not — the pre-flight before the
   brainstorm, and creation right after approval. The issue asked only for the skill's
   `allowed-tools`, and touching `desktop/` was out of scope, but this is a parity gap worth closing
   before the Jira branch is used in anger.
2. `$ATLASSIAN_ENABLED` can never be `false`: `jq -r '.integrations.atlassian // true'` returns the
   right-hand side for `false` as well as `null`. The idiom is copied verbatim from
   `/magic:start` Step 0.3, so keeping the two skills in sync won over fixing it here — but this is
   the first ticket to hang a decision on that value.

**Review focus.** Four rounds of independent adversarial review ran on this change, which corrected
three wrong MCP call contracts (`expand` on a tool that has none, `requiredFieldsOnly` defaulting to
`true`, and an issue-type id sent where the API takes a name) and one backwards `createIssueLink`
direction. The most useful thing a reviewer can do is check the remaining call shapes against the
live tool schemas, and read `references/jira-fields.md` §4 — its "a failed call must never be
reported as 'no required fields'" invariant is what the whole pre-flight rests on.


